### PR TITLE
Reduce number of dependencies by disabling features from multipart

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,8 @@ optional = true
 
 [dependencies.multipart]
 version = "0.18"
+default-features=false
+features=['client']
 optional = true
 
 [dependencies.serde]


### PR DESCRIPTION
I noticed the dependency graph was pretty heavy due to `multipart`, this helps the problem by disabling a bunch of unused features. 