### PR TITLE
ParseMode enum

### DIFF
--- a/src/api_params.rs
+++ b/src/api_params.rs
@@ -13,6 +13,7 @@ use crate::objects::{
     PassportElementErrorUnspecified, PollType, ReplyKeyboardMarkup, ReplyKeyboardRemove,
     ShippingOption,
 };
+use crate::ParseMode;
 use derive_builder::Builder;
 use serde::Deserialize;
 use serde::Serialize;
@@ -292,7 +293,7 @@ pub struct SendMessageParams {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(setter(strip_option), default)]
-    pub parse_mode: Option<String>,
+    pub parse_mode: Option<ParseMode>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(setter(strip_option), default)]
@@ -356,7 +357,7 @@ pub struct CopyMessageParams {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(setter(strip_option), default)]
-    pub parse_mode: Option<String>,
+    pub parse_mode: Option<ParseMode>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(setter(strip_option), default)]
@@ -396,7 +397,7 @@ pub struct SendPhotoParams {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(setter(strip_option), default)]
-    pub parse_mode: Option<String>,
+    pub parse_mode: Option<ParseMode>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(setter(strip_option), default)]
@@ -436,7 +437,7 @@ pub struct SendAudioParams {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(setter(strip_option), default)]
-    pub parse_mode: Option<String>,
+    pub parse_mode: Option<ParseMode>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(setter(strip_option), default)]
@@ -496,7 +497,7 @@ pub struct SendDocumentParams {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(setter(strip_option), default)]
-    pub parse_mode: Option<String>,
+    pub parse_mode: Option<ParseMode>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(setter(strip_option), default)]
@@ -556,7 +557,7 @@ pub struct SendVideoParams {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(setter(strip_option), default)]
-    pub parse_mode: Option<String>,
+    pub parse_mode: Option<ParseMode>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(setter(strip_option), default)]
@@ -616,7 +617,7 @@ pub struct SendAnimationParams {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(setter(strip_option), default)]
-    pub parse_mode: Option<String>,
+    pub parse_mode: Option<ParseMode>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(setter(strip_option), default)]
@@ -656,7 +657,7 @@ pub struct SendVoiceParams {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(setter(strip_option), default)]
-    pub parse_mode: Option<String>,
+    pub parse_mode: Option<ParseMode>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(setter(strip_option), default)]
@@ -972,7 +973,7 @@ pub struct SendPollParams {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(setter(strip_option), default)]
-    pub explanation_parse_mode: Option<String>,
+    pub explanation_parse_mode: Option<ParseMode>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(setter(strip_option), default)]
@@ -1458,7 +1459,7 @@ pub struct EditMessageTextParams {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(setter(strip_option), default)]
-    pub parse_mode: Option<String>,
+    pub parse_mode: Option<ParseMode>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(setter(strip_option), default)]
@@ -1494,7 +1495,7 @@ pub struct EditMessageCaptionParams {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(setter(strip_option), default)]
-    pub parse_mode: Option<String>,
+    pub parse_mode: Option<ParseMode>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(setter(strip_option), default)]
@@ -1940,7 +1941,7 @@ pub struct InputMediaPhoto {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(setter(strip_option), default)]
-    pub parse_mode: Option<String>,
+    pub parse_mode: Option<ParseMode>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(setter(strip_option), default)]
@@ -1962,7 +1963,7 @@ pub struct InputMediaVideo {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(setter(strip_option), default)]
-    pub parse_mode: Option<String>,
+    pub parse_mode: Option<ParseMode>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(setter(strip_option), default)]
@@ -2000,7 +2001,7 @@ pub struct InputMediaAnimation {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(setter(strip_option), default)]
-    pub parse_mode: Option<String>,
+    pub parse_mode: Option<ParseMode>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(setter(strip_option), default)]
@@ -2034,7 +2035,7 @@ pub struct InputMediaAudio {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(setter(strip_option), default)]
-    pub parse_mode: Option<String>,
+    pub parse_mode: Option<ParseMode>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(setter(strip_option), default)]
@@ -2068,7 +2069,7 @@ pub struct InputMediaDocument {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(setter(strip_option), default)]
-    pub parse_mode: Option<String>,
+    pub parse_mode: Option<ParseMode>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(setter(strip_option), default)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,8 @@ pub use api_traits::*;
 
 pub mod api_params;
 pub mod objects;
+mod parse_mode;
 
 pub use api_params::*;
 pub use objects::*;
+pub use parse_mode::*;

--- a/src/objects.rs
+++ b/src/objects.rs
@@ -1,6 +1,8 @@
 use derive_builder::Builder;
 use serde::{Deserialize, Serialize};
 
