### PR TITLE
refactor: move main properties away from isize

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ In frankenstein, it's described as:
 ```rust
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct User {
-    pub id: isize,
+    pub id: i64,
 
     pub is_bot: bool,
 
@@ -73,7 +73,7 @@ Optional fields are described as Option enum.
 Every struct has the `new` method which used for initialization. It accepts only required fields, optional fields are set to `None`:
 
 ```rust
-pub fn new(id: isize, is_bot: bool, first_name: String) -> User {
+pub fn new(id: i64, is_bot: bool, first_name: String) -> User {
     Self {
         id,
         is_bot,
@@ -96,7 +96,7 @@ All fields have setter and getter methods :
  pub fn set_supports_inline_queries(&mut self, supports_inline_queries: Option<bool>) {
      self.supports_inline_queries = supports_inline_queries;
  }
- pub fn id(&self) -> isize {
+ pub fn id(&self) -> i64 {
      self.id
  }
 

--- a/examples/api_trait_implementation.rs
+++ b/examples/api_trait_implementation.rs
@@ -143,7 +143,7 @@ impl TelegramApi for Api {
 fn main() {
     let api = Api::new(TOKEN.to_string());
 
-    let params = SendMessageParams::new(ChatIdEnum::IsizeVariant(275808073), "Hello!".to_string());
+    let params = SendMessageParams::new(ChatIdEnum::IntegerVariant(275808073), "Hello!".to_string());
 
     let result = api.send_message(&params);
 

--- a/examples/reply_to_message_updates.rs
+++ b/examples/reply_to_message_updates.rs
@@ -22,7 +22,7 @@ fn main() {
                 for update in response.result {
                     if let Some(message) = update.message() {
                         let mut send_message_params = SendMessageParams::new(
-                            ChatIdEnum::IsizeVariant(message.chat().id()),
+                            ChatIdEnum::IntegerVariant(message.chat().id()),
                             "hello".to_string(),
                         );
                         send_message_params.set_reply_to_message_id(Some(message.message_id()));

--- a/src/api_impl.rs
+++ b/src/api_impl.rs
@@ -203,7 +203,7 @@ mod tests {
     fn send_message_success() {
         let response_string = "{\"ok\":true,\"result\":{\"message_id\":2746,\"from\":{\"id\":1276618370,\"is_bot\":true,\"first_name\":\"test_el_bot\",\"username\":\"el_mon_test_bot\"},\"date\":1618207352,\"chat\":{\"id\":275808073,\"type\":\"private\",\"username\":\"Ayrat555\",\"first_name\":\"Ayrat\",\"last_name\":\"Badykov\"},\"text\":\"Hello!\"}}";
         let params =
-            SendMessageParams::new(ChatIdEnum::IsizeVariant(275808073), "Hello!".to_string());
+            SendMessageParams::new(ChatIdEnum::IntegerVariant(275808073), "Hello!".to_string());
         let _m = mockito::mock("POST", "/sendMessage")
             .with_status(200)
             .with_body(response_string)
@@ -220,7 +220,7 @@ mod tests {
     fn send_message_failure() {
         let response_string =
             "{\"ok\":false,\"description\":\"Bad Request: chat not found\",\"error_code\":400}";
-        let params = SendMessageParams::new(ChatIdEnum::IsizeVariant(1), "Hello!".to_string());
+        let params = SendMessageParams::new(ChatIdEnum::IntegerVariant(1), "Hello!".to_string());
         let _m = mockito::mock("POST", "/sendMessage")
             .with_status(400)
             .with_body(response_string)
@@ -353,8 +353,8 @@ mod tests {
     fn forward_message_success() {
         let response_string = "{\"ok\":true,\"result\":{\"message_id\":2747,\"from\":{\"id\":1276618370,\"is_bot\":true,\"first_name\":\"test_el_bot\",\"username\":\"el_mon_test_bot\"},\"date\":1618294971,\"chat\":{\"id\":275808073,\"type\":\"private\",\"username\":\"Ayrat555\",\"first_name\":\"Ayrat\",\"last_name\":\"Badykov\"},\"text\":\"Hello\"}}";
         let params = ForwardMessageParams::new(
-            ChatIdEnum::IsizeVariant(275808073),
-            ChatIdEnum::IsizeVariant(275808073),
+            ChatIdEnum::IntegerVariant(275808073),
+            ChatIdEnum::IntegerVariant(275808073),
             2747,
         );
 
@@ -374,8 +374,8 @@ mod tests {
     fn copy_message_success() {
         let response_string = "{\"ok\":true,\"result\":{\"message_id\":2749}}";
         let params = CopyMessageParams::new(
-            ChatIdEnum::IsizeVariant(275808073),
-            ChatIdEnum::IsizeVariant(275808073),
+            ChatIdEnum::IntegerVariant(275808073),
+            ChatIdEnum::IntegerVariant(275808073),
             2747,
         );
 
@@ -394,7 +394,7 @@ mod tests {
     #[test]
     fn send_location_success() {
         let response_string = "{\"ok\":true,\"result\":{\"message_id\":2750,\"from\":{\"id\":1276618370,\"is_bot\":true,\"first_name\":\"test_el_bot\",\"username\":\"el_mon_test_bot\"},\"date\":1618382060,\"chat\":{\"id\":275808073,\"type\":\"private\",\"username\":\"Ayrat555\",\"first_name\":\"Ayrat\",\"last_name\":\"Badykov\"},\"location\":{\"longitude\":6.949981,\"latitude\":49.700002}}}";
-        let params = SendLocationParams::new(ChatIdEnum::IsizeVariant(275808073), 49.7, 6.95);
+        let params = SendLocationParams::new(ChatIdEnum::IntegerVariant(275808073), 49.7, 6.95);
 
         let _m = mockito::mock("POST", "/sendLocation")
             .with_status(200)
@@ -413,7 +413,7 @@ mod tests {
         let response_string = "{\"ok\":true,\"result\":{\"message_id\":2752,\"from\":{\"id\":1276618370,\"is_bot\":true,\"first_name\":\"test_el_bot\",\"username\":\"el_mon_test_bot\"},\"date\":1618382998,\"chat\":{\"id\":275808073,\"type\":\"private\",\"username\":\"Ayrat555\",\"first_name\":\"Ayrat\",\"last_name\":\"Badykov\"},\"edit_date\":1618383189,\"location\":{\"longitude\":6.96,\"latitude\":49.800009,\"live_period\":300}}}";
         let mut params = EditMessageLiveLocationParams::new(49.8, 6.96);
         params.set_message_id(Some(2752));
-        params.set_chat_id(Some(ChatIdEnum::IsizeVariant(275808073)));
+        params.set_chat_id(Some(ChatIdEnum::IntegerVariant(275808073)));
 
         let _m = mockito::mock("POST", "/editMessageLiveLocation")
             .with_status(200)
@@ -432,7 +432,7 @@ mod tests {
         let response_string = "{\"ok\":true,\"result\":{\"message_id\":2752,\"from\":{\"id\":1276618370,\"is_bot\":true,\"first_name\":\"test_el_bot\",\"username\":\"el_mon_test_bot\"},\"date\":1618382998,\"chat\":{\"id\":275808073,\"type\":\"private\",\"username\":\"Ayrat555\",\"first_name\":\"Ayrat\",\"last_name\":\"Badykov\"},\"edit_date\":1618383189,\"location\":{\"longitude\":6.96,\"latitude\":49.800009,\"live_period\":300}}}";
         let mut params = StopMessageLiveLocationParams::new();
         params.set_message_id(Some(2752));
-        params.set_chat_id(Some(ChatIdEnum::IsizeVariant(275808073)));
+        params.set_chat_id(Some(ChatIdEnum::IntegerVariant(275808073)));
 
         let _m = mockito::mock("POST", "/stopMessageLiveLocation")
             .with_status(200)
@@ -450,7 +450,7 @@ mod tests {
     fn send_venue_success() {
         let response_string = "{\"ok\":true,\"result\":{\"message_id\":2754,\"from\":{\"id\":1276618370,\"is_bot\":true,\"first_name\":\"test_el_bot\",\"username\":\"el_mon_test_bot\"},\"date\":1618410490,\"chat\":{\"id\":275808073,\"type\":\"private\",\"username\":\"Ayrat555\",\"first_name\":\"Ayrat\",\"last_name\":\"Badykov\"},\"venue\":{\"location\":{\"longitude\":6.949981,\"latitude\":49.700002},\"title\":\"Meow\",\"address\":\"Hoof\"},\"location\":{\"longitude\":6.949981,\"latitude\":49.700002}}}";
         let params = SendVenueParams::new(
-            ChatIdEnum::IsizeVariant(275808073),
+            ChatIdEnum::IntegerVariant(275808073),
             49.7,
             6.95,
             "Meow".to_string(),
@@ -473,7 +473,7 @@ mod tests {
     fn send_contact_success() {
         let response_string = "{\"ok\":true,\"result\":{\"message_id\":2755,\"from\":{\"id\":1276618370,\"is_bot\":true,\"first_name\":\"test_el_bot\",\"username\":\"el_mon_test_bot\"},\"date\":1618465934,\"chat\":{\"id\":275808073,\"type\":\"private\",\"username\":\"Ayrat555\",\"first_name\":\"Ayrat\",\"last_name\":\"Badykov\"},\"contact\":{\"phone_number\":\"49\",\"first_name\":\"Meow\"}}}";
         let params = SendContactParams::new(
-            ChatIdEnum::IsizeVariant(275808073),
+            ChatIdEnum::IntegerVariant(275808073),
             "49".to_string(),
             "Meow".to_string(),
         );
@@ -494,7 +494,7 @@ mod tests {
     fn send_poll_success() {
         let response_string = "{\"ok\":true,\"result\":{\"message_id\":2756,\"from\":{\"id\":1276618370,\"is_bot\":true,\"first_name\":\"test_el_bot\",\"username\":\"el_mon_test_bot\"},\"date\":1618466302,\"chat\":{\"id\":275808073,\"type\":\"private\",\"username\":\"Ayrat555\",\"first_name\":\"Ayrat\",\"last_name\":\"Badykov\"},\"poll\":{\"id\":\"5458519832506925078\",\"question\":\"are you?\",\"options\":[{\"text\":\"1\",\"voter_count\":0},{\"text\":\"2\",\"voter_count\":0}],\"total_voter_count\":0,\"is_closed\":false,\"is_anonymous\":true,\"type\":\"regular\",\"allows_multiple_answers\":false}}}";
         let params = SendPollParams::new(
-            ChatIdEnum::IsizeVariant(275808073),
+            ChatIdEnum::IntegerVariant(275808073),
             "are you?".to_string(),
             vec!["1".to_string(), "2".to_string()],
         );
@@ -514,7 +514,7 @@ mod tests {
     #[test]
     fn send_dice_success() {
         let response_string = "{\"ok\":true,\"result\":{\"message_id\":2757,\"from\":{\"id\":1276618370,\"is_bot\":true,\"first_name\":\"test_el_bot\",\"username\":\"el_mon_test_bot\"},\"date\":1618467133,\"chat\":{\"id\":275808073,\"type\":\"private\",\"username\":\"Ayrat555\",\"first_name\":\"Ayrat\",\"last_name\":\"Badykov\"},\"dice\":{\"emoji\":\"🎲\",\"value\":5}}}";
-        let params = SendDiceParams::new(ChatIdEnum::IsizeVariant(275808073));
+        let params = SendDiceParams::new(ChatIdEnum::IntegerVariant(275808073));
 
         let _m = mockito::mock("POST", "/sendDice")
             .with_status(200)
@@ -532,7 +532,7 @@ mod tests {
     fn send_chat_action_success() {
         let response_string = "{\"ok\":true,\"result\":true}";
         let params =
-            SendChatActionParams::new(ChatIdEnum::IsizeVariant(275808073), "typing".to_string());
+            SendChatActionParams::new(ChatIdEnum::IntegerVariant(275808073), "typing".to_string());
 
         let _m = mockito::mock("POST", "/sendChatAction")
             .with_status(200)
@@ -585,7 +585,7 @@ mod tests {
     #[test]
     fn kick_chat_member_success() {
         let response_string = "{\"ok\":true,\"result\":true}";
-        let params = KickChatMemberParams::new(ChatIdEnum::IsizeVariant(-1001368460856), 275808073);
+        let params = KickChatMemberParams::new(ChatIdEnum::IntegerVariant(-1001368460856), 275808073);
 
         let _m = mockito::mock("POST", "/kickChatMember")
             .with_status(200)
@@ -603,7 +603,7 @@ mod tests {
     fn unban_chat_member_success() {
         let response_string = "{\"ok\":true,\"result\":true}";
         let params =
-            UnbanChatMemberParams::new(ChatIdEnum::IsizeVariant(-1001368460856), 275808072);
+            UnbanChatMemberParams::new(ChatIdEnum::IntegerVariant(-1001368460856), 275808072);
 
         let _m = mockito::mock("POST", "/unbanChatMember")
             .with_status(200)
@@ -623,7 +623,7 @@ mod tests {
         let mut perm = ChatPermissions::new();
         perm.set_can_add_web_page_previews(Some(true));
         let params = RestrictChatMemberParams::new(
-            ChatIdEnum::IsizeVariant(-1001368460856),
+            ChatIdEnum::IntegerVariant(-1001368460856),
             275808073,
             perm,
         );
@@ -644,7 +644,7 @@ mod tests {
     fn promote_chat_member_success() {
         let response_string = "{\"ok\":true,\"result\":true}";
         let mut params =
-            PromoteChatMemberParams::new(ChatIdEnum::IsizeVariant(-1001368460856), 275808073);
+            PromoteChatMemberParams::new(ChatIdEnum::IntegerVariant(-1001368460856), 275808073);
         params.set_can_change_info(Some(true));
 
         let _m = mockito::mock("POST", "/promoteChatMember")
@@ -663,7 +663,7 @@ mod tests {
     fn set_chat_administrator_custom_title_success() {
         let response_string = "{\"ok\":true,\"result\":true}";
         let params = SetChatAdministratorCustomTitleParams::new(
-            ChatIdEnum::IsizeVariant(-1001368460856),
+            ChatIdEnum::IntegerVariant(-1001368460856),
             275808073,
             "King".to_string(),
         );
@@ -686,7 +686,7 @@ mod tests {
         let mut perm = ChatPermissions::new();
         perm.set_can_add_web_page_previews(Some(true));
 
-        let params = SetChatPermissionsParams::new(ChatIdEnum::IsizeVariant(-1001368460856), perm);
+        let params = SetChatPermissionsParams::new(ChatIdEnum::IntegerVariant(-1001368460856), perm);
 
         let _m = mockito::mock("POST", "/setChatPermissions")
             .with_status(200)
@@ -704,7 +704,7 @@ mod tests {
     fn export_chat_invite_link_success() {
         let response_string = "{\"ok\":true,\"result\":\"https://t.me/joinchat/txIUDwjfk7M2ODEy\"}";
 
-        let params = ExportChatInviteLinkParams::new(ChatIdEnum::IsizeVariant(-1001368460856));
+        let params = ExportChatInviteLinkParams::new(ChatIdEnum::IntegerVariant(-1001368460856));
 
         let _m = mockito::mock("POST", "/exportChatInviteLink")
             .with_status(200)
@@ -722,7 +722,7 @@ mod tests {
     fn create_chat_invite_link_success() {
         let response_string = "{\"ok\":true,\"result\":{\"invite_link\":\"https://t.me/joinchat/yFEnSaeiQm83ZTNi\",\"creator\":{\"id\":1276618370,\"is_bot\":true,\"first_name\":\"test_el_bot\",\"username\":\"el_mon_test_bot\"},\"is_primary\":false,\"is_revoked\":false}}";
 
-        let params = CreateChatInviteLinkParams::new(ChatIdEnum::IsizeVariant(-1001368460856));
+        let params = CreateChatInviteLinkParams::new(ChatIdEnum::IntegerVariant(-1001368460856));
 
         let _m = mockito::mock("POST", "/createChatInviteLink")
             .with_status(200)
@@ -741,7 +741,7 @@ mod tests {
         let response_string = "{\"ok\":true,\"result\":{\"invite_link\":\"https://t.me/joinchat/O458bA8hQ0MzNmQy\",\"creator\":{\"id\":1276618370,\"is_bot\":true,\"first_name\":\"test_el_bot\",\"username\":\"el_mon_test_bot\"},\"is_primary\":false,\"is_revoked\":false}}";
 
         let params = EditChatInviteLinkParams::new(
-            ChatIdEnum::IsizeVariant(-1001368460856),
+            ChatIdEnum::IntegerVariant(-1001368460856),
             "https://t.me/joinchat/O458bA8hQ0MzNmQy".to_string(),
         );
 
@@ -762,7 +762,7 @@ mod tests {
         let response_string = "{\"ok\":true,\"result\":{\"invite_link\":\"https://t.me/joinchat/O458bA8hQ0MzNmQy\",\"creator\":{\"id\":1276618370,\"is_bot\":true,\"first_name\":\"test_el_bot\",\"username\":\"el_mon_test_bot\"},\"is_primary\":false,\"is_revoked\":true}}";
 
         let params = RevokeChatInviteLinkParams::new(
-            ChatIdEnum::IsizeVariant(-1001368460856),
+            ChatIdEnum::IntegerVariant(-1001368460856),
             "https://t.me/joinchat/O458bA8hQ0MzNmQy".to_string(),
         );
 
@@ -781,7 +781,7 @@ mod tests {
     #[test]
     fn delete_chat_photo_success() {
         let response_string = "{\"ok\":true,\"result\":true}";
-        let params = DeleteChatPhotoParams::new(ChatIdEnum::IsizeVariant(-1001368460856));
+        let params = DeleteChatPhotoParams::new(ChatIdEnum::IntegerVariant(-1001368460856));
 
         let _m = mockito::mock("POST", "/deleteChatPhoto")
             .with_status(200)
@@ -799,7 +799,7 @@ mod tests {
     fn send_photo_success() {
         let response_string = "{\"ok\":true,\"result\":{\"message_id\":2763,\"from\":{\"id\":1276618370,\"is_bot\":true,\"first_name\":\"test_el_bot\",\"username\":\"el_mon_test_bot\"},\"date\":1618730180,\"chat\":{\"id\":275808073,\"type\":\"private\",\"username\":\"Ayrat555\",\"first_name\":\"Ayrat\",\"last_name\":\"Badykov\"},\"photo\":[{\"file_id\":\"AgACAgIAAxkDAAIKy2B73MQXIhoDDmLXjcUjgqGf-m8bAALjsDEbORLgS-s4BkBzcC5DYvIBny4AAwEAAwIAA20AA0U3AwABHwQ\",\"file_unique_id\":\"AQADYvIBny4AA0U3AwAB\",\"width\":320,\"height\":320,\"file_size\":19968},{\"file_id\":\"AgACAgIAAxkDAAIKy2B73MQXIhoDDmLXjcUjgqGf-m8bAALjsDEbORLgS-s4BkBzcC5DYvIBny4AAwEAAwIAA3gAA0Y3AwABHwQ\",\"file_unique_id\":\"AQADYvIBny4AA0Y3AwAB\",\"width\":799,\"height\":800,\"file_size\":63581},{\"file_id\":\"AgACAgIAAxkDAAIKy2B73MQXIhoDDmLXjcUjgqGf-m8bAALjsDEbORLgS-s4BkBzcC5DYvIBny4AAwEAAwIAA3kAA0M3AwABHwQ\",\"file_unique_id\":\"AQADYvIBny4AA0M3AwAB\",\"width\":847,\"height\":848,\"file_size\":63763}]}}";
         let params = SendPhotoParams::new(
-            ChatIdEnum::IsizeVariant(275808073),
+            ChatIdEnum::IntegerVariant(275808073),
             FileEnum::InputFileVariant(InputFile::new(std::path::PathBuf::from(
                 "./frankenstein_logo.png",
             ))),
@@ -821,7 +821,7 @@ mod tests {
     fn send_audio_file_success() {
         let response_string = "{\"ok\":true,\"result\":{\"message_id\":2766,\"from\":{\"id\":1276618370,\"is_bot\":true,\"first_name\":\"test_el_bot\",\"username\":\"el_mon_test_bot\"},\"date\":1618735176,\"chat\":{\"id\":275808073,\"type\":\"private\",\"username\":\"Ayrat555\",\"first_name\":\"Ayrat\",\"last_name\":\"Badykov\"},\"audio\":{\"file_id\":\"CQACAgIAAxkDAAIKzmB78EjK-iOHo-HKC-M6p4r0jGdmAALkDAACORLgS5co1z0uFAKgHwQ\",\"file_unique_id\":\"AgAD5AwAAjkS4Es\",\"duration\":123,\"title\":\"Way Back Home\",\"file_name\":\"audio.mp3\",\"mime_type\":\"audio/mpeg\",\"file_size\":2957092}}}";
         let params = SendAudioParams::new(
-            ChatIdEnum::IsizeVariant(275808073),
+            ChatIdEnum::IntegerVariant(275808073),
             FileEnum::InputFileVariant(InputFile::new(std::path::PathBuf::from(
                 "./frankenstein_logo.png",
             ))),
@@ -842,7 +842,7 @@ mod tests {
     fn send_audio_file_with_thumb_success() {
         let response_string = "{\"ok\":true,\"result\":{\"message_id\":2766,\"from\":{\"id\":1276618370,\"is_bot\":true,\"first_name\":\"test_el_bot\",\"username\":\"el_mon_test_bot\"},\"date\":1618735176,\"chat\":{\"id\":275808073,\"type\":\"private\",\"username\":\"Ayrat555\",\"first_name\":\"Ayrat\",\"last_name\":\"Badykov\"},\"audio\":{\"file_id\":\"CQACAgIAAxkDAAIKzmB78EjK-iOHo-HKC-M6p4r0jGdmAALkDAACORLgS5co1z0uFAKgHwQ\",\"file_unique_id\":\"AgAD5AwAAjkS4Es\",\"duration\":123,\"title\":\"Way Back Home\",\"file_name\":\"audio.mp3\",\"mime_type\":\"audio/mpeg\",\"file_size\":2957092}}}";
         let mut params = SendAudioParams::new(
-            ChatIdEnum::IsizeVariant(275808073),
+            ChatIdEnum::IntegerVariant(275808073),
             FileEnum::InputFileVariant(InputFile::new(std::path::PathBuf::from(
                 "./frankenstein_logo.png",
             ))),
@@ -866,7 +866,7 @@ mod tests {
     fn send_audio_file_id_success() {
         let response_string = "{\"ok\":true,\"result\":{\"message_id\":2769,\"from\":{\"id\":1276618370,\"is_bot\":true,\"first_name\":\"test_el_bot\",\"username\":\"el_mon_test_bot\"},\"date\":1618735333,\"chat\":{\"id\":275808073,\"type\":\"private\",\"username\":\"Ayrat555\",\"first_name\":\"Ayrat\",\"last_name\":\"Badykov\"},\"audio\":{\"file_id\":\"CQACAgIAAxkDAAIK0WB78OUFavWx6fjzCQ_d5qnu_R7mAALkDAACORLgS5co1z0uFAKgHwQ\",\"file_unique_id\":\"AgAD5AwAAjkS4Es\",\"duration\":123,\"title\":\"Way Back Home\",\"file_name\":\"audio.mp3\",\"mime_type\":\"audio/mpeg\",\"file_size\":2957092}}}";
         let params = SendAudioParams::new(
-            ChatIdEnum::IsizeVariant(275808073),
+            ChatIdEnum::IntegerVariant(275808073),
             FileEnum::StringVariant(
                 "CQACAgIAAxkDAAIKzmB78EjK-iOHo-HKC-M6p4r0jGdmAALkDAACORLgS5co1z0uFAKgHwQ"
                     .to_string(),
@@ -888,7 +888,7 @@ mod tests {
     fn send_document_success() {
         let response_string = "{\"ok\":true,\"result\":{\"message_id\":2770,\"from\":{\"id\":1276618370,\"is_bot\":true,\"first_name\":\"test_el_bot\",\"username\":\"el_mon_test_bot\"},\"date\":1618737593,\"chat\":{\"id\":275808073,\"type\":\"private\",\"username\":\"Ayrat555\",\"first_name\":\"Ayrat\",\"last_name\":\"Badykov\"},\"audio\":{\"file_id\":\"CQACAgIAAxkDAAIK0mB7-bnnewABfdaFKK4NzVLQ7BvgCwAC6gwAAjkS4Et_njaNR8IUMB8E\",\"file_unique_id\":\"AgAD6gwAAjkS4Es\",\"duration\":123,\"title\":\"Way Back Home\",\"file_name\":\"audio.mp3\",\"mime_type\":\"audio/mpeg\",\"file_size\":2957092}}}";
         let params = SendDocumentParams::new(
-            ChatIdEnum::IsizeVariant(275808073),
+            ChatIdEnum::IntegerVariant(275808073),
             FileEnum::InputFileVariant(InputFile::new(std::path::PathBuf::from(
                 "./frankenstein_logo.png",
             ))),
@@ -909,7 +909,7 @@ mod tests {
     fn send_video_success() {
         let response_string = "{\"ok\":true,\"result\":{\"message_id\":2770,\"from\":{\"id\":1276618370,\"is_bot\":true,\"first_name\":\"test_el_bot\",\"username\":\"el_mon_test_bot\"},\"date\":1618737593,\"chat\":{\"id\":275808073,\"type\":\"private\",\"username\":\"Ayrat555\",\"first_name\":\"Ayrat\",\"last_name\":\"Badykov\"},\"audio\":{\"file_id\":\"CQACAgIAAxkDAAIK0mB7-bnnewABfdaFKK4NzVLQ7BvgCwAC6gwAAjkS4Et_njaNR8IUMB8E\",\"file_unique_id\":\"AgAD6gwAAjkS4Es\",\"duration\":123,\"title\":\"Way Back Home\",\"file_name\":\"audio.mp3\",\"mime_type\":\"audio/mpeg\",\"file_size\":2957092}}}";
         let params = SendVideoParams::new(
-            ChatIdEnum::IsizeVariant(275808073),
+            ChatIdEnum::IntegerVariant(275808073),
             FileEnum::InputFileVariant(InputFile::new(std::path::PathBuf::from(
                 "./frankenstein_logo.png",
             ))),
@@ -930,7 +930,7 @@ mod tests {
     fn send_animation_success() {
         let response_string = "{\"ok\":true,\"result\":{\"message_id\":2770,\"from\":{\"id\":1276618370,\"is_bot\":true,\"first_name\":\"test_el_bot\",\"username\":\"el_mon_test_bot\"},\"date\":1618737593,\"chat\":{\"id\":275808073,\"type\":\"private\",\"username\":\"Ayrat555\",\"first_name\":\"Ayrat\",\"last_name\":\"Badykov\"},\"audio\":{\"file_id\":\"CQACAgIAAxkDAAIK0mB7-bnnewABfdaFKK4NzVLQ7BvgCwAC6gwAAjkS4Et_njaNR8IUMB8E\",\"file_unique_id\":\"AgAD6gwAAjkS4Es\",\"duration\":123,\"title\":\"Way Back Home\",\"file_name\":\"audio.mp3\",\"mime_type\":\"audio/mpeg\",\"file_size\":2957092}}}";
         let params = SendAnimationParams::new(
-            ChatIdEnum::IsizeVariant(275808073),
+            ChatIdEnum::IntegerVariant(275808073),
             FileEnum::InputFileVariant(InputFile::new(std::path::PathBuf::from(
                 "./frankenstein_logo.png",
             ))),
@@ -951,7 +951,7 @@ mod tests {
     fn send_voice_success() {
         let response_string = "{\"ok\":true,\"result\":{\"message_id\":2770,\"from\":{\"id\":1276618370,\"is_bot\":true,\"first_name\":\"test_el_bot\",\"username\":\"el_mon_test_bot\"},\"date\":1618737593,\"chat\":{\"id\":275808073,\"type\":\"private\",\"username\":\"Ayrat555\",\"first_name\":\"Ayrat\",\"last_name\":\"Badykov\"},\"audio\":{\"file_id\":\"CQACAgIAAxkDAAIK0mB7-bnnewABfdaFKK4NzVLQ7BvgCwAC6gwAAjkS4Et_njaNR8IUMB8E\",\"file_unique_id\":\"AgAD6gwAAjkS4Es\",\"duration\":123,\"title\":\"Way Back Home\",\"file_name\":\"audio.mp3\",\"mime_type\":\"audio/mpeg\",\"file_size\":2957092}}}";
         let params = SendVoiceParams::new(
-            ChatIdEnum::IsizeVariant(275808073),
+            ChatIdEnum::IntegerVariant(275808073),
             FileEnum::InputFileVariant(InputFile::new(std::path::PathBuf::from(
                 "./frankenstein_logo.png",
             ))),
@@ -972,7 +972,7 @@ mod tests {
     fn send_video_note_success() {
         let response_string = "{\"ok\":true,\"result\":{\"message_id\":2770,\"from\":{\"id\":1276618370,\"is_bot\":true,\"first_name\":\"test_el_bot\",\"username\":\"el_mon_test_bot\"},\"date\":1618737593,\"chat\":{\"id\":275808073,\"type\":\"private\",\"username\":\"Ayrat555\",\"first_name\":\"Ayrat\",\"last_name\":\"Badykov\"},\"audio\":{\"file_id\":\"CQACAgIAAxkDAAIK0mB7-bnnewABfdaFKK4NzVLQ7BvgCwAC6gwAAjkS4Et_njaNR8IUMB8E\",\"file_unique_id\":\"AgAD6gwAAjkS4Es\",\"duration\":123,\"title\":\"Way Back Home\",\"file_name\":\"audio.mp3\",\"mime_type\":\"audio/mpeg\",\"file_size\":2957092}}}";
         let params = SendVideoNoteParams::new(
-            ChatIdEnum::IsizeVariant(275808073),
+            ChatIdEnum::IntegerVariant(275808073),
             FileEnum::InputFileVariant(InputFile::new(std::path::PathBuf::from(
                 "./frankenstein_logo.png",
             ))),
@@ -993,7 +993,7 @@ mod tests {
     fn set_chat_photo_success() {
         let response_string = "{\"ok\":true,\"result\":true}";
         let params = SetChatPhotoParams::new(
-            ChatIdEnum::IsizeVariant(-1001368460856),
+            ChatIdEnum::IntegerVariant(-1001368460856),
             InputFile::new(std::path::PathBuf::from("./frankenstein_logo.png")),
         );
 
@@ -1013,7 +1013,7 @@ mod tests {
     fn set_chat_title_success() {
         let response_string = "{\"ok\":true,\"result\":true}";
         let params = SetChatTitleParams::new(
-            ChatIdEnum::IsizeVariant(-1001368460856),
+            ChatIdEnum::IntegerVariant(-1001368460856),
             "Frankenstein".to_string(),
         );
 
@@ -1032,7 +1032,7 @@ mod tests {
     #[test]
     fn set_chat_description_success() {
         let response_string = "{\"ok\":true,\"result\":true}";
-        let mut params = SetChatDescriptionParams::new(ChatIdEnum::IsizeVariant(-1001368460856));
+        let mut params = SetChatDescriptionParams::new(ChatIdEnum::IntegerVariant(-1001368460856));
         params.set_description(Some("Frankenstein group".to_string()));
 
         let _m = mockito::mock("POST", "/setChatDescription")
@@ -1050,7 +1050,7 @@ mod tests {
     #[test]
     fn pin_chat_message_success() {
         let response_string = "{\"ok\":true,\"result\":true}";
-        let params = PinChatMessageParams::new(ChatIdEnum::IsizeVariant(275808073), 2766);
+        let params = PinChatMessageParams::new(ChatIdEnum::IntegerVariant(275808073), 2766);
 
         let _m = mockito::mock("POST", "/pinChatMessage")
             .with_status(200)
@@ -1067,7 +1067,7 @@ mod tests {
     #[test]
     fn unpin_chat_message_success() {
         let response_string = "{\"ok\":true,\"result\":true}";
-        let params = UnpinChatMessageParams::new(ChatIdEnum::IsizeVariant(275808073));
+        let params = UnpinChatMessageParams::new(ChatIdEnum::IntegerVariant(275808073));
 
         let _m = mockito::mock("POST", "/unpinChatMessage")
             .with_status(200)
@@ -1084,7 +1084,7 @@ mod tests {
     #[test]
     fn leave_chat_success() {
         let response_string = "{\"ok\":true,\"result\":true}";
-        let params = LeaveChatParams::new(ChatIdEnum::IsizeVariant(-1001368460856));
+        let params = LeaveChatParams::new(ChatIdEnum::IntegerVariant(-1001368460856));
 
         let _m = mockito::mock("POST", "/leaveChat")
             .with_status(200)
@@ -1101,7 +1101,7 @@ mod tests {
     #[test]
     fn get_chat_success() {
         let response_string = "{\"ok\":true,\"result\":{\"id\":-1001368460856,\"type\":\"supergroup\",\"title\":\"Frankenstein\",\"photo\":{\"small_file_id\":\"AQADAgAT-kgrmy4AAwIAA8jhydkW____s1Cm6Dc_w8Ge7QUAAR8E\",\"small_file_unique_id\":\"AQAD-kgrmy4AA57tBQAB\",\"big_file_id\":\"AQADAgAT-kgrmy4AAwMAA8jhydkW____s1Cm6Dc_w8Gg7QUAAR8E\",\"big_file_unique_id\":\"AQAD-kgrmy4AA6DtBQAB\"},\"description\":\"Frankenstein group\",\"invite_link\":\"https://t.me/joinchat/smSXMzNKTwA0ZjFi\",\"permissions\":{\"can_send_messages\":true,\"can_send_media_messages\":true,\"can_send_polls\":true,\"can_send_other_messages\":true,\"can_add_web_page_previews\":true,\"can_change_info\":true,\"can_invite_users\":true,\"can_pin_messages\":true}}}";
-        let params = GetChatParams::new(ChatIdEnum::IsizeVariant(-1001368460856));
+        let params = GetChatParams::new(ChatIdEnum::IntegerVariant(-1001368460856));
 
         let _m = mockito::mock("POST", "/getChat")
             .with_status(200)
@@ -1118,7 +1118,7 @@ mod tests {
     #[test]
     fn get_chat_administrators_success() {
         let response_string = "{\"ok\":true,\"result\":[{\"user\":{\"id\":1276618370,\"is_bot\":true,\"first_name\":\"test_el_bot\",\"username\":\"el_mon_test_bot\"},\"status\":\"administrator\",\"is_anonymous\":false,\"can_be_edited\":false,\"can_manage_chat\":true,\"can_delete_messages\":true,\"can_manage_voice_chats\":true,\"can_restrict_members\":true,\"can_promote_members\":true,\"can_change_info\":true,\"can_invite_users\":true,\"can_pin_messages\":true},{\"user\":{\"id\":275808073,\"is_bot\":false,\"first_name\":\"Ayrat\",\"last_name\":\"Badykov\",\"username\":\"Ayrat555\",\"language_code\":\"en\"},\"status\":\"creator\",\"is_anonymous\":false}]}";
-        let params = GetChatAdministratorsParams::new(ChatIdEnum::IsizeVariant(-1001368460856));
+        let params = GetChatAdministratorsParams::new(ChatIdEnum::IntegerVariant(-1001368460856));
 
         let _m = mockito::mock("POST", "/getChatAdministrators")
             .with_status(200)
@@ -1135,7 +1135,7 @@ mod tests {
     #[test]
     fn get_chat_members_count_success() {
         let response_string = "{\"ok\":true,\"result\":4}";
-        let params = GetChatMembersCountParams::new(ChatIdEnum::IsizeVariant(-1001368460856));
+        let params = GetChatMembersCountParams::new(ChatIdEnum::IntegerVariant(-1001368460856));
 
         let _m = mockito::mock("POST", "/getChatMembersCount")
             .with_status(200)
@@ -1152,7 +1152,7 @@ mod tests {
     #[test]
     fn get_chat_member_success() {
         let response_string = "{\"ok\":true,\"result\":{\"user\":{\"id\":275808073,\"is_bot\":false,\"first_name\":\"Ayrat\",\"last_name\":\"Badykov\",\"username\":\"Ayrat555\",\"language_code\":\"en\"},\"status\":\"creator\",\"is_anonymous\":false}}";
-        let params = GetChatMemberParams::new(ChatIdEnum::IsizeVariant(-1001368460856), 275808073);
+        let params = GetChatMemberParams::new(ChatIdEnum::IntegerVariant(-1001368460856), 275808073);
 
         let _m = mockito::mock("POST", "/getChatMember")
             .with_status(200)
@@ -1170,7 +1170,7 @@ mod tests {
     fn set_chat_sticker_set_success() {
         let response_string = "{\"ok\":true,\"result\":true}";
         let params = SetChatStickerSetParams::new(
-            ChatIdEnum::IsizeVariant(-1001368460856),
+            ChatIdEnum::IntegerVariant(-1001368460856),
             "GBTDPack".to_string(),
         );
 
@@ -1189,7 +1189,7 @@ mod tests {
     #[test]
     fn delete_chat_sticker_set_success() {
         let response_string = "{\"ok\":true,\"result\":true}";
-        let params = DeleteChatStickerSetParams::new(ChatIdEnum::IsizeVariant(-1001368460856));
+        let params = DeleteChatStickerSetParams::new(ChatIdEnum::IntegerVariant(-1001368460856));
 
         let _m = mockito::mock("POST", "/deleteChatStickerSet")
             .with_status(200)
@@ -1295,7 +1295,7 @@ mod tests {
 
         let mut params = EditMessageTextParams::new("Hi!!".to_string());
 
-        params.set_chat_id(Some(ChatIdEnum::IsizeVariant(275808073)));
+        params.set_chat_id(Some(ChatIdEnum::IntegerVariant(275808073)));
         params.set_message_id(Some(2782));
 
         let _m = mockito::mock("POST", "/editMessageText")
@@ -1316,7 +1316,7 @@ mod tests {
 
         let mut params = EditMessageCaptionParams::new();
 
-        params.set_chat_id(Some(ChatIdEnum::IsizeVariant(275808073)));
+        params.set_chat_id(Some(ChatIdEnum::IntegerVariant(275808073)));
         params.set_message_id(Some(2784));
         params.set_caption(Some("Caption".to_string()));
 
@@ -1336,7 +1336,7 @@ mod tests {
     fn stop_poll_success() {
         let response_string = "{\"ok\":true,\"result\":{\"id\":\"5195109123171024927\",\"question\":\"are you?\",\"options\":[{\"text\":\"1\",\"voter_count\":1},{\"text\":\"2\",\"voter_count\":0}],\"total_voter_count\":1,\"is_closed\":true,\"is_anonymous\":true,\"type\":\"regular\",\"allows_multiple_answers\":false}}";
 
-        let params = StopPollParams::new(ChatIdEnum::IsizeVariant(-1001368460856), 495);
+        let params = StopPollParams::new(ChatIdEnum::IntegerVariant(-1001368460856), 495);
 
         let _m = mockito::mock("POST", "/stopPoll")
             .with_status(200)
@@ -1354,7 +1354,7 @@ mod tests {
     fn delete_message_success() {
         let response_string = "{\"ok\":true,\"result\":true}";
 
-        let params = DeleteMessageParams::new(ChatIdEnum::IsizeVariant(275808073), 2784);
+        let params = DeleteMessageParams::new(ChatIdEnum::IntegerVariant(275808073), 2784);
 
         let _m = mockito::mock("POST", "/deleteMessage")
             .with_status(200)
@@ -1372,7 +1372,7 @@ mod tests {
     fn send_sticker_success() {
         let response_string = "{\"ok\":true,\"result\":{\"message_id\":2788,\"from\":{\"id\":1276618370,\"is_bot\":true,\"first_name\":\"test_el_bot\",\"username\":\"el_mon_test_bot\"},\"date\":1619245784,\"chat\":{\"id\":275808073,\"type\":\"private\",\"username\":\"Ayrat555\",\"first_name\":\"Ayrat\",\"last_name\":\"Badykov\"},\"sticker\":{\"file_id\":\"CAACAgIAAxkDAAIK5GCDutgNxc07rqqtjkGWrGskbHfQAAIMEAACRx8ZSKJ6Z5GkdVHcHwQ\",\"file_unique_id\":\"AgADDBAAAkcfGUg\",\"width\":512,\"height\":512,\"is_animated\":false,\"thumb\":{\"file_id\":\"AAMCAgADGQMAAgrkYIO62A3FzTuuqq2OQZasayRsd9AAAgwQAAJHHxlIonpnkaR1Udz29bujLgADAQAHbQADzR4AAh8E\",\"file_unique_id\":\"AQAD9vW7oy4AA80eAAI\",\"width\":320,\"height\":320,\"file_size\":19264},\"file_size\":36596}}}";
         let params = SendStickerParams::new(
-            ChatIdEnum::IsizeVariant(275808073),
+            ChatIdEnum::IntegerVariant(275808073),
             FileEnum::InputFileVariant(InputFile::new(std::path::PathBuf::from(
                 "./frankenstein_logo.png",
             ))),
@@ -1421,7 +1421,7 @@ mod tests {
             MediaEnum::InputMediaPhotoVariant(photo.clone()),
         ];
 
-        let params = SendMediaGroupParams::new(ChatIdEnum::IsizeVariant(-1001368460856), medias);
+        let params = SendMediaGroupParams::new(ChatIdEnum::IntegerVariant(-1001368460856), medias);
 
         let _m = mockito::mock("POST", "/sendMediaGroup")
             .with_status(200)
@@ -1447,7 +1447,7 @@ mod tests {
             InputMediaPhoto::new(file),
         ));
 
-        params.set_chat_id(Some(ChatIdEnum::IsizeVariant(-1001368460856)));
+        params.set_chat_id(Some(ChatIdEnum::IntegerVariant(-1001368460856)));
         params.set_message_id(Some(513));
         let _m = mockito::mock("POST", "/editMessageMedia")
             .with_status(200)

--- a/src/api_params.rs
+++ b/src/api_params.rs
@@ -53,7 +53,7 @@ pub enum PassportElementError {
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 #[serde(untagged)]
 pub enum ChatIdEnum {
-    IsizeVariant(isize),
+    IntegerVariant(i64),
     StringVariant(String),
 }
 
@@ -78,13 +78,13 @@ pub enum MediaEnum {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct GetUpdatesParams {
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub offset: Option<isize>,
+    pub offset: Option<u32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub limit: Option<isize>,
+    pub limit: Option<u32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub timeout: Option<isize>,
+    pub timeout: Option<u32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub allowed_updates: Option<Vec<String>>,
@@ -135,7 +135,7 @@ pub struct SendMessageParams {
     pub disable_notification: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub reply_to_message_id: Option<isize>,
+    pub reply_to_message_id: Option<i32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub allow_sending_without_reply: Option<bool>,
@@ -153,7 +153,7 @@ pub struct ForwardMessageParams {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub disable_notification: Option<bool>,
 
-    pub message_id: isize,
+    pub message_id: i32,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -162,7 +162,7 @@ pub struct CopyMessageParams {
 
     pub from_chat_id: ChatIdEnum,
 
-    pub message_id: isize,
+    pub message_id: i32,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub caption: Option<String>,
@@ -177,7 +177,7 @@ pub struct CopyMessageParams {
     pub disable_notification: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub reply_to_message_id: Option<isize>,
+    pub reply_to_message_id: Option<i32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub allow_sending_without_reply: Option<bool>,
@@ -205,7 +205,7 @@ pub struct SendPhotoParams {
     pub disable_notification: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub reply_to_message_id: Option<isize>,
+    pub reply_to_message_id: Option<i32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub allow_sending_without_reply: Option<bool>,
@@ -230,7 +230,7 @@ pub struct SendAudioParams {
     pub caption_entities: Option<Vec<MessageEntity>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub duration: Option<isize>,
+    pub duration: Option<u32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub performer: Option<String>,
@@ -245,7 +245,7 @@ pub struct SendAudioParams {
     pub disable_notification: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub reply_to_message_id: Option<isize>,
+    pub reply_to_message_id: Option<i32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub allow_sending_without_reply: Option<bool>,
@@ -279,7 +279,7 @@ pub struct SendDocumentParams {
     pub disable_notification: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub reply_to_message_id: Option<isize>,
+    pub reply_to_message_id: Option<i32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub allow_sending_without_reply: Option<bool>,
@@ -295,13 +295,13 @@ pub struct SendVideoParams {
     pub video: FileEnum,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub duration: Option<isize>,
+    pub duration: Option<u32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub width: Option<isize>,
+    pub width: Option<u32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub height: Option<isize>,
+    pub height: Option<u32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub thumb: Option<FileEnum>,
@@ -322,7 +322,7 @@ pub struct SendVideoParams {
     pub disable_notification: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub reply_to_message_id: Option<isize>,
+    pub reply_to_message_id: Option<i32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub allow_sending_without_reply: Option<bool>,
@@ -338,13 +338,13 @@ pub struct SendAnimationParams {
     pub animation: FileEnum,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub duration: Option<isize>,
+    pub duration: Option<u32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub width: Option<isize>,
+    pub width: Option<u32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub height: Option<isize>,
+    pub height: Option<u32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub thumb: Option<FileEnum>,
@@ -362,7 +362,7 @@ pub struct SendAnimationParams {
     pub disable_notification: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub reply_to_message_id: Option<isize>,
+    pub reply_to_message_id: Option<i32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub allow_sending_without_reply: Option<bool>,
@@ -387,13 +387,13 @@ pub struct SendVoiceParams {
     pub caption_entities: Option<Vec<MessageEntity>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub duration: Option<isize>,
+    pub duration: Option<u32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub disable_notification: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub reply_to_message_id: Option<isize>,
+    pub reply_to_message_id: Option<i32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub allow_sending_without_reply: Option<bool>,
@@ -409,7 +409,7 @@ pub struct SendVideoNoteParams {
     pub video_note: FileEnum,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub duration: Option<isize>,
+    pub duration: Option<u32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub length: Option<isize>,
@@ -421,7 +421,7 @@ pub struct SendVideoNoteParams {
     pub disable_notification: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub reply_to_message_id: Option<isize>,
+    pub reply_to_message_id: Option<i32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub allow_sending_without_reply: Option<bool>,
@@ -440,7 +440,7 @@ pub struct SendMediaGroupParams {
     pub disable_notification: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub reply_to_message_id: Option<isize>,
+    pub reply_to_message_id: Option<i32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub allow_sending_without_reply: Option<bool>,
@@ -470,7 +470,7 @@ pub struct SendLocationParams {
     pub disable_notification: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub reply_to_message_id: Option<isize>,
+    pub reply_to_message_id: Option<i32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub allow_sending_without_reply: Option<bool>,
@@ -485,7 +485,7 @@ pub struct EditMessageLiveLocationParams {
     pub chat_id: Option<ChatIdEnum>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub message_id: Option<isize>,
+    pub message_id: Option<i32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub inline_message_id: Option<String>,
@@ -513,7 +513,7 @@ pub struct StopMessageLiveLocationParams {
     pub chat_id: Option<ChatIdEnum>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub message_id: Option<isize>,
+    pub message_id: Option<i32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub inline_message_id: Option<String>,
@@ -550,7 +550,7 @@ pub struct SendVenueParams {
     pub disable_notification: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub reply_to_message_id: Option<isize>,
+    pub reply_to_message_id: Option<i32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub allow_sending_without_reply: Option<bool>,
@@ -577,7 +577,7 @@ pub struct SendContactParams {
     pub disable_notification: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub reply_to_message_id: Option<isize>,
+    pub reply_to_message_id: Option<i32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub allow_sending_without_reply: Option<bool>,
@@ -619,7 +619,7 @@ pub struct SendPollParams {
     pub open_period: Option<isize>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub close_date: Option<isize>,
+    pub close_date: Option<u64>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub is_closed: Option<bool>,
@@ -628,7 +628,7 @@ pub struct SendPollParams {
     pub disable_notification: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub reply_to_message_id: Option<isize>,
+    pub reply_to_message_id: Option<i32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub allow_sending_without_reply: Option<bool>,
@@ -648,7 +648,7 @@ pub struct SendDiceParams {
     pub disable_notification: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub reply_to_message_id: Option<isize>,
+    pub reply_to_message_id: Option<i32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub allow_sending_without_reply: Option<bool>,
@@ -666,13 +666,13 @@ pub struct SendChatActionParams {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct GetUserProfilePhotosParams {
-    pub user_id: isize,
+    pub user_id: u64,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub offset: Option<isize>,
+    pub offset: Option<u32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub limit: Option<isize>,
+    pub limit: Option<u32>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -684,10 +684,10 @@ pub struct GetFileParams {
 pub struct KickChatMemberParams {
     pub chat_id: ChatIdEnum,
 
-    pub user_id: isize,
+    pub user_id: u64,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub until_date: Option<isize>,
+    pub until_date: Option<u64>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub revoke_messages: Option<bool>,
@@ -697,7 +697,7 @@ pub struct KickChatMemberParams {
 pub struct UnbanChatMemberParams {
     pub chat_id: ChatIdEnum,
 
-    pub user_id: isize,
+    pub user_id: u64,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub only_if_banned: Option<bool>,
@@ -707,19 +707,19 @@ pub struct UnbanChatMemberParams {
 pub struct RestrictChatMemberParams {
     pub chat_id: ChatIdEnum,
 
-    pub user_id: isize,
+    pub user_id: u64,
 
     pub permissions: ChatPermissions,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub until_date: Option<isize>,
+    pub until_date: Option<u64>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct PromoteChatMemberParams {
     pub chat_id: ChatIdEnum,
 
-    pub user_id: isize,
+    pub user_id: u64,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub is_anonymous: Option<bool>,
@@ -759,7 +759,7 @@ pub struct PromoteChatMemberParams {
 pub struct SetChatAdministratorCustomTitleParams {
     pub chat_id: ChatIdEnum,
 
-    pub user_id: isize,
+    pub user_id: u64,
 
     pub custom_title: String,
 }
@@ -781,10 +781,10 @@ pub struct CreateChatInviteLinkParams {
     pub chat_id: ChatIdEnum,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub expire_date: Option<isize>,
+    pub expire_date: Option<u64>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub member_limit: Option<isize>,
+    pub member_limit: Option<u32>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -794,10 +794,10 @@ pub struct EditChatInviteLinkParams {
     pub invite_link: String,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub expire_date: Option<isize>,
+    pub expire_date: Option<u64>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub member_limit: Option<isize>,
+    pub member_limit: Option<u32>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -838,7 +838,7 @@ pub struct SetChatDescriptionParams {
 pub struct PinChatMessageParams {
     pub chat_id: ChatIdEnum,
 
-    pub message_id: isize,
+    pub message_id: i32,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub disable_notification: Option<bool>,
@@ -849,7 +849,7 @@ pub struct UnpinChatMessageParams {
     pub chat_id: ChatIdEnum,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub message_id: Option<isize>,
+    pub message_id: Option<i32>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -881,7 +881,7 @@ pub struct GetChatMembersCountParams {
 pub struct GetChatMemberParams {
     pub chat_id: ChatIdEnum,
 
-    pub user_id: isize,
+    pub user_id: u64,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -924,7 +924,7 @@ pub struct EditMessageTextParams {
     pub chat_id: Option<ChatIdEnum>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub message_id: Option<isize>,
+    pub message_id: Option<i32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub inline_message_id: Option<String>,
@@ -950,7 +950,7 @@ pub struct EditMessageCaptionParams {
     pub chat_id: Option<ChatIdEnum>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub message_id: Option<isize>,
+    pub message_id: Option<i32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub inline_message_id: Option<String>,
@@ -974,7 +974,7 @@ pub struct EditMessageMediaParams {
     pub chat_id: Option<ChatIdEnum>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub message_id: Option<isize>,
+    pub message_id: Option<i32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub inline_message_id: Option<String>,
@@ -991,7 +991,7 @@ pub struct EditMessageReplyMarkupParams {
     pub chat_id: Option<ChatIdEnum>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub message_id: Option<isize>,
+    pub message_id: Option<i32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub inline_message_id: Option<String>,
@@ -1004,7 +1004,7 @@ pub struct EditMessageReplyMarkupParams {
 pub struct StopPollParams {
     pub chat_id: ChatIdEnum,
 
-    pub message_id: isize,
+    pub message_id: i32,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub reply_markup: Option<InlineKeyboardMarkup>,
@@ -1014,7 +1014,7 @@ pub struct StopPollParams {
 pub struct DeleteMessageParams {
     pub chat_id: ChatIdEnum,
 
-    pub message_id: isize,
+    pub message_id: i32,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -1027,7 +1027,7 @@ pub struct SendStickerParams {
     pub disable_notification: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub reply_to_message_id: Option<isize>,
+    pub reply_to_message_id: Option<i32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub allow_sending_without_reply: Option<bool>,
@@ -1043,14 +1043,14 @@ pub struct GetStickerSetParams {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct UploadStickerFileParams {
-    pub user_id: isize,
+    pub user_id: u64,
 
     pub png_sticker: InputFile,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct CreateNewStickerSetParams {
-    pub user_id: isize,
+    pub user_id: u64,
 
     pub name: String,
 
@@ -1073,7 +1073,7 @@ pub struct CreateNewStickerSetParams {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct AddStickerToSetParams {
-    pub user_id: isize,
+    pub user_id: u64,
 
     pub name: String,
 
@@ -1105,7 +1105,7 @@ pub struct DeleteStickerFromSetParams {
 pub struct SetStickerSetThumbParams {
     pub name: String,
 
-    pub user_id: isize,
+    pub user_id: u64,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub thumb: Option<FileEnum>,
@@ -1135,7 +1135,7 @@ pub struct AnswerInlineQueryParams {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct SendInvoiceParams {
-    pub chat_id: isize,
+    pub chat_id: i64,
 
     pub title: String,
 
@@ -1165,13 +1165,13 @@ pub struct SendInvoiceParams {
     pub photo_url: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub photo_size: Option<isize>,
+    pub photo_size: Option<u32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub photo_width: Option<isize>,
+    pub photo_width: Option<u32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub photo_height: Option<isize>,
+    pub photo_height: Option<u32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub need_name: Option<bool>,
@@ -1198,7 +1198,7 @@ pub struct SendInvoiceParams {
     pub disable_notification: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub reply_to_message_id: Option<isize>,
+    pub reply_to_message_id: Option<i32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub allow_sending_without_reply: Option<bool>,
@@ -1232,14 +1232,14 @@ pub struct AnswerPreCheckoutQueryParams {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct SetPassportDataErrorsParams {
-    pub user_id: isize,
+    pub user_id: u64,
 
     pub errors: Vec<PassportElementError>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct SendGameParams {
-    pub chat_id: isize,
+    pub chat_id: i64,
 
     pub game_short_name: String,
 
@@ -1247,7 +1247,7 @@ pub struct SendGameParams {
     pub disable_notification: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub reply_to_message_id: Option<isize>,
+    pub reply_to_message_id: Option<i32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub allow_sending_without_reply: Option<bool>,
@@ -1258,7 +1258,7 @@ pub struct SendGameParams {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct SetGameScoreParams {
-    pub user_id: isize,
+    pub user_id: u64,
 
     pub score: isize,
 
@@ -1269,10 +1269,10 @@ pub struct SetGameScoreParams {
     pub disable_edit_message: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub chat_id: Option<isize>,
+    pub chat_id: Option<i64>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub message_id: Option<isize>,
+    pub message_id: Option<i32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub inline_message_id: Option<String>,
@@ -1280,13 +1280,13 @@ pub struct SetGameScoreParams {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct GetGameHighScoresParams {
-    pub user_id: isize,
+    pub user_id: u64,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub chat_id: Option<isize>,
+    pub chat_id: Option<i64>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub message_id: Option<isize>,
+    pub message_id: Option<i32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub inline_message_id: Option<String>,
@@ -1329,13 +1329,13 @@ pub struct InputMediaVideo {
     pub caption_entities: Option<Vec<MessageEntity>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub width: Option<isize>,
+    pub width: Option<u32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub height: Option<isize>,
+    pub height: Option<u32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub duration: Option<isize>,
+    pub duration: Option<u32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub supports_streaming: Option<bool>,
@@ -1361,13 +1361,13 @@ pub struct InputMediaAnimation {
     pub caption_entities: Option<Vec<MessageEntity>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub width: Option<isize>,
+    pub width: Option<u32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub height: Option<isize>,
+    pub height: Option<u32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub duration: Option<isize>,
+    pub duration: Option<u32>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -1390,7 +1390,7 @@ pub struct InputMediaAudio {
     pub caption_entities: Option<Vec<MessageEntity>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub duration: Option<isize>,
+    pub duration: Option<u32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub performer: Option<String>,
@@ -1432,15 +1432,15 @@ impl GetUpdatesParams {
         }
     }
 
-    pub fn set_offset(&mut self, offset: Option<isize>) {
+    pub fn set_offset(&mut self, offset: Option<u32>) {
         self.offset = offset;
     }
 
-    pub fn set_limit(&mut self, limit: Option<isize>) {
+    pub fn set_limit(&mut self, limit: Option<u32>) {
         self.limit = limit;
     }
 
-    pub fn set_timeout(&mut self, timeout: Option<isize>) {
+    pub fn set_timeout(&mut self, timeout: Option<u32>) {
         self.timeout = timeout;
     }
 
@@ -1448,15 +1448,15 @@ impl GetUpdatesParams {
         self.allowed_updates = allowed_updates;
     }
 
-    pub fn offset(&self) -> Option<isize> {
+    pub fn offset(&self) -> Option<u32> {
         self.offset
     }
 
-    pub fn limit(&self) -> Option<isize> {
+    pub fn limit(&self) -> Option<u32> {
         self.limit
     }
 
-    pub fn timeout(&self) -> Option<isize> {
+    pub fn timeout(&self) -> Option<u32> {
         self.timeout
     }
 
@@ -1581,7 +1581,7 @@ impl SendMessageParams {
         self.disable_notification = disable_notification;
     }
 
-    pub fn set_reply_to_message_id(&mut self, reply_to_message_id: Option<isize>) {
+    pub fn set_reply_to_message_id(&mut self, reply_to_message_id: Option<i32>) {
         self.reply_to_message_id = reply_to_message_id;
     }
 
@@ -1617,7 +1617,7 @@ impl SendMessageParams {
         self.disable_notification
     }
 
-    pub fn reply_to_message_id(&self) -> Option<isize> {
+    pub fn reply_to_message_id(&self) -> Option<i32> {
         self.reply_to_message_id
     }
 
@@ -1631,7 +1631,7 @@ impl SendMessageParams {
 }
 
 impl ForwardMessageParams {
-    pub fn new(chat_id: ChatIdEnum, from_chat_id: ChatIdEnum, message_id: isize) -> Self {
+    pub fn new(chat_id: ChatIdEnum, from_chat_id: ChatIdEnum, message_id: i32) -> Self {
         Self {
             chat_id,
             from_chat_id,
@@ -1648,7 +1648,7 @@ impl ForwardMessageParams {
         self.from_chat_id = from_chat_id;
     }
 
-    pub fn set_message_id(&mut self, message_id: isize) {
+    pub fn set_message_id(&mut self, message_id: i32) {
         self.message_id = message_id;
     }
 
@@ -1664,7 +1664,7 @@ impl ForwardMessageParams {
         self.from_chat_id.clone()
     }
 
-    pub fn message_id(&self) -> isize {
+    pub fn message_id(&self) -> i32 {
         self.message_id
     }
 
@@ -1674,7 +1674,7 @@ impl ForwardMessageParams {
 }
 
 impl CopyMessageParams {
-    pub fn new(chat_id: ChatIdEnum, from_chat_id: ChatIdEnum, message_id: isize) -> Self {
+    pub fn new(chat_id: ChatIdEnum, from_chat_id: ChatIdEnum, message_id: i32) -> Self {
         Self {
             chat_id,
             from_chat_id,
@@ -1697,7 +1697,7 @@ impl CopyMessageParams {
         self.from_chat_id = from_chat_id;
     }
 
-    pub fn set_message_id(&mut self, message_id: isize) {
+    pub fn set_message_id(&mut self, message_id: i32) {
         self.message_id = message_id;
     }
 
@@ -1717,7 +1717,7 @@ impl CopyMessageParams {
         self.disable_notification = disable_notification;
     }
 
-    pub fn set_reply_to_message_id(&mut self, reply_to_message_id: Option<isize>) {
+    pub fn set_reply_to_message_id(&mut self, reply_to_message_id: Option<i32>) {
         self.reply_to_message_id = reply_to_message_id;
     }
 
@@ -1737,7 +1737,7 @@ impl CopyMessageParams {
         self.from_chat_id.clone()
     }
 
-    pub fn message_id(&self) -> isize {
+    pub fn message_id(&self) -> i32 {
         self.message_id
     }
 
@@ -1757,7 +1757,7 @@ impl CopyMessageParams {
         self.disable_notification
     }
 
-    pub fn reply_to_message_id(&self) -> Option<isize> {
+    pub fn reply_to_message_id(&self) -> Option<i32> {
         self.reply_to_message_id
     }
 
@@ -1809,7 +1809,7 @@ impl SendPhotoParams {
         self.disable_notification = disable_notification;
     }
 
-    pub fn set_reply_to_message_id(&mut self, reply_to_message_id: Option<isize>) {
+    pub fn set_reply_to_message_id(&mut self, reply_to_message_id: Option<i32>) {
         self.reply_to_message_id = reply_to_message_id;
     }
 
@@ -1845,7 +1845,7 @@ impl SendPhotoParams {
         self.disable_notification
     }
 
-    pub fn reply_to_message_id(&self) -> Option<isize> {
+    pub fn reply_to_message_id(&self) -> Option<i32> {
         self.reply_to_message_id
     }
 
@@ -1897,7 +1897,7 @@ impl SendAudioParams {
         self.caption_entities = caption_entities;
     }
 
-    pub fn set_duration(&mut self, duration: Option<isize>) {
+    pub fn set_duration(&mut self, duration: Option<u32>) {
         self.duration = duration;
     }
 
@@ -1917,7 +1917,7 @@ impl SendAudioParams {
         self.disable_notification = disable_notification;
     }
 
-    pub fn set_reply_to_message_id(&mut self, reply_to_message_id: Option<isize>) {
+    pub fn set_reply_to_message_id(&mut self, reply_to_message_id: Option<i32>) {
         self.reply_to_message_id = reply_to_message_id;
     }
 
@@ -1949,7 +1949,7 @@ impl SendAudioParams {
         self.caption_entities.clone()
     }
 
-    pub fn duration(&self) -> Option<isize> {
+    pub fn duration(&self) -> Option<u32> {
         self.duration
     }
 
@@ -1969,7 +1969,7 @@ impl SendAudioParams {
         self.disable_notification
     }
 
-    pub fn reply_to_message_id(&self) -> Option<isize> {
+    pub fn reply_to_message_id(&self) -> Option<i32> {
         self.reply_to_message_id
     }
 
@@ -2034,7 +2034,7 @@ impl SendDocumentParams {
         self.disable_notification = disable_notification;
     }
 
-    pub fn set_reply_to_message_id(&mut self, reply_to_message_id: Option<isize>) {
+    pub fn set_reply_to_message_id(&mut self, reply_to_message_id: Option<i32>) {
         self.reply_to_message_id = reply_to_message_id;
     }
 
@@ -2078,7 +2078,7 @@ impl SendDocumentParams {
         self.disable_notification
     }
 
-    pub fn reply_to_message_id(&self) -> Option<isize> {
+    pub fn reply_to_message_id(&self) -> Option<i32> {
         self.reply_to_message_id
     }
 
@@ -2119,15 +2119,15 @@ impl SendVideoParams {
         self.video = video;
     }
 
-    pub fn set_duration(&mut self, duration: Option<isize>) {
+    pub fn set_duration(&mut self, duration: Option<u32>) {
         self.duration = duration;
     }
 
-    pub fn set_width(&mut self, width: Option<isize>) {
+    pub fn set_width(&mut self, width: Option<u32>) {
         self.width = width;
     }
 
-    pub fn set_height(&mut self, height: Option<isize>) {
+    pub fn set_height(&mut self, height: Option<u32>) {
         self.height = height;
     }
 
@@ -2155,7 +2155,7 @@ impl SendVideoParams {
         self.disable_notification = disable_notification;
     }
 
-    pub fn set_reply_to_message_id(&mut self, reply_to_message_id: Option<isize>) {
+    pub fn set_reply_to_message_id(&mut self, reply_to_message_id: Option<i32>) {
         self.reply_to_message_id = reply_to_message_id;
     }
 
@@ -2175,15 +2175,15 @@ impl SendVideoParams {
         self.video.clone()
     }
 
-    pub fn duration(&self) -> Option<isize> {
+    pub fn duration(&self) -> Option<u32> {
         self.duration
     }
 
-    pub fn width(&self) -> Option<isize> {
+    pub fn width(&self) -> Option<u32> {
         self.width
     }
 
-    pub fn height(&self) -> Option<isize> {
+    pub fn height(&self) -> Option<u32> {
         self.height
     }
 
@@ -2211,7 +2211,7 @@ impl SendVideoParams {
         self.disable_notification
     }
 
-    pub fn reply_to_message_id(&self) -> Option<isize> {
+    pub fn reply_to_message_id(&self) -> Option<i32> {
         self.reply_to_message_id
     }
 
@@ -2251,15 +2251,15 @@ impl SendAnimationParams {
         self.animation = animation;
     }
 
-    pub fn set_duration(&mut self, duration: Option<isize>) {
+    pub fn set_duration(&mut self, duration: Option<u32>) {
         self.duration = duration;
     }
 
-    pub fn set_width(&mut self, width: Option<isize>) {
+    pub fn set_width(&mut self, width: Option<u32>) {
         self.width = width;
     }
 
-    pub fn set_height(&mut self, height: Option<isize>) {
+    pub fn set_height(&mut self, height: Option<u32>) {
         self.height = height;
     }
 
@@ -2283,7 +2283,7 @@ impl SendAnimationParams {
         self.disable_notification = disable_notification;
     }
 
-    pub fn set_reply_to_message_id(&mut self, reply_to_message_id: Option<isize>) {
+    pub fn set_reply_to_message_id(&mut self, reply_to_message_id: Option<i32>) {
         self.reply_to_message_id = reply_to_message_id;
     }
 
@@ -2303,15 +2303,15 @@ impl SendAnimationParams {
         self.animation.clone()
     }
 
-    pub fn duration(&self) -> Option<isize> {
+    pub fn duration(&self) -> Option<u32> {
         self.duration
     }
 
-    pub fn width(&self) -> Option<isize> {
+    pub fn width(&self) -> Option<u32> {
         self.width
     }
 
-    pub fn height(&self) -> Option<isize> {
+    pub fn height(&self) -> Option<u32> {
         self.height
     }
 
@@ -2335,7 +2335,7 @@ impl SendAnimationParams {
         self.disable_notification
     }
 
-    pub fn reply_to_message_id(&self) -> Option<isize> {
+    pub fn reply_to_message_id(&self) -> Option<i32> {
         self.reply_to_message_id
     }
 
@@ -2384,7 +2384,7 @@ impl SendVoiceParams {
         self.caption_entities = caption_entities;
     }
 
-    pub fn set_duration(&mut self, duration: Option<isize>) {
+    pub fn set_duration(&mut self, duration: Option<u32>) {
         self.duration = duration;
     }
 
@@ -2392,7 +2392,7 @@ impl SendVoiceParams {
         self.disable_notification = disable_notification;
     }
 
-    pub fn set_reply_to_message_id(&mut self, reply_to_message_id: Option<isize>) {
+    pub fn set_reply_to_message_id(&mut self, reply_to_message_id: Option<i32>) {
         self.reply_to_message_id = reply_to_message_id;
     }
 
@@ -2424,7 +2424,7 @@ impl SendVoiceParams {
         self.caption_entities.clone()
     }
 
-    pub fn duration(&self) -> Option<isize> {
+    pub fn duration(&self) -> Option<u32> {
         self.duration
     }
 
@@ -2432,7 +2432,7 @@ impl SendVoiceParams {
         self.disable_notification
     }
 
-    pub fn reply_to_message_id(&self) -> Option<isize> {
+    pub fn reply_to_message_id(&self) -> Option<i32> {
         self.reply_to_message_id
     }
 
@@ -2468,7 +2468,7 @@ impl SendVideoNoteParams {
         self.video_note = video_note;
     }
 
-    pub fn set_duration(&mut self, duration: Option<isize>) {
+    pub fn set_duration(&mut self, duration: Option<u32>) {
         self.duration = duration;
     }
 
@@ -2484,7 +2484,7 @@ impl SendVideoNoteParams {
         self.disable_notification = disable_notification;
     }
 
-    pub fn set_reply_to_message_id(&mut self, reply_to_message_id: Option<isize>) {
+    pub fn set_reply_to_message_id(&mut self, reply_to_message_id: Option<i32>) {
         self.reply_to_message_id = reply_to_message_id;
     }
 
@@ -2504,7 +2504,7 @@ impl SendVideoNoteParams {
         self.video_note.clone()
     }
 
-    pub fn duration(&self) -> Option<isize> {
+    pub fn duration(&self) -> Option<u32> {
         self.duration
     }
 
@@ -2520,7 +2520,7 @@ impl SendVideoNoteParams {
         self.disable_notification
     }
 
-    pub fn reply_to_message_id(&self) -> Option<isize> {
+    pub fn reply_to_message_id(&self) -> Option<i32> {
         self.reply_to_message_id
     }
 
@@ -2556,7 +2556,7 @@ impl SendMediaGroupParams {
         self.disable_notification = disable_notification;
     }
 
-    pub fn set_reply_to_message_id(&mut self, reply_to_message_id: Option<isize>) {
+    pub fn set_reply_to_message_id(&mut self, reply_to_message_id: Option<i32>) {
         self.reply_to_message_id = reply_to_message_id;
     }
 
@@ -2576,7 +2576,7 @@ impl SendMediaGroupParams {
         self.disable_notification
     }
 
-    pub fn reply_to_message_id(&self) -> Option<isize> {
+    pub fn reply_to_message_id(&self) -> Option<i32> {
         self.reply_to_message_id
     }
 
@@ -2634,7 +2634,7 @@ impl SendLocationParams {
         self.disable_notification = disable_notification;
     }
 
-    pub fn set_reply_to_message_id(&mut self, reply_to_message_id: Option<isize>) {
+    pub fn set_reply_to_message_id(&mut self, reply_to_message_id: Option<i32>) {
         self.reply_to_message_id = reply_to_message_id;
     }
 
@@ -2678,7 +2678,7 @@ impl SendLocationParams {
         self.disable_notification
     }
 
-    pub fn reply_to_message_id(&self) -> Option<isize> {
+    pub fn reply_to_message_id(&self) -> Option<i32> {
         self.reply_to_message_id
     }
 
@@ -2718,7 +2718,7 @@ impl EditMessageLiveLocationParams {
         self.chat_id = chat_id;
     }
 
-    pub fn set_message_id(&mut self, message_id: Option<isize>) {
+    pub fn set_message_id(&mut self, message_id: Option<i32>) {
         self.message_id = message_id;
     }
 
@@ -2754,7 +2754,7 @@ impl EditMessageLiveLocationParams {
         self.chat_id.clone()
     }
 
-    pub fn message_id(&self) -> Option<isize> {
+    pub fn message_id(&self) -> Option<i32> {
         self.message_id
     }
 
@@ -2793,7 +2793,7 @@ impl StopMessageLiveLocationParams {
         self.chat_id = chat_id;
     }
 
-    pub fn set_message_id(&mut self, message_id: Option<isize>) {
+    pub fn set_message_id(&mut self, message_id: Option<i32>) {
         self.message_id = message_id;
     }
 
@@ -2809,7 +2809,7 @@ impl StopMessageLiveLocationParams {
         self.chat_id.clone()
     }
 
-    pub fn message_id(&self) -> Option<isize> {
+    pub fn message_id(&self) -> Option<i32> {
         self.message_id
     }
 
@@ -2887,7 +2887,7 @@ impl SendVenueParams {
         self.disable_notification = disable_notification;
     }
 
-    pub fn set_reply_to_message_id(&mut self, reply_to_message_id: Option<isize>) {
+    pub fn set_reply_to_message_id(&mut self, reply_to_message_id: Option<i32>) {
         self.reply_to_message_id = reply_to_message_id;
     }
 
@@ -2939,7 +2939,7 @@ impl SendVenueParams {
         self.disable_notification
     }
 
-    pub fn reply_to_message_id(&self) -> Option<isize> {
+    pub fn reply_to_message_id(&self) -> Option<i32> {
         self.reply_to_message_id
     }
 
@@ -2991,7 +2991,7 @@ impl SendContactParams {
         self.disable_notification = disable_notification;
     }
 
-    pub fn set_reply_to_message_id(&mut self, reply_to_message_id: Option<isize>) {
+    pub fn set_reply_to_message_id(&mut self, reply_to_message_id: Option<i32>) {
         self.reply_to_message_id = reply_to_message_id;
     }
 
@@ -3027,7 +3027,7 @@ impl SendContactParams {
         self.disable_notification
     }
 
-    pub fn reply_to_message_id(&self) -> Option<isize> {
+    pub fn reply_to_message_id(&self) -> Option<i32> {
         self.reply_to_message_id
     }
 
@@ -3107,7 +3107,7 @@ impl SendPollParams {
         self.open_period = open_period;
     }
 
-    pub fn set_close_date(&mut self, close_date: Option<isize>) {
+    pub fn set_close_date(&mut self, close_date: Option<u64>) {
         self.close_date = close_date;
     }
 
@@ -3119,7 +3119,7 @@ impl SendPollParams {
         self.disable_notification = disable_notification;
     }
 
-    pub fn set_reply_to_message_id(&mut self, reply_to_message_id: Option<isize>) {
+    pub fn set_reply_to_message_id(&mut self, reply_to_message_id: Option<i32>) {
         self.reply_to_message_id = reply_to_message_id;
     }
 
@@ -3175,7 +3175,7 @@ impl SendPollParams {
         self.open_period
     }
 
-    pub fn close_date(&self) -> Option<isize> {
+    pub fn close_date(&self) -> Option<u64> {
         self.close_date
     }
 
@@ -3187,7 +3187,7 @@ impl SendPollParams {
         self.disable_notification
     }
 
-    pub fn reply_to_message_id(&self) -> Option<isize> {
+    pub fn reply_to_message_id(&self) -> Option<i32> {
         self.reply_to_message_id
     }
 
@@ -3224,7 +3224,7 @@ impl SendDiceParams {
         self.disable_notification = disable_notification;
     }
 
-    pub fn set_reply_to_message_id(&mut self, reply_to_message_id: Option<isize>) {
+    pub fn set_reply_to_message_id(&mut self, reply_to_message_id: Option<i32>) {
         self.reply_to_message_id = reply_to_message_id;
     }
 
@@ -3248,7 +3248,7 @@ impl SendDiceParams {
         self.disable_notification
     }
 
-    pub fn reply_to_message_id(&self) -> Option<isize> {
+    pub fn reply_to_message_id(&self) -> Option<i32> {
         self.reply_to_message_id
     }
 
@@ -3284,7 +3284,7 @@ impl SendChatActionParams {
 }
 
 impl GetUserProfilePhotosParams {
-    pub fn new(user_id: isize) -> Self {
+    pub fn new(user_id: u64) -> Self {
         Self {
             user_id,
             offset: None,
@@ -3292,27 +3292,27 @@ impl GetUserProfilePhotosParams {
         }
     }
 
-    pub fn set_user_id(&mut self, user_id: isize) {
+    pub fn set_user_id(&mut self, user_id: u64) {
         self.user_id = user_id;
     }
 
-    pub fn set_offset(&mut self, offset: Option<isize>) {
+    pub fn set_offset(&mut self, offset: Option<u32>) {
         self.offset = offset;
     }
 
-    pub fn set_limit(&mut self, limit: Option<isize>) {
+    pub fn set_limit(&mut self, limit: Option<u32>) {
         self.limit = limit;
     }
 
-    pub fn user_id(&self) -> isize {
+    pub fn user_id(&self) -> u64 {
         self.user_id
     }
 
-    pub fn offset(&self) -> Option<isize> {
+    pub fn offset(&self) -> Option<u32> {
         self.offset
     }
 
-    pub fn limit(&self) -> Option<isize> {
+    pub fn limit(&self) -> Option<u32> {
         self.limit
     }
 }
@@ -3332,7 +3332,7 @@ impl GetFileParams {
 }
 
 impl KickChatMemberParams {
-    pub fn new(chat_id: ChatIdEnum, user_id: isize) -> Self {
+    pub fn new(chat_id: ChatIdEnum, user_id: u64) -> Self {
         Self {
             chat_id,
             user_id,
@@ -3345,11 +3345,11 @@ impl KickChatMemberParams {
         self.chat_id = chat_id;
     }
 
-    pub fn set_user_id(&mut self, user_id: isize) {
+    pub fn set_user_id(&mut self, user_id: u64) {
         self.user_id = user_id;
     }
 
-    pub fn set_until_date(&mut self, until_date: Option<isize>) {
+    pub fn set_until_date(&mut self, until_date: Option<u64>) {
         self.until_date = until_date;
     }
 
@@ -3361,11 +3361,11 @@ impl KickChatMemberParams {
         self.chat_id.clone()
     }
 
-    pub fn user_id(&self) -> isize {
+    pub fn user_id(&self) -> u64 {
         self.user_id
     }
 
-    pub fn until_date(&self) -> Option<isize> {
+    pub fn until_date(&self) -> Option<u64> {
         self.until_date
     }
 
@@ -3375,7 +3375,7 @@ impl KickChatMemberParams {
 }
 
 impl UnbanChatMemberParams {
-    pub fn new(chat_id: ChatIdEnum, user_id: isize) -> Self {
+    pub fn new(chat_id: ChatIdEnum, user_id: u64) -> Self {
         Self {
             chat_id,
             user_id,
@@ -3387,7 +3387,7 @@ impl UnbanChatMemberParams {
         self.chat_id = chat_id;
     }
 
-    pub fn set_user_id(&mut self, user_id: isize) {
+    pub fn set_user_id(&mut self, user_id: u64) {
         self.user_id = user_id;
     }
 
@@ -3399,7 +3399,7 @@ impl UnbanChatMemberParams {
         self.chat_id.clone()
     }
 
-    pub fn user_id(&self) -> isize {
+    pub fn user_id(&self) -> u64 {
         self.user_id
     }
 
@@ -3409,7 +3409,7 @@ impl UnbanChatMemberParams {
 }
 
 impl RestrictChatMemberParams {
-    pub fn new(chat_id: ChatIdEnum, user_id: isize, permissions: ChatPermissions) -> Self {
+    pub fn new(chat_id: ChatIdEnum, user_id: u64, permissions: ChatPermissions) -> Self {
         Self {
             chat_id,
             user_id,
@@ -3422,7 +3422,7 @@ impl RestrictChatMemberParams {
         self.chat_id = chat_id;
     }
 
-    pub fn set_user_id(&mut self, user_id: isize) {
+    pub fn set_user_id(&mut self, user_id: u64) {
         self.user_id = user_id;
     }
 
@@ -3430,7 +3430,7 @@ impl RestrictChatMemberParams {
         self.permissions = permissions;
     }
 
-    pub fn set_until_date(&mut self, until_date: Option<isize>) {
+    pub fn set_until_date(&mut self, until_date: Option<u64>) {
         self.until_date = until_date;
     }
 
@@ -3438,7 +3438,7 @@ impl RestrictChatMemberParams {
         self.chat_id.clone()
     }
 
-    pub fn user_id(&self) -> isize {
+    pub fn user_id(&self) -> u64 {
         self.user_id
     }
 
@@ -3446,13 +3446,13 @@ impl RestrictChatMemberParams {
         self.permissions.clone()
     }
 
-    pub fn until_date(&self) -> Option<isize> {
+    pub fn until_date(&self) -> Option<u64> {
         self.until_date
     }
 }
 
 impl PromoteChatMemberParams {
-    pub fn new(chat_id: ChatIdEnum, user_id: isize) -> Self {
+    pub fn new(chat_id: ChatIdEnum, user_id: u64) -> Self {
         Self {
             chat_id,
             user_id,
@@ -3474,7 +3474,7 @@ impl PromoteChatMemberParams {
         self.chat_id = chat_id;
     }
 
-    pub fn set_user_id(&mut self, user_id: isize) {
+    pub fn set_user_id(&mut self, user_id: u64) {
         self.user_id = user_id;
     }
 
@@ -3526,7 +3526,7 @@ impl PromoteChatMemberParams {
         self.chat_id.clone()
     }
 
-    pub fn user_id(&self) -> isize {
+    pub fn user_id(&self) -> u64 {
         self.user_id
     }
 
@@ -3576,7 +3576,7 @@ impl PromoteChatMemberParams {
 }
 
 impl SetChatAdministratorCustomTitleParams {
-    pub fn new(chat_id: ChatIdEnum, user_id: isize, custom_title: String) -> Self {
+    pub fn new(chat_id: ChatIdEnum, user_id: u64, custom_title: String) -> Self {
         Self {
             chat_id,
             user_id,
@@ -3588,7 +3588,7 @@ impl SetChatAdministratorCustomTitleParams {
         self.chat_id = chat_id;
     }
 
-    pub fn set_user_id(&mut self, user_id: isize) {
+    pub fn set_user_id(&mut self, user_id: u64) {
         self.user_id = user_id;
     }
 
@@ -3600,7 +3600,7 @@ impl SetChatAdministratorCustomTitleParams {
         self.chat_id.clone()
     }
 
-    pub fn user_id(&self) -> isize {
+    pub fn user_id(&self) -> u64 {
         self.user_id
     }
 
@@ -3661,11 +3661,11 @@ impl CreateChatInviteLinkParams {
         self.chat_id = chat_id;
     }
 
-    pub fn set_expire_date(&mut self, expire_date: Option<isize>) {
+    pub fn set_expire_date(&mut self, expire_date: Option<u64>) {
         self.expire_date = expire_date;
     }
 
-    pub fn set_member_limit(&mut self, member_limit: Option<isize>) {
+    pub fn set_member_limit(&mut self, member_limit: Option<u32>) {
         self.member_limit = member_limit;
     }
 
@@ -3673,11 +3673,11 @@ impl CreateChatInviteLinkParams {
         self.chat_id.clone()
     }
 
-    pub fn expire_date(&self) -> Option<isize> {
+    pub fn expire_date(&self) -> Option<u64> {
         self.expire_date
     }
 
-    pub fn member_limit(&self) -> Option<isize> {
+    pub fn member_limit(&self) -> Option<u32> {
         self.member_limit
     }
 }
@@ -3700,11 +3700,11 @@ impl EditChatInviteLinkParams {
         self.invite_link = invite_link;
     }
 
-    pub fn set_expire_date(&mut self, expire_date: Option<isize>) {
+    pub fn set_expire_date(&mut self, expire_date: Option<u64>) {
         self.expire_date = expire_date;
     }
 
-    pub fn set_member_limit(&mut self, member_limit: Option<isize>) {
+    pub fn set_member_limit(&mut self, member_limit: Option<u32>) {
         self.member_limit = member_limit;
     }
 
@@ -3716,11 +3716,11 @@ impl EditChatInviteLinkParams {
         self.invite_link.clone()
     }
 
-    pub fn expire_date(&self) -> Option<isize> {
+    pub fn expire_date(&self) -> Option<u64> {
         self.expire_date
     }
 
-    pub fn member_limit(&self) -> Option<isize> {
+    pub fn member_limit(&self) -> Option<u32> {
         self.member_limit
     }
 }
@@ -3834,7 +3834,7 @@ impl SetChatDescriptionParams {
 }
 
 impl PinChatMessageParams {
-    pub fn new(chat_id: ChatIdEnum, message_id: isize) -> Self {
+    pub fn new(chat_id: ChatIdEnum, message_id: i32) -> Self {
         Self {
             chat_id,
             message_id,
@@ -3846,7 +3846,7 @@ impl PinChatMessageParams {
         self.chat_id = chat_id;
     }
 
-    pub fn set_message_id(&mut self, message_id: isize) {
+    pub fn set_message_id(&mut self, message_id: i32) {
         self.message_id = message_id;
     }
 
@@ -3858,7 +3858,7 @@ impl PinChatMessageParams {
         self.chat_id.clone()
     }
 
-    pub fn message_id(&self) -> isize {
+    pub fn message_id(&self) -> i32 {
         self.message_id
     }
 
@@ -3879,7 +3879,7 @@ impl UnpinChatMessageParams {
         self.chat_id = chat_id;
     }
 
-    pub fn set_message_id(&mut self, message_id: Option<isize>) {
+    pub fn set_message_id(&mut self, message_id: Option<i32>) {
         self.message_id = message_id;
     }
 
@@ -3887,7 +3887,7 @@ impl UnpinChatMessageParams {
         self.chat_id.clone()
     }
 
-    pub fn message_id(&self) -> Option<isize> {
+    pub fn message_id(&self) -> Option<i32> {
         self.message_id
     }
 }
@@ -3963,7 +3963,7 @@ impl GetChatMembersCountParams {
 }
 
 impl GetChatMemberParams {
-    pub fn new(chat_id: ChatIdEnum, user_id: isize) -> Self {
+    pub fn new(chat_id: ChatIdEnum, user_id: u64) -> Self {
         Self { chat_id, user_id }
     }
 
@@ -3971,7 +3971,7 @@ impl GetChatMemberParams {
         self.chat_id = chat_id;
     }
 
-    pub fn set_user_id(&mut self, user_id: isize) {
+    pub fn set_user_id(&mut self, user_id: u64) {
         self.user_id = user_id;
     }
 
@@ -3979,7 +3979,7 @@ impl GetChatMemberParams {
         self.chat_id.clone()
     }
 
-    pub fn user_id(&self) -> isize {
+    pub fn user_id(&self) -> u64 {
         self.user_id
     }
 }
@@ -4111,7 +4111,7 @@ impl EditMessageTextParams {
         self.chat_id = chat_id;
     }
 
-    pub fn set_message_id(&mut self, message_id: Option<isize>) {
+    pub fn set_message_id(&mut self, message_id: Option<i32>) {
         self.message_id = message_id;
     }
 
@@ -4143,7 +4143,7 @@ impl EditMessageTextParams {
         self.chat_id.clone()
     }
 
-    pub fn message_id(&self) -> Option<isize> {
+    pub fn message_id(&self) -> Option<i32> {
         self.message_id
     }
 
@@ -4185,7 +4185,7 @@ impl EditMessageCaptionParams {
         self.chat_id = chat_id;
     }
 
-    pub fn set_message_id(&mut self, message_id: Option<isize>) {
+    pub fn set_message_id(&mut self, message_id: Option<i32>) {
         self.message_id = message_id;
     }
 
@@ -4213,7 +4213,7 @@ impl EditMessageCaptionParams {
         self.chat_id.clone()
     }
 
-    pub fn message_id(&self) -> Option<isize> {
+    pub fn message_id(&self) -> Option<i32> {
         self.message_id
     }
 
@@ -4257,7 +4257,7 @@ impl EditMessageMediaParams {
         self.chat_id = chat_id;
     }
 
-    pub fn set_message_id(&mut self, message_id: Option<isize>) {
+    pub fn set_message_id(&mut self, message_id: Option<i32>) {
         self.message_id = message_id;
     }
 
@@ -4277,7 +4277,7 @@ impl EditMessageMediaParams {
         self.chat_id.clone()
     }
 
-    pub fn message_id(&self) -> Option<isize> {
+    pub fn message_id(&self) -> Option<i32> {
         self.message_id
     }
 
@@ -4304,7 +4304,7 @@ impl EditMessageReplyMarkupParams {
         self.chat_id = chat_id;
     }
 
-    pub fn set_message_id(&mut self, message_id: Option<isize>) {
+    pub fn set_message_id(&mut self, message_id: Option<i32>) {
         self.message_id = message_id;
     }
 
@@ -4320,7 +4320,7 @@ impl EditMessageReplyMarkupParams {
         self.chat_id.clone()
     }
 
-    pub fn message_id(&self) -> Option<isize> {
+    pub fn message_id(&self) -> Option<i32> {
         self.message_id
     }
 
@@ -4334,7 +4334,7 @@ impl EditMessageReplyMarkupParams {
 }
 
 impl StopPollParams {
-    pub fn new(chat_id: ChatIdEnum, message_id: isize) -> Self {
+    pub fn new(chat_id: ChatIdEnum, message_id: i32) -> Self {
         Self {
             chat_id,
             message_id,
@@ -4346,7 +4346,7 @@ impl StopPollParams {
         self.chat_id = chat_id;
     }
 
-    pub fn set_message_id(&mut self, message_id: isize) {
+    pub fn set_message_id(&mut self, message_id: i32) {
         self.message_id = message_id;
     }
 
@@ -4358,7 +4358,7 @@ impl StopPollParams {
         self.chat_id.clone()
     }
 
-    pub fn message_id(&self) -> isize {
+    pub fn message_id(&self) -> i32 {
         self.message_id
     }
 
@@ -4368,7 +4368,7 @@ impl StopPollParams {
 }
 
 impl DeleteMessageParams {
-    pub fn new(chat_id: ChatIdEnum, message_id: isize) -> Self {
+    pub fn new(chat_id: ChatIdEnum, message_id: i32) -> Self {
         Self {
             chat_id,
             message_id,
@@ -4379,7 +4379,7 @@ impl DeleteMessageParams {
         self.chat_id = chat_id;
     }
 
-    pub fn set_message_id(&mut self, message_id: isize) {
+    pub fn set_message_id(&mut self, message_id: i32) {
         self.message_id = message_id;
     }
 
@@ -4387,7 +4387,7 @@ impl DeleteMessageParams {
         self.chat_id.clone()
     }
 
-    pub fn message_id(&self) -> isize {
+    pub fn message_id(&self) -> i32 {
         self.message_id
     }
 }
@@ -4416,7 +4416,7 @@ impl SendStickerParams {
         self.disable_notification = disable_notification;
     }
 
-    pub fn set_reply_to_message_id(&mut self, reply_to_message_id: Option<isize>) {
+    pub fn set_reply_to_message_id(&mut self, reply_to_message_id: Option<i32>) {
         self.reply_to_message_id = reply_to_message_id;
     }
 
@@ -4440,7 +4440,7 @@ impl SendStickerParams {
         self.disable_notification
     }
 
-    pub fn reply_to_message_id(&self) -> Option<isize> {
+    pub fn reply_to_message_id(&self) -> Option<i32> {
         self.reply_to_message_id
     }
 
@@ -4468,14 +4468,14 @@ impl GetStickerSetParams {
 }
 
 impl UploadStickerFileParams {
-    pub fn new(user_id: isize, png_sticker: InputFile) -> Self {
+    pub fn new(user_id: u64, png_sticker: InputFile) -> Self {
         Self {
             user_id,
             png_sticker,
         }
     }
 
-    pub fn set_user_id(&mut self, user_id: isize) {
+    pub fn set_user_id(&mut self, user_id: u64) {
         self.user_id = user_id;
     }
 
@@ -4483,7 +4483,7 @@ impl UploadStickerFileParams {
         self.png_sticker = png_sticker;
     }
 
-    pub fn user_id(&self) -> isize {
+    pub fn user_id(&self) -> u64 {
         self.user_id
     }
 
@@ -4493,7 +4493,7 @@ impl UploadStickerFileParams {
 }
 
 impl CreateNewStickerSetParams {
-    pub fn new(user_id: isize, name: String, title: String, emojis: String) -> Self {
+    pub fn new(user_id: u64, name: String, title: String, emojis: String) -> Self {
         Self {
             user_id,
             name,
@@ -4506,7 +4506,7 @@ impl CreateNewStickerSetParams {
         }
     }
 
-    pub fn set_user_id(&mut self, user_id: isize) {
+    pub fn set_user_id(&mut self, user_id: u64) {
         self.user_id = user_id;
     }
 
@@ -4538,7 +4538,7 @@ impl CreateNewStickerSetParams {
         self.mask_position = mask_position;
     }
 
-    pub fn user_id(&self) -> isize {
+    pub fn user_id(&self) -> u64 {
         self.user_id
     }
 
@@ -4572,7 +4572,7 @@ impl CreateNewStickerSetParams {
 }
 
 impl AddStickerToSetParams {
-    pub fn new(user_id: isize, name: String, emojis: String) -> Self {
+    pub fn new(user_id: u64, name: String, emojis: String) -> Self {
         Self {
             user_id,
             name,
@@ -4583,7 +4583,7 @@ impl AddStickerToSetParams {
         }
     }
 
-    pub fn set_user_id(&mut self, user_id: isize) {
+    pub fn set_user_id(&mut self, user_id: u64) {
         self.user_id = user_id;
     }
 
@@ -4607,7 +4607,7 @@ impl AddStickerToSetParams {
         self.mask_position = mask_position;
     }
 
-    pub fn user_id(&self) -> isize {
+    pub fn user_id(&self) -> u64 {
         self.user_id
     }
 
@@ -4669,7 +4669,7 @@ impl DeleteStickerFromSetParams {
 }
 
 impl SetStickerSetThumbParams {
-    pub fn new(name: String, user_id: isize) -> Self {
+    pub fn new(name: String, user_id: u64) -> Self {
         Self {
             name,
             user_id,
@@ -4681,7 +4681,7 @@ impl SetStickerSetThumbParams {
         self.name = name;
     }
 
-    pub fn set_user_id(&mut self, user_id: isize) {
+    pub fn set_user_id(&mut self, user_id: u64) {
         self.user_id = user_id;
     }
 
@@ -4693,7 +4693,7 @@ impl SetStickerSetThumbParams {
         self.name.clone()
     }
 
-    pub fn user_id(&self) -> isize {
+    pub fn user_id(&self) -> u64 {
         self.user_id
     }
 
@@ -4774,7 +4774,7 @@ impl AnswerInlineQueryParams {
 
 impl SendInvoiceParams {
     pub fn new(
-        chat_id: isize,
+        chat_id: i64,
         title: String,
         description: String,
         payload: String,
@@ -4812,7 +4812,7 @@ impl SendInvoiceParams {
         }
     }
 
-    pub fn set_chat_id(&mut self, chat_id: isize) {
+    pub fn set_chat_id(&mut self, chat_id: i64) {
         self.chat_id = chat_id;
     }
 
@@ -4860,15 +4860,15 @@ impl SendInvoiceParams {
         self.photo_url = photo_url;
     }
 
-    pub fn set_photo_size(&mut self, photo_size: Option<isize>) {
+    pub fn set_photo_size(&mut self, photo_size: Option<u32>) {
         self.photo_size = photo_size;
     }
 
-    pub fn set_photo_width(&mut self, photo_width: Option<isize>) {
+    pub fn set_photo_width(&mut self, photo_width: Option<u32>) {
         self.photo_width = photo_width;
     }
 
-    pub fn set_photo_height(&mut self, photo_height: Option<isize>) {
+    pub fn set_photo_height(&mut self, photo_height: Option<u32>) {
         self.photo_height = photo_height;
     }
 
@@ -4907,7 +4907,7 @@ impl SendInvoiceParams {
         self.disable_notification = disable_notification;
     }
 
-    pub fn set_reply_to_message_id(&mut self, reply_to_message_id: Option<isize>) {
+    pub fn set_reply_to_message_id(&mut self, reply_to_message_id: Option<i32>) {
         self.reply_to_message_id = reply_to_message_id;
     }
 
@@ -4919,7 +4919,7 @@ impl SendInvoiceParams {
         self.reply_markup = reply_markup;
     }
 
-    pub fn chat_id(&self) -> isize {
+    pub fn chat_id(&self) -> i64 {
         self.chat_id
     }
 
@@ -4967,15 +4967,15 @@ impl SendInvoiceParams {
         self.photo_url.clone()
     }
 
-    pub fn photo_size(&self) -> Option<isize> {
+    pub fn photo_size(&self) -> Option<u32> {
         self.photo_size
     }
 
-    pub fn photo_width(&self) -> Option<isize> {
+    pub fn photo_width(&self) -> Option<u32> {
         self.photo_width
     }
 
-    pub fn photo_height(&self) -> Option<isize> {
+    pub fn photo_height(&self) -> Option<u32> {
         self.photo_height
     }
 
@@ -5011,7 +5011,7 @@ impl SendInvoiceParams {
         self.disable_notification
     }
 
-    pub fn reply_to_message_id(&self) -> Option<isize> {
+    pub fn reply_to_message_id(&self) -> Option<i32> {
         self.reply_to_message_id
     }
 
@@ -5102,11 +5102,11 @@ impl AnswerPreCheckoutQueryParams {
 }
 
 impl SetPassportDataErrorsParams {
-    pub fn new(user_id: isize, errors: Vec<PassportElementError>) -> Self {
+    pub fn new(user_id: u64, errors: Vec<PassportElementError>) -> Self {
         Self { user_id, errors }
     }
 
-    pub fn set_user_id(&mut self, user_id: isize) {
+    pub fn set_user_id(&mut self, user_id: u64) {
         self.user_id = user_id;
     }
 
@@ -5114,7 +5114,7 @@ impl SetPassportDataErrorsParams {
         self.errors = errors;
     }
 
-    pub fn user_id(&self) -> isize {
+    pub fn user_id(&self) -> u64 {
         self.user_id
     }
 
@@ -5124,7 +5124,7 @@ impl SetPassportDataErrorsParams {
 }
 
 impl SendGameParams {
-    pub fn new(chat_id: isize, game_short_name: String) -> Self {
+    pub fn new(chat_id: i64, game_short_name: String) -> Self {
         Self {
             chat_id,
             game_short_name,
@@ -5135,7 +5135,7 @@ impl SendGameParams {
         }
     }
 
-    pub fn set_chat_id(&mut self, chat_id: isize) {
+    pub fn set_chat_id(&mut self, chat_id: i64) {
         self.chat_id = chat_id;
     }
 
@@ -5147,7 +5147,7 @@ impl SendGameParams {
         self.disable_notification = disable_notification;
     }
 
-    pub fn set_reply_to_message_id(&mut self, reply_to_message_id: Option<isize>) {
+    pub fn set_reply_to_message_id(&mut self, reply_to_message_id: Option<i32>) {
         self.reply_to_message_id = reply_to_message_id;
     }
 
@@ -5159,7 +5159,7 @@ impl SendGameParams {
         self.reply_markup = reply_markup;
     }
 
-    pub fn chat_id(&self) -> isize {
+    pub fn chat_id(&self) -> i64 {
         self.chat_id
     }
 
@@ -5171,7 +5171,7 @@ impl SendGameParams {
         self.disable_notification
     }
 
-    pub fn reply_to_message_id(&self) -> Option<isize> {
+    pub fn reply_to_message_id(&self) -> Option<i32> {
         self.reply_to_message_id
     }
 
@@ -5185,7 +5185,7 @@ impl SendGameParams {
 }
 
 impl SetGameScoreParams {
-    pub fn new(user_id: isize, score: isize) -> Self {
+    pub fn new(user_id: u64, score: isize) -> Self {
         Self {
             user_id,
             score,
@@ -5197,7 +5197,7 @@ impl SetGameScoreParams {
         }
     }
 
-    pub fn set_user_id(&mut self, user_id: isize) {
+    pub fn set_user_id(&mut self, user_id: u64) {
         self.user_id = user_id;
     }
 
@@ -5213,11 +5213,11 @@ impl SetGameScoreParams {
         self.disable_edit_message = disable_edit_message;
     }
 
-    pub fn set_chat_id(&mut self, chat_id: Option<isize>) {
+    pub fn set_chat_id(&mut self, chat_id: Option<i64>) {
         self.chat_id = chat_id;
     }
 
-    pub fn set_message_id(&mut self, message_id: Option<isize>) {
+    pub fn set_message_id(&mut self, message_id: Option<i32>) {
         self.message_id = message_id;
     }
 
@@ -5225,7 +5225,7 @@ impl SetGameScoreParams {
         self.inline_message_id = inline_message_id;
     }
 
-    pub fn user_id(&self) -> isize {
+    pub fn user_id(&self) -> u64 {
         self.user_id
     }
 
@@ -5241,11 +5241,11 @@ impl SetGameScoreParams {
         self.disable_edit_message
     }
 
-    pub fn chat_id(&self) -> Option<isize> {
+    pub fn chat_id(&self) -> Option<i64> {
         self.chat_id
     }
 
-    pub fn message_id(&self) -> Option<isize> {
+    pub fn message_id(&self) -> Option<i32> {
         self.message_id
     }
 
@@ -5255,7 +5255,7 @@ impl SetGameScoreParams {
 }
 
 impl GetGameHighScoresParams {
-    pub fn new(user_id: isize) -> Self {
+    pub fn new(user_id: u64) -> Self {
         Self {
             user_id,
             chat_id: None,
@@ -5264,15 +5264,15 @@ impl GetGameHighScoresParams {
         }
     }
 
-    pub fn set_user_id(&mut self, user_id: isize) {
+    pub fn set_user_id(&mut self, user_id: u64) {
         self.user_id = user_id;
     }
 
-    pub fn set_chat_id(&mut self, chat_id: Option<isize>) {
+    pub fn set_chat_id(&mut self, chat_id: Option<i64>) {
         self.chat_id = chat_id;
     }
 
-    pub fn set_message_id(&mut self, message_id: Option<isize>) {
+    pub fn set_message_id(&mut self, message_id: Option<i32>) {
         self.message_id = message_id;
     }
 
@@ -5280,15 +5280,15 @@ impl GetGameHighScoresParams {
         self.inline_message_id = inline_message_id;
     }
 
-    pub fn user_id(&self) -> isize {
+    pub fn user_id(&self) -> u64 {
         self.user_id
     }
 
-    pub fn chat_id(&self) -> Option<isize> {
+    pub fn chat_id(&self) -> Option<i64> {
         self.chat_id
     }
 
-    pub fn message_id(&self) -> Option<isize> {
+    pub fn message_id(&self) -> Option<i32> {
         self.message_id
     }
 
@@ -5389,15 +5389,15 @@ impl InputMediaVideo {
         self.caption_entities = caption_entities;
     }
 
-    pub fn set_width(&mut self, width: Option<isize>) {
+    pub fn set_width(&mut self, width: Option<u32>) {
         self.width = width;
     }
 
-    pub fn set_height(&mut self, height: Option<isize>) {
+    pub fn set_height(&mut self, height: Option<u32>) {
         self.height = height;
     }
 
-    pub fn set_duration(&mut self, duration: Option<isize>) {
+    pub fn set_duration(&mut self, duration: Option<u32>) {
         self.duration = duration;
     }
 
@@ -5429,15 +5429,15 @@ impl InputMediaVideo {
         self.caption_entities.clone()
     }
 
-    pub fn width(&self) -> Option<isize> {
+    pub fn width(&self) -> Option<u32> {
         self.width
     }
 
-    pub fn height(&self) -> Option<isize> {
+    pub fn height(&self) -> Option<u32> {
         self.height
     }
 
-    pub fn duration(&self) -> Option<isize> {
+    pub fn duration(&self) -> Option<u32> {
         self.duration
     }
 
@@ -5485,15 +5485,15 @@ impl InputMediaAnimation {
         self.caption_entities = caption_entities;
     }
 
-    pub fn set_width(&mut self, width: Option<isize>) {
+    pub fn set_width(&mut self, width: Option<u32>) {
         self.width = width;
     }
 
-    pub fn set_height(&mut self, height: Option<isize>) {
+    pub fn set_height(&mut self, height: Option<u32>) {
         self.height = height;
     }
 
-    pub fn set_duration(&mut self, duration: Option<isize>) {
+    pub fn set_duration(&mut self, duration: Option<u32>) {
         self.duration = duration;
     }
 
@@ -5521,15 +5521,15 @@ impl InputMediaAnimation {
         self.caption_entities.clone()
     }
 
-    pub fn width(&self) -> Option<isize> {
+    pub fn width(&self) -> Option<u32> {
         self.width
     }
 
-    pub fn height(&self) -> Option<isize> {
+    pub fn height(&self) -> Option<u32> {
         self.height
     }
 
-    pub fn duration(&self) -> Option<isize> {
+    pub fn duration(&self) -> Option<u32> {
         self.duration
     }
 }
@@ -5573,7 +5573,7 @@ impl InputMediaAudio {
         self.caption_entities = caption_entities;
     }
 
-    pub fn set_duration(&mut self, duration: Option<isize>) {
+    pub fn set_duration(&mut self, duration: Option<u32>) {
         self.duration = duration;
     }
 
@@ -5609,7 +5609,7 @@ impl InputMediaAudio {
         self.caption_entities.clone()
     }
 
-    pub fn duration(&self) -> Option<isize> {
+    pub fn duration(&self) -> Option<u32> {
         self.duration
     }
 

--- a/src/objects.rs
+++ b/src/objects.rs
@@ -21,7 +21,7 @@ pub struct VoiceChatStarted {}
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct VoiceChatScheduled {
-    pub start_date: isize,
+    pub start_date: u64,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -36,7 +36,7 @@ pub enum FileEnum {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct Update {
-    pub update_id: isize,
+    pub update_id: u32,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub message: Option<Message>,
@@ -90,7 +90,7 @@ pub struct WebhookInfo {
     pub ip_address: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub last_error_date: Option<isize>,
+    pub last_error_date: Option<u64>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub last_error_message: Option<String>,
@@ -104,7 +104,7 @@ pub struct WebhookInfo {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct User {
-    pub id: isize,
+    pub id: u64,
 
     pub is_bot: bool,
 
@@ -131,7 +131,7 @@ pub struct User {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct Chat {
-    pub id: isize,
+    pub id: i64,
 
     #[serde(rename = "type")]
     pub type_field: String,
@@ -179,7 +179,7 @@ pub struct Chat {
     pub can_set_sticker_set: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub linked_chat_id: Option<isize>,
+    pub linked_chat_id: Option<i64>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub location: Option<ChatLocation>,
@@ -187,7 +187,7 @@ pub struct Chat {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct Message {
-    pub message_id: isize,
+    pub message_id: i32,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub from: Option<User>,
@@ -195,7 +195,7 @@ pub struct Message {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub sender_chat: Option<Chat>,
 
-    pub date: isize,
+    pub date: u64,
 
     pub chat: Chat,
 
@@ -206,7 +206,7 @@ pub struct Message {
     pub forward_from_chat: Option<Chat>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub forward_from_message_id: Option<isize>,
+    pub forward_from_message_id: Option<i32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub forward_signature: Option<String>,
@@ -215,7 +215,7 @@ pub struct Message {
     pub forward_sender_name: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub forward_date: Option<isize>,
+    pub forward_date: Option<u64>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub reply_to_message: Option<Box<Message>>,
@@ -224,7 +224,7 @@ pub struct Message {
     pub via_bot: Option<User>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub edit_date: Option<isize>,
+    pub edit_date: Option<u64>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub media_group_id: Option<String>,
@@ -314,10 +314,10 @@ pub struct Message {
     pub message_auto_delete_timer_changed: Option<MessageAutoDeleteTimerChanged>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub migrate_to_chat_id: Option<isize>,
+    pub migrate_to_chat_id: Option<i64>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub migrate_from_chat_id: Option<isize>,
+    pub migrate_from_chat_id: Option<i64>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub pinned_message: Option<Box<Message>>,
@@ -355,7 +355,7 @@ pub struct Message {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct MessageId {
-    pub message_id: isize,
+    pub message_id: i32,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -383,12 +383,12 @@ pub struct PhotoSize {
 
     pub file_unique_id: String,
 
-    pub width: isize,
+    pub width: u32,
 
-    pub height: isize,
+    pub height: u32,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub file_size: Option<isize>,
+    pub file_size: Option<u32>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -397,11 +397,11 @@ pub struct Animation {
 
     pub file_unique_id: String,
 
-    pub width: isize,
+    pub width: u32,
 
-    pub height: isize,
+    pub height: u32,
 
-    pub duration: isize,
+    pub duration: u32,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub thumb: Option<PhotoSize>,
@@ -413,7 +413,7 @@ pub struct Animation {
     pub mime_type: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub file_size: Option<isize>,
+    pub file_size: Option<u32>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -422,7 +422,7 @@ pub struct Audio {
 
     pub file_unique_id: String,
 
-    pub duration: isize,
+    pub duration: u32,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub performer: Option<String>,
@@ -437,7 +437,7 @@ pub struct Audio {
     pub mime_type: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub file_size: Option<isize>,
+    pub file_size: Option<u32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub thumb: Option<PhotoSize>,
@@ -459,7 +459,7 @@ pub struct Document {
     pub mime_type: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub file_size: Option<isize>,
+    pub file_size: Option<u32>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -468,11 +468,11 @@ pub struct Video {
 
     pub file_unique_id: String,
 
-    pub width: isize,
+    pub width: u32,
 
-    pub height: isize,
+    pub height: u32,
 
-    pub duration: isize,
+    pub duration: u32,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub thumb: Option<PhotoSize>,
@@ -484,7 +484,7 @@ pub struct Video {
     pub mime_type: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub file_size: Option<isize>,
+    pub file_size: Option<u32>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -495,13 +495,13 @@ pub struct VideoNote {
 
     pub length: isize,
 
-    pub duration: isize,
+    pub duration: u32,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub thumb: Option<PhotoSize>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub file_size: Option<isize>,
+    pub file_size: Option<u32>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -510,13 +510,13 @@ pub struct Voice {
 
     pub file_unique_id: String,
 
-    pub duration: isize,
+    pub duration: u32,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub mime_type: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub file_size: Option<isize>,
+    pub file_size: Option<u32>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -529,7 +529,7 @@ pub struct Contact {
     pub last_name: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub user_id: Option<isize>,
+    pub user_id: Option<u64>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub vcard: Option<String>,
@@ -589,7 +589,7 @@ pub struct Poll {
     pub open_period: Option<isize>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub close_date: Option<isize>,
+    pub close_date: Option<u64>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -648,7 +648,7 @@ pub struct MessageAutoDeleteTimerChanged {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct VoiceChatEnded {
-    pub duration: isize,
+    pub duration: u32,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -671,7 +671,7 @@ pub struct File {
     pub file_unique_id: String,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub file_size: Option<isize>,
+    pub file_size: Option<u32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub file_path: Option<String>,
@@ -816,10 +816,10 @@ pub struct ChatInviteLink {
     pub is_revoked: bool,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub expire_date: Option<isize>,
+    pub expire_date: Option<u64>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub member_limit: Option<isize>,
+    pub member_limit: Option<u32>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -886,7 +886,7 @@ pub struct ChatMember {
     pub can_add_web_page_previews: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub until_date: Option<isize>,
+    pub until_date: Option<u64>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -895,7 +895,7 @@ pub struct ChatMemberUpdated {
 
     pub from: User,
 
-    pub date: isize,
+    pub date: u64,
 
     pub old_chat_member: ChatMember,
 
@@ -949,7 +949,7 @@ pub struct BotCommand {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct ResponseParameters {
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub migrate_to_chat_id: Option<isize>,
+    pub migrate_to_chat_id: Option<i64>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub retry_after: Option<isize>,
@@ -961,9 +961,9 @@ pub struct Sticker {
 
     pub file_unique_id: String,
 
-    pub width: isize,
+    pub width: u32,
 
-    pub height: isize,
+    pub height: u32,
 
     pub is_animated: bool,
 
@@ -980,7 +980,7 @@ pub struct Sticker {
     pub mask_position: Option<MaskPosition>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub file_size: Option<isize>,
+    pub file_size: Option<u32>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -1054,10 +1054,10 @@ pub struct InlineQueryResultArticle {
     pub thumb_url: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub thumb_width: Option<isize>,
+    pub thumb_width: Option<u32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub thumb_height: Option<isize>,
+    pub thumb_height: Option<u32>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -1072,10 +1072,10 @@ pub struct InlineQueryResultPhoto {
     pub thumb_url: String,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub photo_width: Option<isize>,
+    pub photo_width: Option<u32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub photo_height: Option<isize>,
+    pub photo_height: Option<u32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub title: Option<String>,
@@ -1109,13 +1109,13 @@ pub struct InlineQueryResultGif {
     pub gif_url: String,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub gif_width: Option<isize>,
+    pub gif_width: Option<u32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub gif_height: Option<isize>,
+    pub gif_height: Option<u32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub gif_duration: Option<isize>,
+    pub gif_duration: Option<u32>,
 
     pub thumb_url: String,
 
@@ -1151,13 +1151,13 @@ pub struct InlineQueryResultMpeg4Gif {
     pub mpeg4_url: String,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub mpeg4_width: Option<isize>,
+    pub mpeg4_width: Option<u32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub mpeg4_height: Option<isize>,
+    pub mpeg4_height: Option<u32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub mpeg4_duration: Option<isize>,
+    pub mpeg4_duration: Option<u32>,
 
     pub thumb_url: String,
 
@@ -1208,13 +1208,13 @@ pub struct InlineQueryResultVideo {
     pub caption_entities: Option<Vec<MessageEntity>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub video_width: Option<isize>,
+    pub video_width: Option<u32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub video_height: Option<isize>,
+    pub video_height: Option<u32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub video_duration: Option<isize>,
+    pub video_duration: Option<u32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
@@ -1250,7 +1250,7 @@ pub struct InlineQueryResultAudio {
     pub performer: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub audio_duration: Option<isize>,
+    pub audio_duration: Option<u32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub reply_markup: Option<InlineKeyboardMarkup>,
@@ -1280,7 +1280,7 @@ pub struct InlineQueryResultVoice {
     pub caption_entities: Option<Vec<MessageEntity>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub voice_duration: Option<isize>,
+    pub voice_duration: Option<u32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub reply_markup: Option<InlineKeyboardMarkup>,
@@ -1324,10 +1324,10 @@ pub struct InlineQueryResultDocument {
     pub thumb_url: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub thumb_width: Option<isize>,
+    pub thumb_width: Option<u32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub thumb_height: Option<isize>,
+    pub thumb_height: Option<u32>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -1365,10 +1365,10 @@ pub struct InlineQueryResultLocation {
     pub thumb_url: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub thumb_width: Option<isize>,
+    pub thumb_width: Option<u32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub thumb_height: Option<isize>,
+    pub thumb_height: Option<u32>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -1408,10 +1408,10 @@ pub struct InlineQueryResultVenue {
     pub thumb_url: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub thumb_width: Option<isize>,
+    pub thumb_width: Option<u32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub thumb_height: Option<isize>,
+    pub thumb_height: Option<u32>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -1441,10 +1441,10 @@ pub struct InlineQueryResultContact {
     pub thumb_url: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub thumb_width: Option<isize>,
+    pub thumb_width: Option<u32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub thumb_height: Option<isize>,
+    pub thumb_height: Option<u32>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -1735,13 +1735,13 @@ pub struct InputInvoiceMessageContent {
     pub photo_url: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub photo_size: Option<isize>,
+    pub photo_size: Option<u32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub photo_width: Option<isize>,
+    pub photo_width: Option<u32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub photo_height: Option<isize>,
+    pub photo_height: Option<u32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub need_name: Option<bool>,
@@ -1937,9 +1937,9 @@ pub struct PassportFile {
 
     pub file_unique_id: String,
 
-    pub file_size: isize,
+    pub file_size: u32,
 
-    pub file_date: isize,
+    pub file_date: u64,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -2112,7 +2112,7 @@ pub struct GameHighScore {
 }
 
 impl Update {
-    pub fn new(update_id: isize) -> Self {
+    pub fn new(update_id: u32) -> Self {
         Self {
             update_id,
             message: None,
@@ -2131,7 +2131,7 @@ impl Update {
         }
     }
 
-    pub fn set_update_id(&mut self, update_id: isize) {
+    pub fn set_update_id(&mut self, update_id: u32) {
         self.update_id = update_id;
     }
 
@@ -2187,7 +2187,7 @@ impl Update {
         self.chat_member = chat_member;
     }
 
-    pub fn update_id(&self) -> isize {
+    pub fn update_id(&self) -> u32 {
         self.update_id
     }
 
@@ -2274,7 +2274,7 @@ impl WebhookInfo {
         self.ip_address = ip_address;
     }
 
-    pub fn set_last_error_date(&mut self, last_error_date: Option<isize>) {
+    pub fn set_last_error_date(&mut self, last_error_date: Option<u64>) {
         self.last_error_date = last_error_date;
     }
 
@@ -2306,7 +2306,7 @@ impl WebhookInfo {
         self.ip_address.clone()
     }
 
-    pub fn last_error_date(&self) -> Option<isize> {
+    pub fn last_error_date(&self) -> Option<u64> {
         self.last_error_date
     }
 
@@ -2324,7 +2324,7 @@ impl WebhookInfo {
 }
 
 impl User {
-    pub fn new(id: isize, is_bot: bool, first_name: String) -> Self {
+    pub fn new(id: u64, is_bot: bool, first_name: String) -> Self {
         Self {
             id,
             is_bot,
@@ -2338,7 +2338,7 @@ impl User {
         }
     }
 
-    pub fn set_id(&mut self, id: isize) {
+    pub fn set_id(&mut self, id: u64) {
         self.id = id;
     }
 
@@ -2374,7 +2374,7 @@ impl User {
         self.supports_inline_queries = supports_inline_queries;
     }
 
-    pub fn id(&self) -> isize {
+    pub fn id(&self) -> u64 {
         self.id
     }
 
@@ -2412,7 +2412,7 @@ impl User {
 }
 
 impl Chat {
-    pub fn new(id: isize, type_field: String) -> Self {
+    pub fn new(id: i64, type_field: String) -> Self {
         Self {
             id,
             type_field,
@@ -2435,7 +2435,7 @@ impl Chat {
         }
     }
 
-    pub fn set_id(&mut self, id: isize) {
+    pub fn set_id(&mut self, id: i64) {
         self.id = id;
     }
 
@@ -2499,7 +2499,7 @@ impl Chat {
         self.can_set_sticker_set = can_set_sticker_set;
     }
 
-    pub fn set_linked_chat_id(&mut self, linked_chat_id: Option<isize>) {
+    pub fn set_linked_chat_id(&mut self, linked_chat_id: Option<i64>) {
         self.linked_chat_id = linked_chat_id;
     }
 
@@ -2507,7 +2507,7 @@ impl Chat {
         self.location = location;
     }
 
-    pub fn id(&self) -> isize {
+    pub fn id(&self) -> i64 {
         self.id
     }
 
@@ -2571,7 +2571,7 @@ impl Chat {
         self.can_set_sticker_set
     }
 
-    pub fn linked_chat_id(&self) -> Option<isize> {
+    pub fn linked_chat_id(&self) -> Option<i64> {
         self.linked_chat_id
     }
 
@@ -2581,7 +2581,7 @@ impl Chat {
 }
 
 impl Message {
-    pub fn new(message_id: isize, date: isize, chat: Chat) -> Self {
+    pub fn new(message_id: i32, date: u64, chat: Chat) -> Self {
         Self {
             message_id,
             date,
@@ -2642,11 +2642,11 @@ impl Message {
         }
     }
 
-    pub fn set_message_id(&mut self, message_id: isize) {
+    pub fn set_message_id(&mut self, message_id: i32) {
         self.message_id = message_id;
     }
 
-    pub fn set_date(&mut self, date: isize) {
+    pub fn set_date(&mut self, date: u64) {
         self.date = date;
     }
 
@@ -2670,7 +2670,7 @@ impl Message {
         self.forward_from_chat = forward_from_chat;
     }
 
-    pub fn set_forward_from_message_id(&mut self, forward_from_message_id: Option<isize>) {
+    pub fn set_forward_from_message_id(&mut self, forward_from_message_id: Option<i32>) {
         self.forward_from_message_id = forward_from_message_id;
     }
 
@@ -2682,7 +2682,7 @@ impl Message {
         self.forward_sender_name = forward_sender_name;
     }
 
-    pub fn set_forward_date(&mut self, forward_date: Option<isize>) {
+    pub fn set_forward_date(&mut self, forward_date: Option<u64>) {
         self.forward_date = forward_date;
     }
 
@@ -2694,7 +2694,7 @@ impl Message {
         self.via_bot = via_bot;
     }
 
-    pub fn set_edit_date(&mut self, edit_date: Option<isize>) {
+    pub fn set_edit_date(&mut self, edit_date: Option<u64>) {
         self.edit_date = edit_date;
     }
 
@@ -2817,11 +2817,11 @@ impl Message {
         self.message_auto_delete_timer_changed = message_auto_delete_timer_changed;
     }
 
-    pub fn set_migrate_to_chat_id(&mut self, migrate_to_chat_id: Option<isize>) {
+    pub fn set_migrate_to_chat_id(&mut self, migrate_to_chat_id: Option<i64>) {
         self.migrate_to_chat_id = migrate_to_chat_id;
     }
 
-    pub fn set_migrate_from_chat_id(&mut self, migrate_from_chat_id: Option<isize>) {
+    pub fn set_migrate_from_chat_id(&mut self, migrate_from_chat_id: Option<i64>) {
         self.migrate_from_chat_id = migrate_from_chat_id;
     }
 
@@ -2879,11 +2879,11 @@ impl Message {
         self.voice_chat_scheduled.clone()
     }
 
-    pub fn message_id(&self) -> isize {
+    pub fn message_id(&self) -> i32 {
         self.message_id
     }
 
-    pub fn date(&self) -> isize {
+    pub fn date(&self) -> u64 {
         self.date
     }
 
@@ -2907,7 +2907,7 @@ impl Message {
         self.forward_from_chat.clone()
     }
 
-    pub fn forward_from_message_id(&self) -> Option<isize> {
+    pub fn forward_from_message_id(&self) -> Option<i32> {
         self.forward_from_message_id
     }
 
@@ -2919,7 +2919,7 @@ impl Message {
         self.forward_sender_name.clone()
     }
 
-    pub fn forward_date(&self) -> Option<isize> {
+    pub fn forward_date(&self) -> Option<u64> {
         self.forward_date
     }
 
@@ -2931,7 +2931,7 @@ impl Message {
         self.via_bot.clone()
     }
 
-    pub fn edit_date(&self) -> Option<isize> {
+    pub fn edit_date(&self) -> Option<u64> {
         self.edit_date
     }
 
@@ -3051,11 +3051,11 @@ impl Message {
         self.message_auto_delete_timer_changed.clone()
     }
 
-    pub fn migrate_to_chat_id(&self) -> Option<isize> {
+    pub fn migrate_to_chat_id(&self) -> Option<i64> {
         self.migrate_to_chat_id
     }
 
-    pub fn migrate_from_chat_id(&self) -> Option<isize> {
+    pub fn migrate_from_chat_id(&self) -> Option<i64> {
         self.migrate_from_chat_id
     }
 
@@ -3101,15 +3101,15 @@ impl Message {
 }
 
 impl MessageId {
-    pub fn new(message_id: isize) -> Self {
+    pub fn new(message_id: i32) -> Self {
         Self { message_id }
     }
 
-    pub fn set_message_id(&mut self, message_id: isize) {
+    pub fn set_message_id(&mut self, message_id: i32) {
         self.message_id = message_id;
     }
 
-    pub fn message_id(&self) -> isize {
+    pub fn message_id(&self) -> i32 {
         self.message_id
     }
 }
@@ -3176,7 +3176,7 @@ impl MessageEntity {
 }
 
 impl PhotoSize {
-    pub fn new(file_id: String, file_unique_id: String, width: isize, height: isize) -> Self {
+    pub fn new(file_id: String, file_unique_id: String, width: u32, height: u32) -> Self {
         Self {
             file_id,
             file_unique_id,
@@ -3194,15 +3194,15 @@ impl PhotoSize {
         self.file_unique_id = file_unique_id;
     }
 
-    pub fn set_width(&mut self, width: isize) {
+    pub fn set_width(&mut self, width: u32) {
         self.width = width;
     }
 
-    pub fn set_height(&mut self, height: isize) {
+    pub fn set_height(&mut self, height: u32) {
         self.height = height;
     }
 
-    pub fn set_file_size(&mut self, file_size: Option<isize>) {
+    pub fn set_file_size(&mut self, file_size: Option<u32>) {
         self.file_size = file_size;
     }
 
@@ -3214,15 +3214,15 @@ impl PhotoSize {
         self.file_unique_id.clone()
     }
 
-    pub fn width(&self) -> isize {
+    pub fn width(&self) -> u32 {
         self.width
     }
 
-    pub fn height(&self) -> isize {
+    pub fn height(&self) -> u32 {
         self.height
     }
 
-    pub fn file_size(&self) -> Option<isize> {
+    pub fn file_size(&self) -> Option<u32> {
         self.file_size
     }
 }
@@ -3231,9 +3231,9 @@ impl Animation {
     pub fn new(
         file_id: String,
         file_unique_id: String,
-        width: isize,
-        height: isize,
-        duration: isize,
+        width: u32,
+        height: u32,
+        duration: u32,
     ) -> Self {
         Self {
             file_id,
@@ -3256,15 +3256,15 @@ impl Animation {
         self.file_unique_id = file_unique_id;
     }
 
-    pub fn set_width(&mut self, width: isize) {
+    pub fn set_width(&mut self, width: u32) {
         self.width = width;
     }
 
-    pub fn set_height(&mut self, height: isize) {
+    pub fn set_height(&mut self, height: u32) {
         self.height = height;
     }
 
-    pub fn set_duration(&mut self, duration: isize) {
+    pub fn set_duration(&mut self, duration: u32) {
         self.duration = duration;
     }
 
@@ -3280,7 +3280,7 @@ impl Animation {
         self.mime_type = mime_type;
     }
 
-    pub fn set_file_size(&mut self, file_size: Option<isize>) {
+    pub fn set_file_size(&mut self, file_size: Option<u32>) {
         self.file_size = file_size;
     }
 
@@ -3292,15 +3292,15 @@ impl Animation {
         self.file_unique_id.clone()
     }
 
-    pub fn width(&self) -> isize {
+    pub fn width(&self) -> u32 {
         self.width
     }
 
-    pub fn height(&self) -> isize {
+    pub fn height(&self) -> u32 {
         self.height
     }
 
-    pub fn duration(&self) -> isize {
+    pub fn duration(&self) -> u32 {
         self.duration
     }
 
@@ -3316,13 +3316,13 @@ impl Animation {
         self.mime_type.clone()
     }
 
-    pub fn file_size(&self) -> Option<isize> {
+    pub fn file_size(&self) -> Option<u32> {
         self.file_size
     }
 }
 
 impl Audio {
-    pub fn new(file_id: String, file_unique_id: String, duration: isize) -> Self {
+    pub fn new(file_id: String, file_unique_id: String, duration: u32) -> Self {
         Self {
             file_id,
             file_unique_id,
@@ -3344,7 +3344,7 @@ impl Audio {
         self.file_unique_id = file_unique_id;
     }
 
-    pub fn set_duration(&mut self, duration: isize) {
+    pub fn set_duration(&mut self, duration: u32) {
         self.duration = duration;
     }
 
@@ -3364,7 +3364,7 @@ impl Audio {
         self.mime_type = mime_type;
     }
 
-    pub fn set_file_size(&mut self, file_size: Option<isize>) {
+    pub fn set_file_size(&mut self, file_size: Option<u32>) {
         self.file_size = file_size;
     }
 
@@ -3380,7 +3380,7 @@ impl Audio {
         self.file_unique_id.clone()
     }
 
-    pub fn duration(&self) -> isize {
+    pub fn duration(&self) -> u32 {
         self.duration
     }
 
@@ -3400,7 +3400,7 @@ impl Audio {
         self.mime_type.clone()
     }
 
-    pub fn file_size(&self) -> Option<isize> {
+    pub fn file_size(&self) -> Option<u32> {
         self.file_size
     }
 
@@ -3441,7 +3441,7 @@ impl Document {
         self.mime_type = mime_type;
     }
 
-    pub fn set_file_size(&mut self, file_size: Option<isize>) {
+    pub fn set_file_size(&mut self, file_size: Option<u32>) {
         self.file_size = file_size;
     }
 
@@ -3465,7 +3465,7 @@ impl Document {
         self.mime_type.clone()
     }
 
-    pub fn file_size(&self) -> Option<isize> {
+    pub fn file_size(&self) -> Option<u32> {
         self.file_size
     }
 }
@@ -3474,9 +3474,9 @@ impl Video {
     pub fn new(
         file_id: String,
         file_unique_id: String,
-        width: isize,
-        height: isize,
-        duration: isize,
+        width: u32,
+        height: u32,
+        duration: u32,
     ) -> Self {
         Self {
             file_id,
@@ -3499,15 +3499,15 @@ impl Video {
         self.file_unique_id = file_unique_id;
     }
 
-    pub fn set_width(&mut self, width: isize) {
+    pub fn set_width(&mut self, width: u32) {
         self.width = width;
     }
 
-    pub fn set_height(&mut self, height: isize) {
+    pub fn set_height(&mut self, height: u32) {
         self.height = height;
     }
 
-    pub fn set_duration(&mut self, duration: isize) {
+    pub fn set_duration(&mut self, duration: u32) {
         self.duration = duration;
     }
 
@@ -3523,7 +3523,7 @@ impl Video {
         self.mime_type = mime_type;
     }
 
-    pub fn set_file_size(&mut self, file_size: Option<isize>) {
+    pub fn set_file_size(&mut self, file_size: Option<u32>) {
         self.file_size = file_size;
     }
 
@@ -3535,15 +3535,15 @@ impl Video {
         self.file_unique_id.clone()
     }
 
-    pub fn width(&self) -> isize {
+    pub fn width(&self) -> u32 {
         self.width
     }
 
-    pub fn height(&self) -> isize {
+    pub fn height(&self) -> u32 {
         self.height
     }
 
-    pub fn duration(&self) -> isize {
+    pub fn duration(&self) -> u32 {
         self.duration
     }
 
@@ -3559,13 +3559,13 @@ impl Video {
         self.mime_type.clone()
     }
 
-    pub fn file_size(&self) -> Option<isize> {
+    pub fn file_size(&self) -> Option<u32> {
         self.file_size
     }
 }
 
 impl VideoNote {
-    pub fn new(file_id: String, file_unique_id: String, length: isize, duration: isize) -> Self {
+    pub fn new(file_id: String, file_unique_id: String, length: isize, duration: u32) -> Self {
         Self {
             file_id,
             file_unique_id,
@@ -3588,7 +3588,7 @@ impl VideoNote {
         self.length = length;
     }
 
-    pub fn set_duration(&mut self, duration: isize) {
+    pub fn set_duration(&mut self, duration: u32) {
         self.duration = duration;
     }
 
@@ -3596,7 +3596,7 @@ impl VideoNote {
         self.thumb = thumb;
     }
 
-    pub fn set_file_size(&mut self, file_size: Option<isize>) {
+    pub fn set_file_size(&mut self, file_size: Option<u32>) {
         self.file_size = file_size;
     }
 
@@ -3612,7 +3612,7 @@ impl VideoNote {
         self.length
     }
 
-    pub fn duration(&self) -> isize {
+    pub fn duration(&self) -> u32 {
         self.duration
     }
 
@@ -3620,13 +3620,13 @@ impl VideoNote {
         self.thumb.clone()
     }
 
-    pub fn file_size(&self) -> Option<isize> {
+    pub fn file_size(&self) -> Option<u32> {
         self.file_size
     }
 }
 
 impl Voice {
-    pub fn new(file_id: String, file_unique_id: String, duration: isize) -> Self {
+    pub fn new(file_id: String, file_unique_id: String, duration: u32) -> Self {
         Self {
             file_id,
             file_unique_id,
@@ -3644,7 +3644,7 @@ impl Voice {
         self.file_unique_id = file_unique_id;
     }
 
-    pub fn set_duration(&mut self, duration: isize) {
+    pub fn set_duration(&mut self, duration: u32) {
         self.duration = duration;
     }
 
@@ -3652,7 +3652,7 @@ impl Voice {
         self.mime_type = mime_type;
     }
 
-    pub fn set_file_size(&mut self, file_size: Option<isize>) {
+    pub fn set_file_size(&mut self, file_size: Option<u32>) {
         self.file_size = file_size;
     }
 
@@ -3664,7 +3664,7 @@ impl Voice {
         self.file_unique_id.clone()
     }
 
-    pub fn duration(&self) -> isize {
+    pub fn duration(&self) -> u32 {
         self.duration
     }
 
@@ -3672,7 +3672,7 @@ impl Voice {
         self.mime_type.clone()
     }
 
-    pub fn file_size(&self) -> Option<isize> {
+    pub fn file_size(&self) -> Option<u32> {
         self.file_size
     }
 }
@@ -3700,7 +3700,7 @@ impl Contact {
         self.last_name = last_name;
     }
 
-    pub fn set_user_id(&mut self, user_id: Option<isize>) {
+    pub fn set_user_id(&mut self, user_id: Option<u64>) {
         self.user_id = user_id;
     }
 
@@ -3720,7 +3720,7 @@ impl Contact {
         self.last_name.clone()
     }
 
-    pub fn user_id(&self) -> Option<isize> {
+    pub fn user_id(&self) -> Option<u64> {
         self.user_id
     }
 
@@ -3883,7 +3883,7 @@ impl Poll {
         self.open_period = open_period;
     }
 
-    pub fn set_close_date(&mut self, close_date: Option<isize>) {
+    pub fn set_close_date(&mut self, close_date: Option<u64>) {
         self.close_date = close_date;
     }
 
@@ -3935,7 +3935,7 @@ impl Poll {
         self.open_period
     }
 
-    pub fn close_date(&self) -> Option<isize> {
+    pub fn close_date(&self) -> Option<u64> {
         self.close_date
     }
 }
@@ -4122,29 +4122,29 @@ impl MessageAutoDeleteTimerChanged {
 }
 
 impl VoiceChatEnded {
-    pub fn new(duration: isize) -> Self {
+    pub fn new(duration: u32) -> Self {
         Self { duration }
     }
 
-    pub fn set_duration(&mut self, duration: isize) {
+    pub fn set_duration(&mut self, duration: u32) {
         self.duration = duration;
     }
 
-    pub fn duration(&self) -> isize {
+    pub fn duration(&self) -> u32 {
         self.duration
     }
 }
 
 impl VoiceChatScheduled {
-    pub fn new(start_date: isize) -> Self {
+    pub fn new(start_date: u64) -> Self {
         Self { start_date }
     }
 
-    pub fn set_start_date(&mut self, start_date: isize) {
+    pub fn set_start_date(&mut self, start_date: u64) {
         self.start_date = start_date;
     }
 
-    pub fn start_date(&self) -> isize {
+    pub fn start_date(&self) -> u64 {
         self.start_date
     }
 }
@@ -4206,7 +4206,7 @@ impl File {
         self.file_unique_id = file_unique_id;
     }
 
-    pub fn set_file_size(&mut self, file_size: Option<isize>) {
+    pub fn set_file_size(&mut self, file_size: Option<u32>) {
         self.file_size = file_size;
     }
 
@@ -4222,7 +4222,7 @@ impl File {
         self.file_unique_id.clone()
     }
 
-    pub fn file_size(&self) -> Option<isize> {
+    pub fn file_size(&self) -> Option<u32> {
         self.file_size
     }
 
@@ -4666,11 +4666,11 @@ impl ChatInviteLink {
         self.is_revoked = is_revoked;
     }
 
-    pub fn set_expire_date(&mut self, expire_date: Option<isize>) {
+    pub fn set_expire_date(&mut self, expire_date: Option<u64>) {
         self.expire_date = expire_date;
     }
 
-    pub fn set_member_limit(&mut self, member_limit: Option<isize>) {
+    pub fn set_member_limit(&mut self, member_limit: Option<u32>) {
         self.member_limit = member_limit;
     }
 
@@ -4690,11 +4690,11 @@ impl ChatInviteLink {
         self.is_revoked
     }
 
-    pub fn expire_date(&self) -> Option<isize> {
+    pub fn expire_date(&self) -> Option<u64> {
         self.expire_date
     }
 
-    pub fn member_limit(&self) -> Option<isize> {
+    pub fn member_limit(&self) -> Option<u32> {
         self.member_limit
     }
 }
@@ -4811,7 +4811,7 @@ impl ChatMember {
         self.can_add_web_page_previews = can_add_web_page_previews;
     }
 
-    pub fn set_until_date(&mut self, until_date: Option<isize>) {
+    pub fn set_until_date(&mut self, until_date: Option<u64>) {
         self.until_date = until_date;
     }
 
@@ -4899,7 +4899,7 @@ impl ChatMember {
         self.can_add_web_page_previews
     }
 
-    pub fn until_date(&self) -> Option<isize> {
+    pub fn until_date(&self) -> Option<u64> {
         self.until_date
     }
 }
@@ -4908,7 +4908,7 @@ impl ChatMemberUpdated {
     pub fn new(
         chat: Chat,
         from: User,
-        date: isize,
+        date: u64,
         old_chat_member: ChatMember,
         new_chat_member: ChatMember,
     ) -> Self {
@@ -4930,7 +4930,7 @@ impl ChatMemberUpdated {
         self.from = from;
     }
 
-    pub fn set_date(&mut self, date: isize) {
+    pub fn set_date(&mut self, date: u64) {
         self.date = date;
     }
 
@@ -4954,7 +4954,7 @@ impl ChatMemberUpdated {
         self.from.clone()
     }
 
-    pub fn date(&self) -> isize {
+    pub fn date(&self) -> u64 {
         self.date
     }
 
@@ -5105,7 +5105,7 @@ impl ResponseParameters {
         }
     }
 
-    pub fn set_migrate_to_chat_id(&mut self, migrate_to_chat_id: Option<isize>) {
+    pub fn set_migrate_to_chat_id(&mut self, migrate_to_chat_id: Option<i64>) {
         self.migrate_to_chat_id = migrate_to_chat_id;
     }
 
@@ -5113,7 +5113,7 @@ impl ResponseParameters {
         self.retry_after = retry_after;
     }
 
-    pub fn migrate_to_chat_id(&self) -> Option<isize> {
+    pub fn migrate_to_chat_id(&self) -> Option<i64> {
         self.migrate_to_chat_id
     }
 
@@ -5126,8 +5126,8 @@ impl Sticker {
     pub fn new(
         file_id: String,
         file_unique_id: String,
-        width: isize,
-        height: isize,
+        width: u32,
+        height: u32,
         is_animated: bool,
     ) -> Self {
         Self {
@@ -5152,11 +5152,11 @@ impl Sticker {
         self.file_unique_id = file_unique_id;
     }
 
-    pub fn set_width(&mut self, width: isize) {
+    pub fn set_width(&mut self, width: u32) {
         self.width = width;
     }
 
-    pub fn set_height(&mut self, height: isize) {
+    pub fn set_height(&mut self, height: u32) {
         self.height = height;
     }
 
@@ -5180,7 +5180,7 @@ impl Sticker {
         self.mask_position = mask_position;
     }
 
-    pub fn set_file_size(&mut self, file_size: Option<isize>) {
+    pub fn set_file_size(&mut self, file_size: Option<u32>) {
         self.file_size = file_size;
     }
 
@@ -5192,11 +5192,11 @@ impl Sticker {
         self.file_unique_id.clone()
     }
 
-    pub fn width(&self) -> isize {
+    pub fn width(&self) -> u32 {
         self.width
     }
 
-    pub fn height(&self) -> isize {
+    pub fn height(&self) -> u32 {
         self.height
     }
 
@@ -5220,7 +5220,7 @@ impl Sticker {
         self.mask_position.clone()
     }
 
-    pub fn file_size(&self) -> Option<isize> {
+    pub fn file_size(&self) -> Option<u32> {
         self.file_size
     }
 }
@@ -5449,11 +5449,11 @@ impl InlineQueryResultArticle {
         self.thumb_url = thumb_url;
     }
 
-    pub fn set_thumb_width(&mut self, thumb_width: Option<isize>) {
+    pub fn set_thumb_width(&mut self, thumb_width: Option<u32>) {
         self.thumb_width = thumb_width;
     }
 
-    pub fn set_thumb_height(&mut self, thumb_height: Option<isize>) {
+    pub fn set_thumb_height(&mut self, thumb_height: Option<u32>) {
         self.thumb_height = thumb_height;
     }
 
@@ -5493,11 +5493,11 @@ impl InlineQueryResultArticle {
         self.thumb_url.clone()
     }
 
-    pub fn thumb_width(&self) -> Option<isize> {
+    pub fn thumb_width(&self) -> Option<u32> {
         self.thumb_width
     }
 
-    pub fn thumb_height(&self) -> Option<isize> {
+    pub fn thumb_height(&self) -> Option<u32> {
         self.thumb_height
     }
 }
@@ -5537,11 +5537,11 @@ impl InlineQueryResultPhoto {
         self.thumb_url = thumb_url;
     }
 
-    pub fn set_photo_width(&mut self, photo_width: Option<isize>) {
+    pub fn set_photo_width(&mut self, photo_width: Option<u32>) {
         self.photo_width = photo_width;
     }
 
-    pub fn set_photo_height(&mut self, photo_height: Option<isize>) {
+    pub fn set_photo_height(&mut self, photo_height: Option<u32>) {
         self.photo_height = photo_height;
     }
 
@@ -5592,11 +5592,11 @@ impl InlineQueryResultPhoto {
         self.thumb_url.clone()
     }
 
-    pub fn photo_width(&self) -> Option<isize> {
+    pub fn photo_width(&self) -> Option<u32> {
         self.photo_width
     }
 
-    pub fn photo_height(&self) -> Option<isize> {
+    pub fn photo_height(&self) -> Option<u32> {
         self.photo_height
     }
 
@@ -5665,15 +5665,15 @@ impl InlineQueryResultGif {
         self.thumb_url = thumb_url;
     }
 
-    pub fn set_gif_width(&mut self, gif_width: Option<isize>) {
+    pub fn set_gif_width(&mut self, gif_width: Option<u32>) {
         self.gif_width = gif_width;
     }
 
-    pub fn set_gif_height(&mut self, gif_height: Option<isize>) {
+    pub fn set_gif_height(&mut self, gif_height: Option<u32>) {
         self.gif_height = gif_height;
     }
 
-    pub fn set_gif_duration(&mut self, gif_duration: Option<isize>) {
+    pub fn set_gif_duration(&mut self, gif_duration: Option<u32>) {
         self.gif_duration = gif_duration;
     }
 
@@ -5724,15 +5724,15 @@ impl InlineQueryResultGif {
         self.thumb_url.clone()
     }
 
-    pub fn gif_width(&self) -> Option<isize> {
+    pub fn gif_width(&self) -> Option<u32> {
         self.gif_width
     }
 
-    pub fn gif_height(&self) -> Option<isize> {
+    pub fn gif_height(&self) -> Option<u32> {
         self.gif_height
     }
 
-    pub fn gif_duration(&self) -> Option<isize> {
+    pub fn gif_duration(&self) -> Option<u32> {
         self.gif_duration
     }
 
@@ -5801,15 +5801,15 @@ impl InlineQueryResultMpeg4Gif {
         self.thumb_url = thumb_url;
     }
 
-    pub fn set_mpeg4_width(&mut self, mpeg4_width: Option<isize>) {
+    pub fn set_mpeg4_width(&mut self, mpeg4_width: Option<u32>) {
         self.mpeg4_width = mpeg4_width;
     }
 
-    pub fn set_mpeg4_height(&mut self, mpeg4_height: Option<isize>) {
+    pub fn set_mpeg4_height(&mut self, mpeg4_height: Option<u32>) {
         self.mpeg4_height = mpeg4_height;
     }
 
-    pub fn set_mpeg4_duration(&mut self, mpeg4_duration: Option<isize>) {
+    pub fn set_mpeg4_duration(&mut self, mpeg4_duration: Option<u32>) {
         self.mpeg4_duration = mpeg4_duration;
     }
 
@@ -5860,15 +5860,15 @@ impl InlineQueryResultMpeg4Gif {
         self.thumb_url.clone()
     }
 
-    pub fn mpeg4_width(&self) -> Option<isize> {
+    pub fn mpeg4_width(&self) -> Option<u32> {
         self.mpeg4_width
     }
 
-    pub fn mpeg4_height(&self) -> Option<isize> {
+    pub fn mpeg4_height(&self) -> Option<u32> {
         self.mpeg4_height
     }
 
-    pub fn mpeg4_duration(&self) -> Option<isize> {
+    pub fn mpeg4_duration(&self) -> Option<u32> {
         self.mpeg4_duration
     }
 
@@ -5964,15 +5964,15 @@ impl InlineQueryResultVideo {
         self.caption_entities = caption_entities;
     }
 
-    pub fn set_video_width(&mut self, video_width: Option<isize>) {
+    pub fn set_video_width(&mut self, video_width: Option<u32>) {
         self.video_width = video_width;
     }
 
-    pub fn set_video_height(&mut self, video_height: Option<isize>) {
+    pub fn set_video_height(&mut self, video_height: Option<u32>) {
         self.video_height = video_height;
     }
 
-    pub fn set_video_duration(&mut self, video_duration: Option<isize>) {
+    pub fn set_video_duration(&mut self, video_duration: Option<u32>) {
         self.video_duration = video_duration;
     }
 
@@ -6027,15 +6027,15 @@ impl InlineQueryResultVideo {
         self.caption_entities.clone()
     }
 
-    pub fn video_width(&self) -> Option<isize> {
+    pub fn video_width(&self) -> Option<u32> {
         self.video_width
     }
 
-    pub fn video_height(&self) -> Option<isize> {
+    pub fn video_height(&self) -> Option<u32> {
         self.video_height
     }
 
-    pub fn video_duration(&self) -> Option<isize> {
+    pub fn video_duration(&self) -> Option<u32> {
         self.video_duration
     }
 
@@ -6101,7 +6101,7 @@ impl InlineQueryResultAudio {
         self.performer = performer;
     }
 
-    pub fn set_audio_duration(&mut self, audio_duration: Option<isize>) {
+    pub fn set_audio_duration(&mut self, audio_duration: Option<u32>) {
         self.audio_duration = audio_duration;
     }
 
@@ -6148,7 +6148,7 @@ impl InlineQueryResultAudio {
         self.performer.clone()
     }
 
-    pub fn audio_duration(&self) -> Option<isize> {
+    pub fn audio_duration(&self) -> Option<u32> {
         self.audio_duration
     }
 
@@ -6205,7 +6205,7 @@ impl InlineQueryResultVoice {
         self.caption_entities = caption_entities;
     }
 
-    pub fn set_voice_duration(&mut self, voice_duration: Option<isize>) {
+    pub fn set_voice_duration(&mut self, voice_duration: Option<u32>) {
         self.voice_duration = voice_duration;
     }
 
@@ -6248,7 +6248,7 @@ impl InlineQueryResultVoice {
         self.caption_entities.clone()
     }
 
-    pub fn voice_duration(&self) -> Option<isize> {
+    pub fn voice_duration(&self) -> Option<u32> {
         self.voice_duration
     }
 
@@ -6332,11 +6332,11 @@ impl InlineQueryResultDocument {
         self.thumb_url = thumb_url;
     }
 
-    pub fn set_thumb_width(&mut self, thumb_width: Option<isize>) {
+    pub fn set_thumb_width(&mut self, thumb_width: Option<u32>) {
         self.thumb_width = thumb_width;
     }
 
-    pub fn set_thumb_height(&mut self, thumb_height: Option<isize>) {
+    pub fn set_thumb_height(&mut self, thumb_height: Option<u32>) {
         self.thumb_height = thumb_height;
     }
 
@@ -6388,11 +6388,11 @@ impl InlineQueryResultDocument {
         self.thumb_url.clone()
     }
 
-    pub fn thumb_width(&self) -> Option<isize> {
+    pub fn thumb_width(&self) -> Option<u32> {
         self.thumb_width
     }
 
-    pub fn thumb_height(&self) -> Option<isize> {
+    pub fn thumb_height(&self) -> Option<u32> {
         self.thumb_height
     }
 }
@@ -6468,11 +6468,11 @@ impl InlineQueryResultLocation {
         self.thumb_url = thumb_url;
     }
 
-    pub fn set_thumb_width(&mut self, thumb_width: Option<isize>) {
+    pub fn set_thumb_width(&mut self, thumb_width: Option<u32>) {
         self.thumb_width = thumb_width;
     }
 
-    pub fn set_thumb_height(&mut self, thumb_height: Option<isize>) {
+    pub fn set_thumb_height(&mut self, thumb_height: Option<u32>) {
         self.thumb_height = thumb_height;
     }
 
@@ -6524,11 +6524,11 @@ impl InlineQueryResultLocation {
         self.thumb_url.clone()
     }
 
-    pub fn thumb_width(&self) -> Option<isize> {
+    pub fn thumb_width(&self) -> Option<u32> {
         self.thumb_width
     }
 
-    pub fn thumb_height(&self) -> Option<isize> {
+    pub fn thumb_height(&self) -> Option<u32> {
         self.thumb_height
     }
 }
@@ -6609,11 +6609,11 @@ impl InlineQueryResultVenue {
         self.thumb_url = thumb_url;
     }
 
-    pub fn set_thumb_width(&mut self, thumb_width: Option<isize>) {
+    pub fn set_thumb_width(&mut self, thumb_width: Option<u32>) {
         self.thumb_width = thumb_width;
     }
 
-    pub fn set_thumb_height(&mut self, thumb_height: Option<isize>) {
+    pub fn set_thumb_height(&mut self, thumb_height: Option<u32>) {
         self.thumb_height = thumb_height;
     }
 
@@ -6669,11 +6669,11 @@ impl InlineQueryResultVenue {
         self.thumb_url.clone()
     }
 
-    pub fn thumb_width(&self) -> Option<isize> {
+    pub fn thumb_width(&self) -> Option<u32> {
         self.thumb_width
     }
 
-    pub fn thumb_height(&self) -> Option<isize> {
+    pub fn thumb_height(&self) -> Option<u32> {
         self.thumb_height
     }
 }
@@ -6734,11 +6734,11 @@ impl InlineQueryResultContact {
         self.thumb_url = thumb_url;
     }
 
-    pub fn set_thumb_width(&mut self, thumb_width: Option<isize>) {
+    pub fn set_thumb_width(&mut self, thumb_width: Option<u32>) {
         self.thumb_width = thumb_width;
     }
 
-    pub fn set_thumb_height(&mut self, thumb_height: Option<isize>) {
+    pub fn set_thumb_height(&mut self, thumb_height: Option<u32>) {
         self.thumb_height = thumb_height;
     }
 
@@ -6778,11 +6778,11 @@ impl InlineQueryResultContact {
         self.thumb_url.clone()
     }
 
-    pub fn thumb_width(&self) -> Option<isize> {
+    pub fn thumb_width(&self) -> Option<u32> {
         self.thumb_width
     }
 
-    pub fn thumb_height(&self) -> Option<isize> {
+    pub fn thumb_height(&self) -> Option<u32> {
         self.thumb_height
     }
 }
@@ -7839,15 +7839,15 @@ impl InputInvoiceMessageContent {
         self.photo_url = photo_url;
     }
 
-    pub fn set_photo_size(&mut self, photo_size: Option<isize>) {
+    pub fn set_photo_size(&mut self, photo_size: Option<u32>) {
         self.photo_size = photo_size;
     }
 
-    pub fn set_photo_width(&mut self, photo_width: Option<isize>) {
+    pub fn set_photo_width(&mut self, photo_width: Option<u32>) {
         self.photo_width = photo_width;
     }
 
-    pub fn set_photo_height(&mut self, photo_height: Option<isize>) {
+    pub fn set_photo_height(&mut self, photo_height: Option<u32>) {
         self.photo_height = photo_height;
     }
 
@@ -7922,15 +7922,15 @@ impl InputInvoiceMessageContent {
         self.photo_url.clone()
     }
 
-    pub fn photo_size(&self) -> Option<isize> {
+    pub fn photo_size(&self) -> Option<u32> {
         self.photo_size
     }
 
-    pub fn photo_width(&self) -> Option<isize> {
+    pub fn photo_width(&self) -> Option<u32> {
         self.photo_width
     }
 
-    pub fn photo_height(&self) -> Option<isize> {
+    pub fn photo_height(&self) -> Option<u32> {
         self.photo_height
     }
 
@@ -8462,8 +8462,8 @@ impl PassportFile {
     pub fn new(
         file_id: String,
         file_unique_id: String,
-        file_size: isize,
-        file_date: isize,
+        file_size: u32,
+        file_date: u64,
     ) -> Self {
         Self {
             file_id,
@@ -8481,11 +8481,11 @@ impl PassportFile {
         self.file_unique_id = file_unique_id;
     }
 
-    pub fn set_file_size(&mut self, file_size: isize) {
+    pub fn set_file_size(&mut self, file_size: u32) {
         self.file_size = file_size;
     }
 
-    pub fn set_file_date(&mut self, file_date: isize) {
+    pub fn set_file_date(&mut self, file_date: u64) {
         self.file_date = file_date;
     }
 
@@ -8497,11 +8497,11 @@ impl PassportFile {
         self.file_unique_id.clone()
     }
 
-    pub fn file_size(&self) -> isize {
+    pub fn file_size(&self) -> u32 {
         self.file_size
     }
 
-    pub fn file_date(&self) -> isize {
+    pub fn file_date(&self) -> u64 {
         self.file_date
     }
 }


### PR DESCRIPTION
partially fixes #10. The two types user_id and chat_id which need 64bit types are fixed. But there still is a lot of isize.

Please check for mistakes in here. Tests are green and it builds but that's not everything.

This changed to following types:
- ChatIdEnum::IntegerVariant `i64`
- chat_id `i64`
- date `u64`
- message_id `i32`
- user_id `u64`
- update_id `u32`
- *width `u32`
- *height `u32`
- *size `u32`
- *duration `u32`
- *offset `u32`
- *limit `u32`
- *timeout `u32`

As this is a breaking change I suggest the next release could also include some suggestions from `cargo clippy --all-targets -- -W clippy::pedantic`.