### PR TITLE
Error handling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ async-telegram-trait = ["async-trait"]
 
 [dependencies]
 derive_builder = "0.10"
+thiserror = "1"
 
 [dependencies.async-trait]
 version = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,20 +42,10 @@ async-http-client = ["reqwest", "tokio", "async-telegram-trait", "serde_json"]
 async-telegram-trait = ["async-trait"]
 
 [dependencies]
+derive_builder = "0.10"
 
 [dependencies.async-trait]
 version = "0.1"
-optional = true
-
-[dependencies.reqwest]
-version = "0.11"
-default-features = false
-features = ["multipart", "stream", "rustls-tls"]
-optional = true
-
-[dependencies.tokio]
-version = "1.16"
-features = ["fs"]
 optional = true
 
 [dependencies.mime_guess]
@@ -64,19 +54,27 @@ optional = true
 
 [dependencies.multipart]
 version = "0.18"
-default-features=false
-features=['client']
+default-features = false
+features = ['client']
+optional = true
+
+[dependencies.reqwest]
+version = "0.11"
+default-features = false
+features = ["multipart", "stream", "rustls-tls"]
 optional = true
 
 [dependencies.serde]
 version = "1"
 features = ["derive"]
 
-[dependencies.derive_builder]
-version = "0.10"
-
 [dependencies.serde_json]
 version = "1"
+optional = true
+
+[dependencies.tokio]
+version = "1"
+features = ["fs"]
 optional = true
 
 [dependencies.ureq]
@@ -87,4 +85,4 @@ optional = true
 isahc = "1"
 mockito = "0.31"
 serde_json = "1"
-tokio = { version = "1.16", features = ["full"] }
+tokio = { version = "1", features = ["full"] }

--- a/src/api.rs
+++ b/src/api.rs
@@ -13,16 +13,21 @@ pub use telegram_api_impl::*;
 
 pub static BASE_API_URL: &str = "https://api.telegram.org/bot";
 
-#[derive(PartialEq, Debug, Serialize, Deserialize)]
+#[derive(PartialEq, Debug, Serialize, Deserialize, thiserror::Error)]
 #[serde(untagged)]
 pub enum Error {
+    #[error("{0}")]
     HttpError(HttpError),
+    #[error("Api Error {0:?}")]
     ApiError(ErrorResponse),
+    #[error("Decode Error {0}")]
     DecodeError(String),
+    #[error("Encode Error {0}")]
     EncodeError(String),
 }
 
-#[derive(PartialEq, Debug, Serialize, Deserialize)]
+#[derive(PartialEq, Debug, Serialize, Deserialize, thiserror::Error)]
+#[error("Http Error {code}: {message}")]
 pub struct HttpError {
     pub code: u16,
     pub message: String,

--- a/src/api/async_telegram_api_impl.rs
+++ b/src/api/async_telegram_api_impl.rs
@@ -221,6 +221,7 @@ mod async_tests {
             ok: false,
             description,
             error_code: 400,
+            parameters: None,
         })) = api.send_message(&params).await
         {
             assert_eq!("Bad Request: chat not found".to_string(), description);

--- a/src/api/telegram_api_impl.rs
+++ b/src/api/telegram_api_impl.rs
@@ -330,6 +330,7 @@ mod tests {
             ok: false,
             description,
             error_code: 400,
+            parameters: None,
         })) = api.send_message(&params)
         {
             assert_eq!("Bad Request: chat not found".to_string(), description);

--- a/src/api_traits.rs
+++ b/src/api_traits.rs
@@ -1,4 +1,4 @@
-use crate::objects::Message;
+use crate::objects::{Message, ResponseParameters};
 use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "async-telegram-trait")]
@@ -15,6 +15,7 @@ pub use telegram_api::*;
 
 #[derive(PartialEq, Debug, Serialize, Deserialize)]
 pub struct MethodResponse<T> {
+    /// Always true
     pub ok: bool,
     pub result: T,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -22,10 +23,19 @@ pub struct MethodResponse<T> {
 }
 
 #[derive(PartialEq, Debug, Serialize, Deserialize)]
+/// \[…\] an unsuccessful request, `ok` equals false and the error is explained in the `description`.
+/// An Integer `error_code` field is also returned, but its contents are subject to change in the future.
+/// Some errors may also have an optional field `parameters` of the type `ResponseParameters`, which can help to automatically handle the error.
+///
+/// See <https://core.telegram.org/bots/api#making-requests>
 pub struct ErrorResponse {
+    /// Always false
     pub ok: bool,
     pub description: String,
+    /// Contents are subject to change in the future
     pub error_code: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub parameters: Option<ResponseParameters>,
 }
 
 #[derive(PartialEq, Debug, Serialize, Deserialize)]


### PR DESCRIPTION
`thiserror` implements `std::error::Error`. Having the std Error implemented is helpful for error handling as crates like `anyhow` or other errors like `std::io::Error` automatically work via `Into`.

also `parameters` was added to the `ErrorResponse` which could be helpful for the retry_after property.