### PR TITLE
refactor: dont use 64bit integer when not needed

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -571,7 +571,7 @@ pub trait TelegramApi {
     fn get_chat_members_count(
         &self,
         params: &GetChatMembersCountParams,
-    ) -> Result<MethodResponse<u64>, Self::Error> {
+    ) -> Result<MethodResponse<u32>, Self::Error> {
         self.request("getChatMembersCount", Some(params))
     }
 

--- a/src/api_params.rs
+++ b/src/api_params.rs
@@ -128,7 +128,7 @@ pub struct SetWebhookParams {
     pub ip_address: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub max_connections: Option<i64>,
+    pub max_connections: Option<u32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub allowed_updates: Option<Vec<String>>,
@@ -439,7 +439,7 @@ pub struct SendVideoNoteParams {
     pub duration: Option<u32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub length: Option<i64>,
+    pub length: Option<u32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub thumb: Option<File>,
@@ -485,13 +485,13 @@ pub struct SendLocationParams {
     pub horizontal_accuracy: Option<f64>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub live_period: Option<i64>,
+    pub live_period: Option<u32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub heading: Option<i64>,
+    pub heading: Option<u16>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub proximity_alert_radius: Option<i64>,
+    pub proximity_alert_radius: Option<u32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub disable_notification: Option<bool>,
@@ -525,10 +525,10 @@ pub struct EditMessageLiveLocationParams {
     pub horizontal_accuracy: Option<f64>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub heading: Option<i64>,
+    pub heading: Option<u16>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub proximity_alert_radius: Option<i64>,
+    pub proximity_alert_radius: Option<u32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub reply_markup: Option<InlineKeyboardMarkup>,
@@ -631,7 +631,7 @@ pub struct SendPollParams {
     pub allows_multiple_answers: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub correct_option_id: Option<i64>,
+    pub correct_option_id: Option<u8>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub explanation: Option<String>,
@@ -643,7 +643,7 @@ pub struct SendPollParams {
     pub explanation_entities: Option<Vec<MessageEntity>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub open_period: Option<i64>,
+    pub open_period: Option<u32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub close_date: Option<u64>,
@@ -937,7 +937,7 @@ pub struct AnswerCallbackQueryParams {
     pub url: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub cache_time: Option<i64>,
+    pub cache_time: Option<u32>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -1120,7 +1120,7 @@ pub struct AddStickerToSetParams {
 pub struct SetStickerPositionInSetParams {
     pub sticker: String,
 
-    pub position: i64,
+    pub position: u32,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -1145,7 +1145,7 @@ pub struct AnswerInlineQueryParams {
     pub results: Vec<InlineQueryResult>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub cache_time: Option<i64>,
+    pub cache_time: Option<u32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub is_personal: Option<bool>,
@@ -1177,10 +1177,10 @@ pub struct SendInvoiceParams {
     pub prices: Vec<LabeledPrice>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub max_tip_amount: Option<i64>,
+    pub max_tip_amount: Option<u32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub suggested_tip_amounts: Option<Vec<i64>>,
+    pub suggested_tip_amounts: Option<Vec<u32>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub start_parameter: Option<String>,
@@ -1287,7 +1287,7 @@ pub struct SendGameParams {
 pub struct SetGameScoreParams {
     pub user_id: u64,
 
-    pub score: i64,
+    pub score: i32,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub force: Option<bool>,
@@ -1516,7 +1516,7 @@ impl SetWebhookParams {
         self.ip_address = ip_address;
     }
 
-    pub fn set_max_connections(&mut self, max_connections: Option<i64>) {
+    pub fn set_max_connections(&mut self, max_connections: Option<u32>) {
         self.max_connections = max_connections;
     }
 
@@ -1540,7 +1540,7 @@ impl SetWebhookParams {
         self.ip_address.clone()
     }
 
-    pub fn max_connections(&self) -> Option<i64> {
+    pub fn max_connections(&self) -> Option<u32> {
         self.max_connections
     }
 
@@ -2499,7 +2499,7 @@ impl SendVideoNoteParams {
         self.duration = duration;
     }
 
-    pub fn set_length(&mut self, length: Option<i64>) {
+    pub fn set_length(&mut self, length: Option<u32>) {
         self.length = length;
     }
 
@@ -2535,7 +2535,7 @@ impl SendVideoNoteParams {
         self.duration
     }
 
-    pub fn length(&self) -> Option<i64> {
+    pub fn length(&self) -> Option<u32> {
         self.length
     }
 
@@ -2645,15 +2645,15 @@ impl SendLocationParams {
         self.horizontal_accuracy = horizontal_accuracy;
     }
 
-    pub fn set_live_period(&mut self, live_period: Option<i64>) {
+    pub fn set_live_period(&mut self, live_period: Option<u32>) {
         self.live_period = live_period;
     }
 
-    pub fn set_heading(&mut self, heading: Option<i64>) {
+    pub fn set_heading(&mut self, heading: Option<u16>) {
         self.heading = heading;
     }
 
-    pub fn set_proximity_alert_radius(&mut self, proximity_alert_radius: Option<i64>) {
+    pub fn set_proximity_alert_radius(&mut self, proximity_alert_radius: Option<u32>) {
         self.proximity_alert_radius = proximity_alert_radius;
     }
 
@@ -2689,15 +2689,15 @@ impl SendLocationParams {
         self.horizontal_accuracy
     }
 
-    pub fn live_period(&self) -> Option<i64> {
+    pub fn live_period(&self) -> Option<u32> {
         self.live_period
     }
 
-    pub fn heading(&self) -> Option<i64> {
+    pub fn heading(&self) -> Option<u16> {
         self.heading
     }
 
-    pub fn proximity_alert_radius(&self) -> Option<i64> {
+    pub fn proximity_alert_radius(&self) -> Option<u32> {
         self.proximity_alert_radius
     }
 
@@ -2757,11 +2757,11 @@ impl EditMessageLiveLocationParams {
         self.horizontal_accuracy = horizontal_accuracy;
     }
 
-    pub fn set_heading(&mut self, heading: Option<i64>) {
+    pub fn set_heading(&mut self, heading: Option<u16>) {
         self.heading = heading;
     }
 
-    pub fn set_proximity_alert_radius(&mut self, proximity_alert_radius: Option<i64>) {
+    pub fn set_proximity_alert_radius(&mut self, proximity_alert_radius: Option<u32>) {
         self.proximity_alert_radius = proximity_alert_radius;
     }
 
@@ -2793,11 +2793,11 @@ impl EditMessageLiveLocationParams {
         self.horizontal_accuracy
     }
 
-    pub fn heading(&self) -> Option<i64> {
+    pub fn heading(&self) -> Option<u16> {
         self.heading
     }
 
-    pub fn proximity_alert_radius(&self) -> Option<i64> {
+    pub fn proximity_alert_radius(&self) -> Option<u32> {
         self.proximity_alert_radius
     }
 
@@ -3114,7 +3114,7 @@ impl SendPollParams {
         self.allows_multiple_answers = allows_multiple_answers;
     }
 
-    pub fn set_correct_option_id(&mut self, correct_option_id: Option<i64>) {
+    pub fn set_correct_option_id(&mut self, correct_option_id: Option<u8>) {
         self.correct_option_id = correct_option_id;
     }
 
@@ -3130,7 +3130,7 @@ impl SendPollParams {
         self.explanation_entities = explanation_entities;
     }
 
-    pub fn set_open_period(&mut self, open_period: Option<i64>) {
+    pub fn set_open_period(&mut self, open_period: Option<u32>) {
         self.open_period = open_period;
     }
 
@@ -3182,7 +3182,7 @@ impl SendPollParams {
         self.allows_multiple_answers
     }
 
-    pub fn correct_option_id(&self) -> Option<i64> {
+    pub fn correct_option_id(&self) -> Option<u8> {
         self.correct_option_id
     }
 
@@ -3198,7 +3198,7 @@ impl SendPollParams {
         self.explanation_entities.clone()
     }
 
-    pub fn open_period(&self) -> Option<i64> {
+    pub fn open_period(&self) -> Option<u32> {
         self.open_period
     }
 
@@ -4077,7 +4077,7 @@ impl AnswerCallbackQueryParams {
         self.url = url;
     }
 
-    pub fn set_cache_time(&mut self, cache_time: Option<i64>) {
+    pub fn set_cache_time(&mut self, cache_time: Option<u32>) {
         self.cache_time = cache_time;
     }
 
@@ -4097,7 +4097,7 @@ impl AnswerCallbackQueryParams {
         self.url.clone()
     }
 
-    pub fn cache_time(&self) -> Option<i64> {
+    pub fn cache_time(&self) -> Option<u32> {
         self.cache_time
     }
 }
@@ -4660,7 +4660,7 @@ impl AddStickerToSetParams {
 }
 
 impl SetStickerPositionInSetParams {
-    pub fn new(sticker: String, position: i64) -> Self {
+    pub fn new(sticker: String, position: u32) -> Self {
         Self { sticker, position }
     }
 
@@ -4668,7 +4668,7 @@ impl SetStickerPositionInSetParams {
         self.sticker = sticker;
     }
 
-    pub fn set_position(&mut self, position: i64) {
+    pub fn set_position(&mut self, position: u32) {
         self.position = position;
     }
 
@@ -4676,7 +4676,7 @@ impl SetStickerPositionInSetParams {
         self.sticker.clone()
     }
 
-    pub fn position(&self) -> i64 {
+    pub fn position(&self) -> u32 {
         self.position
     }
 }
@@ -4750,7 +4750,7 @@ impl AnswerInlineQueryParams {
         self.results = results;
     }
 
-    pub fn set_cache_time(&mut self, cache_time: Option<i64>) {
+    pub fn set_cache_time(&mut self, cache_time: Option<u32>) {
         self.cache_time = cache_time;
     }
 
@@ -4778,7 +4778,7 @@ impl AnswerInlineQueryParams {
         self.results.clone()
     }
 
-    pub fn cache_time(&self) -> Option<i64> {
+    pub fn cache_time(&self) -> Option<u32> {
         self.cache_time
     }
 
@@ -4875,11 +4875,11 @@ impl SendInvoiceParams {
         self.provider_data = provider_data;
     }
 
-    pub fn set_max_tip_amount(&mut self, max_tip_amount: Option<i64>) {
+    pub fn set_max_tip_amount(&mut self, max_tip_amount: Option<u32>) {
         self.max_tip_amount = max_tip_amount;
     }
 
-    pub fn set_suggested_tip_amounts(&mut self, suggested_tip_amounts: Option<Vec<i64>>) {
+    pub fn set_suggested_tip_amounts(&mut self, suggested_tip_amounts: Option<Vec<u32>>) {
         self.suggested_tip_amounts = suggested_tip_amounts;
     }
 
@@ -4978,11 +4978,11 @@ impl SendInvoiceParams {
         self.prices.clone()
     }
 
-    pub fn max_tip_amount(&self) -> Option<i64> {
+    pub fn max_tip_amount(&self) -> Option<u32> {
         self.max_tip_amount
     }
 
-    pub fn suggested_tip_amounts(&self) -> Option<Vec<i64>> {
+    pub fn suggested_tip_amounts(&self) -> Option<Vec<u32>> {
         self.suggested_tip_amounts.clone()
     }
 
@@ -5212,7 +5212,7 @@ impl SendGameParams {
 }
 
 impl SetGameScoreParams {
-    pub fn new(user_id: u64, score: i64) -> Self {
+    pub fn new(user_id: u64, score: i32) -> Self {
         Self {
             user_id,
             score,
@@ -5228,7 +5228,7 @@ impl SetGameScoreParams {
         self.user_id = user_id;
     }
 
-    pub fn set_score(&mut self, score: i64) {
+    pub fn set_score(&mut self, score: i32) {
         self.score = score;
     }
 
@@ -5256,7 +5256,7 @@ impl SetGameScoreParams {
         self.user_id
     }
 
-    pub fn score(&self) -> i64 {
+    pub fn score(&self) -> i32 {
         self.score
     }
 

--- a/src/objects.rs
+++ b/src/objects.rs
@@ -71,7 +71,7 @@ pub struct WebhookInfo {
 
     pub has_custom_certificate: bool,
 
-    pub pending_update_count: i64,
+    pub pending_update_count: u32,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ip_address: Option<String>,
@@ -83,7 +83,7 @@ pub struct WebhookInfo {
     pub last_error_message: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub max_connections: Option<i64>,
+    pub max_connections: Option<u16>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub allowed_updates: Option<Vec<String>>,
@@ -154,10 +154,10 @@ pub struct Chat {
     pub permissions: Option<ChatPermissions>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub slow_mode_delay: Option<i64>,
+    pub slow_mode_delay: Option<u16>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub message_auto_delete_time: Option<i64>,
+    pub message_auto_delete_time: Option<u32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub sticker_set_name: Option<String>,
@@ -350,9 +350,9 @@ pub struct MessageEntity {
     #[serde(rename = "type")]
     pub type_field: String,
 
-    pub offset: i64,
+    pub offset: u16,
 
-    pub length: i64,
+    pub length: u16,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub url: Option<String>,
@@ -480,7 +480,7 @@ pub struct VideoNote {
 
     pub file_unique_id: String,
 
-    pub length: i64,
+    pub length: u32,
 
     pub duration: u32,
 
@@ -526,14 +526,14 @@ pub struct Contact {
 pub struct Dice {
     pub emoji: String,
 
-    pub value: i64,
+    pub value: u8,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct PollOption {
     pub text: String,
 
-    pub voter_count: i64,
+    pub voter_count: u32,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -542,7 +542,7 @@ pub struct PollAnswer {
 
     pub user: User,
 
-    pub option_ids: Vec<i64>,
+    pub option_ids: Vec<u8>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -553,7 +553,7 @@ pub struct Poll {
 
     pub options: Vec<PollOption>,
 
-    pub total_voter_count: i64,
+    pub total_voter_count: u32,
 
     pub is_closed: bool,
 
@@ -564,7 +564,7 @@ pub struct Poll {
     pub allows_multiple_answers: bool,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub correct_option_id: Option<i64>,
+    pub correct_option_id: Option<u8>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub explanation: Option<String>,
@@ -573,7 +573,7 @@ pub struct Poll {
     pub explanation_entities: Option<Vec<MessageEntity>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub open_period: Option<i64>,
+    pub open_period: Option<u32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub close_date: Option<u64>,
@@ -589,13 +589,13 @@ pub struct Location {
     pub horizontal_accuracy: Option<f64>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub live_period: Option<i64>,
+    pub live_period: Option<u32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub heading: Option<i64>,
+    pub heading: Option<u16>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub proximity_alert_radius: Option<i64>,
+    pub proximity_alert_radius: Option<u32>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -625,12 +625,12 @@ pub struct ProximityAlertTriggered {
 
     pub watcher: User,
 
-    pub distance: i64,
+    pub distance: u32,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct MessageAutoDeleteTimerChanged {
-    pub message_auto_delete_time: i64,
+    pub message_auto_delete_time: u32,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -646,7 +646,7 @@ pub struct VoiceChatParticipantsInvited {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct UserProfilePhotos {
-    pub total_count: i64,
+    pub total_count: u32,
 
     pub photos: Vec<Vec<PhotoSize>>,
 }
@@ -939,7 +939,7 @@ pub struct ResponseParameters {
     pub migrate_to_chat_id: Option<i64>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub retry_after: Option<i64>,
+    pub retry_after: Option<u16>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -1334,13 +1334,13 @@ pub struct InlineQueryResultLocation {
     pub horizontal_accuracy: Option<f64>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub live_period: Option<i64>,
+    pub live_period: Option<u32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub heading: Option<i64>,
+    pub heading: Option<u16>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub proximity_alert_radius: Option<i64>,
+    pub proximity_alert_radius: Option<u32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub reply_markup: Option<InlineKeyboardMarkup>,
@@ -1686,13 +1686,13 @@ pub struct InputLocationMessageContent {
     pub horizontal_accuracy: Option<f64>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub live_period: Option<i64>,
+    pub live_period: Option<u32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub heading: Option<i64>,
+    pub heading: Option<u16>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub proximity_alert_radius: Option<i64>,
+    pub proximity_alert_radius: Option<u32>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -1710,10 +1710,10 @@ pub struct InputInvoiceMessageContent {
     pub prices: Vec<LabeledPrice>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub max_tip_amount: Option<i64>,
+    pub max_tip_amount: Option<u32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub suggested_tip_amounts: Option<Vec<i64>>,
+    pub suggested_tip_amounts: Option<Vec<u32>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub provider_data: Option<String>,
@@ -1807,7 +1807,7 @@ pub struct ChosenInlineResult {
 pub struct LabeledPrice {
     pub label: String,
 
-    pub amount: i64,
+    pub amount: u32,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -1820,7 +1820,7 @@ pub struct Invoice {
 
     pub currency: String,
 
-    pub total_amount: i64,
+    pub total_amount: u32,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -1866,7 +1866,7 @@ pub struct ShippingOption {
 pub struct SuccessfulPayment {
     pub currency: String,
 
-    pub total_amount: i64,
+    pub total_amount: u32,
 
     pub invoice_payload: String,
 
@@ -1900,7 +1900,7 @@ pub struct PreCheckoutQuery {
 
     pub currency: String,
 
-    pub total_amount: i64,
+    pub total_amount: u32,
 
     pub invoice_payload: String,
 
@@ -2091,11 +2091,11 @@ pub struct Game {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct GameHighScore {
-    pub position: i64,
+    pub position: u32,
 
     pub user: User,
 
-    pub score: i64,
+    pub score: i32,
 }
 
 impl Update {
@@ -2232,7 +2232,7 @@ impl Update {
 }
 
 impl WebhookInfo {
-    pub fn new(url: String, has_custom_certificate: bool, pending_update_count: i64) -> Self {
+    pub fn new(url: String, has_custom_certificate: bool, pending_update_count: u32) -> Self {
         Self {
             url,
             has_custom_certificate,
@@ -2253,7 +2253,7 @@ impl WebhookInfo {
         self.has_custom_certificate = has_custom_certificate;
     }
 
-    pub fn set_pending_update_count(&mut self, pending_update_count: i64) {
+    pub fn set_pending_update_count(&mut self, pending_update_count: u32) {
         self.pending_update_count = pending_update_count;
     }
 
@@ -2269,7 +2269,7 @@ impl WebhookInfo {
         self.last_error_message = last_error_message;
     }
 
-    pub fn set_max_connections(&mut self, max_connections: Option<i64>) {
+    pub fn set_max_connections(&mut self, max_connections: Option<u16>) {
         self.max_connections = max_connections;
     }
 
@@ -2285,7 +2285,7 @@ impl WebhookInfo {
         self.has_custom_certificate
     }
 
-    pub fn pending_update_count(&self) -> i64 {
+    pub fn pending_update_count(&self) -> u32 {
         self.pending_update_count
     }
 
@@ -2301,7 +2301,7 @@ impl WebhookInfo {
         self.last_error_message.clone()
     }
 
-    pub fn max_connections(&self) -> Option<i64> {
+    pub fn max_connections(&self) -> Option<u16> {
         self.max_connections
     }
 
@@ -2470,11 +2470,11 @@ impl Chat {
         self.permissions = permissions;
     }
 
-    pub fn set_slow_mode_delay(&mut self, slow_mode_delay: Option<i64>) {
+    pub fn set_slow_mode_delay(&mut self, slow_mode_delay: Option<u16>) {
         self.slow_mode_delay = slow_mode_delay;
     }
 
-    pub fn set_message_auto_delete_time(&mut self, message_auto_delete_time: Option<i64>) {
+    pub fn set_message_auto_delete_time(&mut self, message_auto_delete_time: Option<u32>) {
         self.message_auto_delete_time = message_auto_delete_time;
     }
 
@@ -2542,11 +2542,11 @@ impl Chat {
         self.permissions.clone()
     }
 
-    pub fn slow_mode_delay(&self) -> Option<i64> {
+    pub fn slow_mode_delay(&self) -> Option<u16> {
         self.slow_mode_delay
     }
 
-    pub fn message_auto_delete_time(&self) -> Option<i64> {
+    pub fn message_auto_delete_time(&self) -> Option<u32> {
         self.message_auto_delete_time
     }
 
@@ -3102,7 +3102,7 @@ impl MessageId {
 }
 
 impl MessageEntity {
-    pub fn new(type_field: String, offset: i64, length: i64) -> Self {
+    pub fn new(type_field: String, offset: u16, length: u16) -> Self {
         Self {
             type_field,
             offset,
@@ -3117,11 +3117,11 @@ impl MessageEntity {
         self.type_field = type_field;
     }
 
-    pub fn set_offset(&mut self, offset: i64) {
+    pub fn set_offset(&mut self, offset: u16) {
         self.offset = offset;
     }
 
-    pub fn set_length(&mut self, length: i64) {
+    pub fn set_length(&mut self, length: u16) {
         self.length = length;
     }
 
@@ -3141,11 +3141,11 @@ impl MessageEntity {
         self.type_field.clone()
     }
 
-    pub fn offset(&self) -> i64 {
+    pub fn offset(&self) -> u16 {
         self.offset
     }
 
-    pub fn length(&self) -> i64 {
+    pub fn length(&self) -> u16 {
         self.length
     }
 
@@ -3552,7 +3552,7 @@ impl Video {
 }
 
 impl VideoNote {
-    pub fn new(file_id: String, file_unique_id: String, length: i64, duration: u32) -> Self {
+    pub fn new(file_id: String, file_unique_id: String, length: u32, duration: u32) -> Self {
         Self {
             file_id,
             file_unique_id,
@@ -3571,7 +3571,7 @@ impl VideoNote {
         self.file_unique_id = file_unique_id;
     }
 
-    pub fn set_length(&mut self, length: i64) {
+    pub fn set_length(&mut self, length: u32) {
         self.length = length;
     }
 
@@ -3595,7 +3595,7 @@ impl VideoNote {
         self.file_unique_id.clone()
     }
 
-    pub fn length(&self) -> i64 {
+    pub fn length(&self) -> u32 {
         self.length
     }
 
@@ -3717,7 +3717,7 @@ impl Contact {
 }
 
 impl Dice {
-    pub fn new(emoji: String, value: i64) -> Self {
+    pub fn new(emoji: String, value: u8) -> Self {
         Self { emoji, value }
     }
 
@@ -3725,7 +3725,7 @@ impl Dice {
         self.emoji = emoji;
     }
 
-    pub fn set_value(&mut self, value: i64) {
+    pub fn set_value(&mut self, value: u8) {
         self.value = value;
     }
 
@@ -3733,13 +3733,13 @@ impl Dice {
         self.emoji.clone()
     }
 
-    pub fn value(&self) -> i64 {
+    pub fn value(&self) -> u8 {
         self.value
     }
 }
 
 impl PollOption {
-    pub fn new(text: String, voter_count: i64) -> Self {
+    pub fn new(text: String, voter_count: u32) -> Self {
         Self { text, voter_count }
     }
 
@@ -3747,7 +3747,7 @@ impl PollOption {
         self.text = text;
     }
 
-    pub fn set_voter_count(&mut self, voter_count: i64) {
+    pub fn set_voter_count(&mut self, voter_count: u32) {
         self.voter_count = voter_count;
     }
 
@@ -3755,13 +3755,13 @@ impl PollOption {
         self.text.clone()
     }
 
-    pub fn voter_count(&self) -> i64 {
+    pub fn voter_count(&self) -> u32 {
         self.voter_count
     }
 }
 
 impl PollAnswer {
-    pub fn new(poll_id: String, user: User, option_ids: Vec<i64>) -> Self {
+    pub fn new(poll_id: String, user: User, option_ids: Vec<u8>) -> Self {
         Self {
             poll_id,
             user,
@@ -3777,7 +3777,7 @@ impl PollAnswer {
         self.user = user;
     }
 
-    pub fn set_option_ids(&mut self, option_ids: Vec<i64>) {
+    pub fn set_option_ids(&mut self, option_ids: Vec<u8>) {
         self.option_ids = option_ids;
     }
 
@@ -3789,7 +3789,7 @@ impl PollAnswer {
         self.user.clone()
     }
 
-    pub fn option_ids(&self) -> Vec<i64> {
+    pub fn option_ids(&self) -> Vec<u8> {
         self.option_ids.clone()
     }
 }
@@ -3799,7 +3799,7 @@ impl Poll {
         id: String,
         question: String,
         options: Vec<PollOption>,
-        total_voter_count: i64,
+        total_voter_count: u32,
         is_closed: bool,
         is_anonymous: bool,
         type_field: String,
@@ -3834,7 +3834,7 @@ impl Poll {
         self.options = options;
     }
 
-    pub fn set_total_voter_count(&mut self, total_voter_count: i64) {
+    pub fn set_total_voter_count(&mut self, total_voter_count: u32) {
         self.total_voter_count = total_voter_count;
     }
 
@@ -3854,7 +3854,7 @@ impl Poll {
         self.allows_multiple_answers = allows_multiple_answers;
     }
 
-    pub fn set_correct_option_id(&mut self, correct_option_id: Option<i64>) {
+    pub fn set_correct_option_id(&mut self, correct_option_id: Option<u8>) {
         self.correct_option_id = correct_option_id;
     }
 
@@ -3866,7 +3866,7 @@ impl Poll {
         self.explanation_entities = explanation_entities;
     }
 
-    pub fn set_open_period(&mut self, open_period: Option<i64>) {
+    pub fn set_open_period(&mut self, open_period: Option<u32>) {
         self.open_period = open_period;
     }
 
@@ -3886,7 +3886,7 @@ impl Poll {
         self.options.clone()
     }
 
-    pub fn total_voter_count(&self) -> i64 {
+    pub fn total_voter_count(&self) -> u32 {
         self.total_voter_count
     }
 
@@ -3906,7 +3906,7 @@ impl Poll {
         self.allows_multiple_answers
     }
 
-    pub fn correct_option_id(&self) -> Option<i64> {
+    pub fn correct_option_id(&self) -> Option<u8> {
         self.correct_option_id
     }
 
@@ -3918,7 +3918,7 @@ impl Poll {
         self.explanation_entities.clone()
     }
 
-    pub fn open_period(&self) -> Option<i64> {
+    pub fn open_period(&self) -> Option<u32> {
         self.open_period
     }
 
@@ -3951,15 +3951,15 @@ impl Location {
         self.horizontal_accuracy = horizontal_accuracy;
     }
 
-    pub fn set_live_period(&mut self, live_period: Option<i64>) {
+    pub fn set_live_period(&mut self, live_period: Option<u32>) {
         self.live_period = live_period;
     }
 
-    pub fn set_heading(&mut self, heading: Option<i64>) {
+    pub fn set_heading(&mut self, heading: Option<u16>) {
         self.heading = heading;
     }
 
-    pub fn set_proximity_alert_radius(&mut self, proximity_alert_radius: Option<i64>) {
+    pub fn set_proximity_alert_radius(&mut self, proximity_alert_radius: Option<u32>) {
         self.proximity_alert_radius = proximity_alert_radius;
     }
 
@@ -3975,15 +3975,15 @@ impl Location {
         self.horizontal_accuracy
     }
 
-    pub fn live_period(&self) -> Option<i64> {
+    pub fn live_period(&self) -> Option<u32> {
         self.live_period
     }
 
-    pub fn heading(&self) -> Option<i64> {
+    pub fn heading(&self) -> Option<u16> {
         self.heading
     }
 
-    pub fn proximity_alert_radius(&self) -> Option<i64> {
+    pub fn proximity_alert_radius(&self) -> Option<u32> {
         self.proximity_alert_radius
     }
 }
@@ -4059,7 +4059,7 @@ impl Venue {
 }
 
 impl ProximityAlertTriggered {
-    pub fn new(traveler: User, watcher: User, distance: i64) -> Self {
+    pub fn new(traveler: User, watcher: User, distance: u32) -> Self {
         Self {
             traveler,
             watcher,
@@ -4075,7 +4075,7 @@ impl ProximityAlertTriggered {
         self.watcher = watcher;
     }
 
-    pub fn set_distance(&mut self, distance: i64) {
+    pub fn set_distance(&mut self, distance: u32) {
         self.distance = distance;
     }
 
@@ -4087,23 +4087,23 @@ impl ProximityAlertTriggered {
         self.watcher.clone()
     }
 
-    pub fn distance(&self) -> i64 {
+    pub fn distance(&self) -> u32 {
         self.distance
     }
 }
 
 impl MessageAutoDeleteTimerChanged {
-    pub fn new(message_auto_delete_time: i64) -> Self {
+    pub fn new(message_auto_delete_time: u32) -> Self {
         Self {
             message_auto_delete_time,
         }
     }
 
-    pub fn set_message_auto_delete_time(&mut self, message_auto_delete_time: i64) {
+    pub fn set_message_auto_delete_time(&mut self, message_auto_delete_time: u32) {
         self.message_auto_delete_time = message_auto_delete_time;
     }
 
-    pub fn message_auto_delete_time(&self) -> i64 {
+    pub fn message_auto_delete_time(&self) -> u32 {
         self.message_auto_delete_time
     }
 }
@@ -4151,14 +4151,14 @@ impl VoiceChatParticipantsInvited {
 }
 
 impl UserProfilePhotos {
-    pub fn new(total_count: i64, photos: Vec<Vec<PhotoSize>>) -> Self {
+    pub fn new(total_count: u32, photos: Vec<Vec<PhotoSize>>) -> Self {
         Self {
             total_count,
             photos,
         }
     }
 
-    pub fn set_total_count(&mut self, total_count: i64) {
+    pub fn set_total_count(&mut self, total_count: u32) {
         self.total_count = total_count;
     }
 
@@ -4166,7 +4166,7 @@ impl UserProfilePhotos {
         self.photos = photos;
     }
 
-    pub fn total_count(&self) -> i64 {
+    pub fn total_count(&self) -> u32 {
         self.total_count
     }
 
@@ -5096,7 +5096,7 @@ impl ResponseParameters {
         self.migrate_to_chat_id = migrate_to_chat_id;
     }
 
-    pub fn set_retry_after(&mut self, retry_after: Option<i64>) {
+    pub fn set_retry_after(&mut self, retry_after: Option<u16>) {
         self.retry_after = retry_after;
     }
 
@@ -5104,7 +5104,7 @@ impl ResponseParameters {
         self.migrate_to_chat_id
     }
 
-    pub fn retry_after(&self) -> Option<i64> {
+    pub fn retry_after(&self) -> Option<u16> {
         self.retry_after
     }
 }
@@ -6428,15 +6428,15 @@ impl InlineQueryResultLocation {
         self.horizontal_accuracy = horizontal_accuracy;
     }
 
-    pub fn set_live_period(&mut self, live_period: Option<i64>) {
+    pub fn set_live_period(&mut self, live_period: Option<u32>) {
         self.live_period = live_period;
     }
 
-    pub fn set_heading(&mut self, heading: Option<i64>) {
+    pub fn set_heading(&mut self, heading: Option<u16>) {
         self.heading = heading;
     }
 
-    pub fn set_proximity_alert_radius(&mut self, proximity_alert_radius: Option<i64>) {
+    pub fn set_proximity_alert_radius(&mut self, proximity_alert_radius: Option<u32>) {
         self.proximity_alert_radius = proximity_alert_radius;
     }
 
@@ -6487,15 +6487,15 @@ impl InlineQueryResultLocation {
         self.horizontal_accuracy
     }
 
-    pub fn live_period(&self) -> Option<i64> {
+    pub fn live_period(&self) -> Option<u32> {
         self.live_period
     }
 
-    pub fn heading(&self) -> Option<i64> {
+    pub fn heading(&self) -> Option<u16> {
         self.heading
     }
 
-    pub fn proximity_alert_radius(&self) -> Option<i64> {
+    pub fn proximity_alert_radius(&self) -> Option<u32> {
         self.proximity_alert_radius
     }
 
@@ -7594,15 +7594,15 @@ impl InputLocationMessageContent {
         self.horizontal_accuracy = horizontal_accuracy;
     }
 
-    pub fn set_live_period(&mut self, live_period: Option<i64>) {
+    pub fn set_live_period(&mut self, live_period: Option<u32>) {
         self.live_period = live_period;
     }
 
-    pub fn set_heading(&mut self, heading: Option<i64>) {
+    pub fn set_heading(&mut self, heading: Option<u16>) {
         self.heading = heading;
     }
 
-    pub fn set_proximity_alert_radius(&mut self, proximity_alert_radius: Option<i64>) {
+    pub fn set_proximity_alert_radius(&mut self, proximity_alert_radius: Option<u32>) {
         self.proximity_alert_radius = proximity_alert_radius;
     }
 
@@ -7618,15 +7618,15 @@ impl InputLocationMessageContent {
         self.horizontal_accuracy
     }
 
-    pub fn live_period(&self) -> Option<i64> {
+    pub fn live_period(&self) -> Option<u32> {
         self.live_period
     }
 
-    pub fn heading(&self) -> Option<i64> {
+    pub fn heading(&self) -> Option<u16> {
         self.heading
     }
 
-    pub fn proximity_alert_radius(&self) -> Option<i64> {
+    pub fn proximity_alert_radius(&self) -> Option<u32> {
         self.proximity_alert_radius
     }
 }
@@ -7810,11 +7810,11 @@ impl InputInvoiceMessageContent {
         self.prices = prices;
     }
 
-    pub fn set_max_tip_amount(&mut self, max_tip_amount: Option<i64>) {
+    pub fn set_max_tip_amount(&mut self, max_tip_amount: Option<u32>) {
         self.max_tip_amount = max_tip_amount;
     }
 
-    pub fn set_suggested_tip_amounts(&mut self, suggested_tip_amounts: Option<Vec<i64>>) {
+    pub fn set_suggested_tip_amounts(&mut self, suggested_tip_amounts: Option<Vec<u32>>) {
         self.suggested_tip_amounts = suggested_tip_amounts;
     }
 
@@ -7893,11 +7893,11 @@ impl InputInvoiceMessageContent {
         self.prices.clone()
     }
 
-    pub fn max_tip_amount(&self) -> Option<i64> {
+    pub fn max_tip_amount(&self) -> Option<u32> {
         self.max_tip_amount
     }
 
-    pub fn suggested_tip_amounts(&self) -> Option<Vec<i64>> {
+    pub fn suggested_tip_amounts(&self) -> Option<Vec<u32>> {
         self.suggested_tip_amounts.clone()
     }
 
@@ -8003,7 +8003,7 @@ impl ChosenInlineResult {
 }
 
 impl LabeledPrice {
-    pub fn new(label: String, amount: i64) -> Self {
+    pub fn new(label: String, amount: u32) -> Self {
         Self { label, amount }
     }
 
@@ -8011,7 +8011,7 @@ impl LabeledPrice {
         self.label = label;
     }
 
-    pub fn set_amount(&mut self, amount: i64) {
+    pub fn set_amount(&mut self, amount: u32) {
         self.amount = amount;
     }
 
@@ -8019,7 +8019,7 @@ impl LabeledPrice {
         self.label.clone()
     }
 
-    pub fn amount(&self) -> i64 {
+    pub fn amount(&self) -> u32 {
         self.amount
     }
 }
@@ -8030,7 +8030,7 @@ impl Invoice {
         description: String,
         start_parameter: String,
         currency: String,
-        total_amount: i64,
+        total_amount: u32,
     ) -> Self {
         Self {
             title,
@@ -8057,7 +8057,7 @@ impl Invoice {
         self.currency = currency;
     }
 
-    pub fn set_total_amount(&mut self, total_amount: i64) {
+    pub fn set_total_amount(&mut self, total_amount: u32) {
         self.total_amount = total_amount;
     }
 
@@ -8077,7 +8077,7 @@ impl Invoice {
         self.currency.clone()
     }
 
-    pub fn total_amount(&self) -> i64 {
+    pub fn total_amount(&self) -> u32 {
         self.total_amount
     }
 }
@@ -8226,7 +8226,7 @@ impl ShippingOption {
 impl SuccessfulPayment {
     pub fn new(
         currency: String,
-        total_amount: i64,
+        total_amount: u32,
         invoice_payload: String,
         telegram_payment_charge_id: String,
         provider_payment_charge_id: String,
@@ -8246,7 +8246,7 @@ impl SuccessfulPayment {
         self.currency = currency;
     }
 
-    pub fn set_total_amount(&mut self, total_amount: i64) {
+    pub fn set_total_amount(&mut self, total_amount: u32) {
         self.total_amount = total_amount;
     }
 
@@ -8274,7 +8274,7 @@ impl SuccessfulPayment {
         self.currency.clone()
     }
 
-    pub fn total_amount(&self) -> i64 {
+    pub fn total_amount(&self) -> u32 {
         self.total_amount
     }
 
@@ -8352,7 +8352,7 @@ impl PreCheckoutQuery {
         id: String,
         from: User,
         currency: String,
-        total_amount: i64,
+        total_amount: u32,
         invoice_payload: String,
     ) -> Self {
         Self {
@@ -8378,7 +8378,7 @@ impl PreCheckoutQuery {
         self.currency = currency;
     }
 
-    pub fn set_total_amount(&mut self, total_amount: i64) {
+    pub fn set_total_amount(&mut self, total_amount: u32) {
         self.total_amount = total_amount;
     }
 
@@ -8406,7 +8406,7 @@ impl PreCheckoutQuery {
         self.currency.clone()
     }
 
-    pub fn total_amount(&self) -> i64 {
+    pub fn total_amount(&self) -> u32 {
         self.total_amount
     }
 
@@ -9089,7 +9089,7 @@ impl Game {
 }
 
 impl GameHighScore {
-    pub fn new(position: i64, user: User, score: i64) -> Self {
+    pub fn new(position: u32, user: User, score: i32) -> Self {
         Self {
             position,
             user,
@@ -9097,7 +9097,7 @@ impl GameHighScore {
         }
     }
 
-    pub fn set_position(&mut self, position: i64) {
+    pub fn set_position(&mut self, position: u32) {
         self.position = position;
     }
 
@@ -9105,11 +9105,11 @@ impl GameHighScore {
         self.user = user;
     }
 
-    pub fn set_score(&mut self, score: i64) {
+    pub fn set_score(&mut self, score: i32) {
         self.score = score;
     }
 
-    pub fn position(&self) -> i64 {
+    pub fn position(&self) -> u32 {
         self.position
     }
 
@@ -9117,7 +9117,7 @@ impl GameHighScore {
         self.user.clone()
     }
 
-    pub fn score(&self) -> i64 {
+    pub fn score(&self) -> i32 {
         self.score
     }
 }


### PR DESCRIPTION
This changes all the 64bit integers to something smaller when not needed. Mostly 32bit, but some things are even smaller. For example `length`/`offset` in a 4096 text message with u32 is just way too big.

fixes #10