### PR TITLE
Add timeout option with default as 60s

### DIFF
--- a/src/api_impl.rs
+++ b/src/api_impl.rs
@@ -19,18 +19,23 @@ impl Api {
     pub fn new(api_key: &str) -> Self {
         let api_url = format!("{}{}", BASE_API_URL, api_key);
         let request_agent = ureq::builder().timeout(Duration::from_secs(60)).build();
-        Self { api_url, request_agent }
-    }
-
-    pub fn new_timeout(api_key: &str, timeout: Duration) -> Self {
-        let api_url = format!("{}{}", BASE_API_URL, api_key);
-        let request_agent = ureq::builder().timeout(timeout).build();
-        Self { api_url, request_agent }
+        Self {
+            api_url,
+            request_agent,
+        }
     }
 
     pub fn new_url(api_url: String) -> Self {
         let request_agent = ureq::builder().timeout(Duration::from_secs(60)).build();
-        Self { api_url, request_agent }
+        Self {
+            api_url,
+            request_agent,
+        }
+    }
+
+    pub fn with_timeout(&mut self, timeout: Duration) {
+        let request_agent = ureq::builder().timeout(timeout).build();
+        self.request_agent = request_agent;
     }
 
     pub fn encode_params<T: serde::ser::Serialize + std::fmt::Debug>(
@@ -116,7 +121,10 @@ impl TelegramApi for Api {
         params: Option<T1>,
     ) -> Result<T2, Error> {
         let url = format!("{}/{}", self.api_url, method);
-        let prepared_request = self.request_agent.post(&url).set("Content-Type", "application/json");
+        let prepared_request = self
+            .request_agent
+            .post(&url)
+            .set("Content-Type", "application/json");
 
         let response = match params {
             None => prepared_request.call()?,
@@ -174,7 +182,9 @@ impl TelegramApi for Api {
 
         let url = format!("{}/{}", self.api_url, method);
         let form_data = form.prepare().unwrap();
-        let response = self.request_agent.post(&url)
+        let response = self
+            .request_agent
+            .post(&url)
             .set(
                 "Content-Type",
                 &format!("multipart/form-data; boundary={}", form_data.boundary()),
@@ -267,12 +277,7 @@ mod tests {
     fn new_sets_correct_url() {
         let api = Api::new("hey");
 
-        assert_eq!(
-            Api {
-                api_url: "https://api.telegram.org/bothey".to_string()
-            },
-            api
-        );
+        assert_eq!("https://api.telegram.org/bothey", api.api_url);
     }
 
     #[test]

--- a/src/api_impl.rs
+++ b/src/api_impl.rs
@@ -4,23 +4,33 @@ use multipart::client::lazy::Multipart;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::path::PathBuf;
+use std::time::Duration;
 use ureq::Response;
 
 static BASE_API_URL: &str = "https://api.telegram.org/bot";
 
-#[derive(PartialEq, Debug, Clone)]
+#[derive(Debug, Clone)]
 pub struct Api {
     pub api_url: String,
+    request_agent: ureq::Agent,
 }
 
 impl Api {
     pub fn new(api_key: &str) -> Self {
         let api_url = format!("{}{}", BASE_API_URL, api_key);
-        Self { api_url }
+        let request_agent = ureq::builder().timeout(Duration::from_secs(60)).build();
+        Self { api_url, request_agent }
     }
 
-    pub const fn new_url(api_url: String) -> Self {
-        Self { api_url }
+    pub fn new_timeout(api_key: &str, timeout: Duration) -> Self {
+        let api_url = format!("{}{}", BASE_API_URL, api_key);
+        let request_agent = ureq::builder().timeout(timeout).build();
+        Self { api_url, request_agent }
+    }
+
+    pub fn new_url(api_url: String) -> Self {
+        let request_agent = ureq::builder().timeout(Duration::from_secs(60)).build();
+        Self { api_url, request_agent }
     }
 
     pub fn encode_params<T: serde::ser::Serialize + std::fmt::Debug>(
@@ -106,8 +116,7 @@ impl TelegramApi for Api {
         params: Option<T1>,
     ) -> Result<T2, Error> {
         let url = format!("{}/{}", self.api_url, method);
-
-        let prepared_request = ureq::post(&url).set("Content-Type", "application/json");
+        let prepared_request = self.request_agent.post(&url).set("Content-Type", "application/json");
 
         let response = match params {
             None => prepared_request.call()?,
@@ -165,7 +174,7 @@ impl TelegramApi for Api {
 
         let url = format!("{}/{}", self.api_url, method);
         let form_data = form.prepare().unwrap();
-        let response = ureq::post(&url)
+        let response = self.request_agent.post(&url)
             .set(
                 "Content-Type",
                 &format!("multipart/form-data; boundary={}", form_data.boundary()),


### PR DESCRIPTION
Hey, thank you for this project! 

I couldn't find a way to add a timeout to the default http client, so I modified the existing code a bit. 

This was needed because sometimes my client just gets stuck forever waiting for a network response.

I also made the change to reuse the existing client instead of creating one each time, this helps speed up things on small boards (I'm using a Pi Zero W) and makes it so we don't need to reconfigure the timeout each time. 

Had to remove the PartialEq derive because the ureq agent doesn't implement it. 

Anyway, thank you for the great project and feel free to reject this change if it doesn't fit the project for any reason or should be implemented another way. 