+use crate::ParseMode;
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(untagged)]
 pub enum InputMessageContent {
@@ -1540,7 +1542,7 @@ pub struct InlineQueryResultPhoto {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(setter(strip_option), default)]
-    pub parse_mode: Option<String>,
+    pub parse_mode: Option<ParseMode>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(setter(strip_option), default)]
@@ -1590,7 +1592,7 @@ pub struct InlineQueryResultGif {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(setter(strip_option), default)]
-    pub parse_mode: Option<String>,
+    pub parse_mode: Option<ParseMode>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(setter(strip_option), default)]
@@ -1640,7 +1642,7 @@ pub struct InlineQueryResultMpeg4Gif {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(setter(strip_option), default)]
-    pub parse_mode: Option<String>,
+    pub parse_mode: Option<ParseMode>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(setter(strip_option), default)]
@@ -1674,7 +1676,7 @@ pub struct InlineQueryResultVideo {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(setter(strip_option), default)]
-    pub parse_mode: Option<String>,
+    pub parse_mode: Option<ParseMode>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(setter(strip_option), default)]
@@ -1720,7 +1722,7 @@ pub struct InlineQueryResultAudio {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(setter(strip_option), default)]
-    pub parse_mode: Option<String>,
+    pub parse_mode: Option<ParseMode>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(setter(strip_option), default)]
@@ -1758,7 +1760,7 @@ pub struct InlineQueryResultVoice {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(setter(strip_option), default)]
-    pub parse_mode: Option<String>,
+    pub parse_mode: Option<ParseMode>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(setter(strip_option), default)]
@@ -1790,7 +1792,7 @@ pub struct InlineQueryResultDocument {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(setter(strip_option), default)]
-    pub parse_mode: Option<String>,
+    pub parse_mode: Option<ParseMode>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(setter(strip_option), default)]
@@ -1994,7 +1996,7 @@ pub struct InlineQueryResultCachedPhoto {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(setter(strip_option), default)]
-    pub parse_mode: Option<String>,
+    pub parse_mode: Option<ParseMode>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(setter(strip_option), default)]
@@ -2026,7 +2028,7 @@ pub struct InlineQueryResultCachedGif {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(setter(strip_option), default)]
-    pub parse_mode: Option<String>,
+    pub parse_mode: Option<ParseMode>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(setter(strip_option), default)]
@@ -2058,7 +2060,7 @@ pub struct InlineQueryResultCachedMpeg4Gif {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(setter(strip_option), default)]
-    pub parse_mode: Option<String>,
+    pub parse_mode: Option<ParseMode>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(setter(strip_option), default)]
@@ -2108,7 +2110,7 @@ pub struct InlineQueryResultCachedDocument {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(setter(strip_option), default)]
-    pub parse_mode: Option<String>,
+    pub parse_mode: Option<ParseMode>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(setter(strip_option), default)]
@@ -2142,7 +2144,7 @@ pub struct InlineQueryResultCachedVideo {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(setter(strip_option), default)]
-    pub parse_mode: Option<String>,
+    pub parse_mode: Option<ParseMode>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(setter(strip_option), default)]
@@ -2172,7 +2174,7 @@ pub struct InlineQueryResultCachedVoice {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(setter(strip_option), default)]
-    pub parse_mode: Option<String>,
+    pub parse_mode: Option<ParseMode>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(setter(strip_option), default)]
@@ -2200,7 +2202,7 @@ pub struct InlineQueryResultCachedAudio {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(setter(strip_option), default)]
-    pub parse_mode: Option<String>,
+    pub parse_mode: Option<ParseMode>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(setter(strip_option), default)]
@@ -2222,7 +2224,7 @@ pub struct InputTextMessageContent {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(setter(strip_option), default)]
-    pub parse_mode: Option<String>,
+    pub parse_mode: Option<ParseMode>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(setter(strip_option), default)]

--- a/src/parse_mode.rs
+++ b/src/parse_mode.rs
@@ -1,0 +1,56 @@
+#![allow(deprecated)]
+
+use std::str::FromStr;
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ParseMode {
+    #[serde(rename = "HTML")]
+    Html,
+
+    MarkdownV2,
+
+    #[deprecated = "This is a legacy mode, retained for backward compatibility. Use `MarkdownV2` instead."]
+    Markdown,
+}
+
+impl FromStr for ParseMode {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "HTML" | "Html" | "html" => Ok(ParseMode::Html),
+            "Markdown" | "markdown" => Ok(ParseMode::Markdown),
+            "MarkdownV2" | "markdownv2" => Ok(ParseMode::MarkdownV2),
+            _ => Err(()),
+        }
+    }
+}
+
+impl ParseMode {
+    pub const fn to_str(&self) -> &'static str {
+        match self {
+            ParseMode::Html => "HTML",
+            ParseMode::MarkdownV2 => "MarkdownV2",
+            ParseMode::Markdown => "Markdown",
+        }
+    }
+}
+
+impl ToString for ParseMode {
+    fn to_string(&self) -> String {
+        self.to_str().to_string()
+    }
+}
+
+#[test]
+fn serde_markdown_works() {
+    let json = serde_json::to_string(&ParseMode::MarkdownV2).unwrap();
+    assert_eq!(json, r#""MarkdownV2""#);
+}
+
+#[test]
+fn serde_html_works() {
+    let json = serde_json::to_string(&ParseMode::Html).unwrap();
+    assert_eq!(json, r#""HTML""#);
+}


### PR DESCRIPTION
This prevents errors like using "Html" where "HTML" would have been required.

BREAKING CHANGE: string input for parse_mode isnt working anymore as the enum is required.

