### PR TITLE
switch to typed-builder

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,8 +42,8 @@ async-http-client = ["reqwest", "tokio", "async-telegram-trait", "serde_json"]
 async-telegram-trait = ["async-trait"]
 
 [dependencies]
-derive_builder = "0.10"
 thiserror = "1"
+typed-builder = "0.10"
 
 [dependencies.async-trait]
 version = "0.1"

--- a/README.md
+++ b/README.md
@@ -66,55 +66,32 @@ can_read_all_group_messages	Boolean	Optional. True, if privacy mode is disabled 
 supports_inline_queries	Boolean	Optional. True, if the bot supports inline queries. Returned only in getMe.
 ```
 
-In frankenstein, it's described as:
+In frankenstein, it's described like this:
 
 ```rust
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct User {
     pub id: u64,
-
     pub is_bot: bool,
-
     pub first_name: String,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
     pub last_name: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
     pub username: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
     pub language_code: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
     pub can_join_groups: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
     pub can_read_all_group_messages: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
     pub supports_inline_queries: Option<bool>,
 }
 ```
 
-Optional fields are described as Option enum.
+Optional fields are described as `Option`.
 
-Every struct can be created with the associated builder. It accepts only required fields, optional fields are set to `None`:
+Every struct can be created with the associated builder. Only required fields are required to set, optional fields are set to `None` when not provided:
 
 ```rust
-let send_message_params = SendMessageParamsBuilder::default()
+let send_message_params = SendMessageParams::builder()
     .chat_id(message.chat.id)
     .text("hello")
     .reply_to_message_id(message.message_id)
-    .build()
-    .unwrap();
+    .build();
 ```
 
 For api parameters, the same approach is used. The only difference for parameters is the name of the struct in frankenstein ends with `Params` postfix.
@@ -148,10 +125,9 @@ let api = Api::new(token);
 2. Use this api object to make requests to the Bot API:
 
 ```rust
-let mut update_params_builder = GetUpdatesParamsBuilder::default();
-update_params_builder.allowed_updates(vec!["message".to_string()]);
-
-let update_params = update_params_builder.build().unwrap();
+let update_params = GetUpdatesParams::builder()
+    .allowed_updates(vec!["message".to_string()])
+    .build();
 
 let result = api.get_updates(&update_params);
 ```

--- a/examples/api_trait_implementation.rs
+++ b/examples/api_trait_implementation.rs
@@ -1,5 +1,5 @@
 use frankenstein::ErrorResponse;
-use frankenstein::SendMessageParamsBuilder;
+use frankenstein::SendMessageParams;
 use frankenstein::TelegramApi;
 use isahc::{prelude::*, Request};
 use std::path::PathBuf;
@@ -120,11 +120,10 @@ impl TelegramApi for Api {
 fn main() {
     let api = Api::new(TOKEN);
 
-    let params = SendMessageParamsBuilder::default()
+    let params = SendMessageParams::builder()
         .chat_id(275_808_073)
         .text("Hello!")
-        .build()
-        .unwrap();
+        .build();
 
     let result = api.send_message(&params);
 

--- a/examples/async_file_upload.rs
+++ b/examples/async_file_upload.rs
@@ -1,4 +1,4 @@
-use frankenstein::api_params::SendPhotoParamsBuilder;
+use frankenstein::api_params::SendPhotoParams;
 use frankenstein::AsyncApi;
 use frankenstein::AsyncTelegramApi;
 
@@ -11,11 +11,10 @@ async fn main() {
 
     let file = std::path::PathBuf::from("./frankenstein_logo.png");
 
-    let params = SendPhotoParamsBuilder::default()
+    let params = SendPhotoParams::builder()
         .chat_id(CHAT_ID)
         .photo(file)
-        .build()
-        .unwrap();
+        .build();
 
     match api.send_photo(&params).await {
         Ok(response) => {

--- a/examples/async_reply_to_message_updates.rs
+++ b/examples/async_reply_to_message_updates.rs
@@ -1,8 +1,8 @@
 use frankenstein::AsyncApi;
 use frankenstein::AsyncTelegramApi;
-use frankenstein::GetUpdatesParamsBuilder;
+use frankenstein::GetUpdatesParams;
 use frankenstein::Message;
-use frankenstein::SendMessageParamsBuilder;
+use frankenstein::SendMessageParams;
 
 static TOKEN: &str = "API_TOKEN";
 
@@ -10,10 +10,9 @@ static TOKEN: &str = "API_TOKEN";
 async fn main() {
     let api = AsyncApi::new(TOKEN);
 
-    let mut update_params_builder = GetUpdatesParamsBuilder::default();
-    update_params_builder.allowed_updates(vec!["message".to_string()]);
-
-    let mut update_params = update_params_builder.build().unwrap();
+    let update_params_builder =
+        GetUpdatesParams::builder().allowed_updates(vec!["message".to_string()]);
+    let mut update_params = update_params_builder.clone().build();
 
     loop {
         let result = api.get_updates(&update_params).await;
@@ -31,9 +30,9 @@ async fn main() {
                         });
 
                         update_params = update_params_builder
+                            .clone()
                             .offset(update.update_id + 1)
-                            .build()
-                            .unwrap();
+                            .build();
                     }
                 }
             }
@@ -45,12 +44,11 @@ async fn main() {
 }
 
 async fn process_message(message: Message, api: AsyncApi) {
-    let send_message_params = SendMessageParamsBuilder::default()
+    let send_message_params = SendMessageParams::builder()
         .chat_id(message.chat.id)
         .text("hello")
         .reply_to_message_id(message.message_id)
-        .build()
-        .unwrap();
+        .build();
 
     if let Err(err) = api.send_message(&send_message_params).await {
         println!("Failed to send message: {:?}", err);

--- a/examples/reply_to_message_updates.rs
+++ b/examples/reply_to_message_updates.rs
@@ -1,6 +1,6 @@
 use frankenstein::Api;
-use frankenstein::GetUpdatesParamsBuilder;
-use frankenstein::SendMessageParamsBuilder;
+use frankenstein::GetUpdatesParams;
+use frankenstein::SendMessageParams;
 use frankenstein::TelegramApi;
 
 static TOKEN: &str = "API_TOKEN";
@@ -8,10 +8,9 @@ static TOKEN: &str = "API_TOKEN";
 fn main() {
     let api = Api::new(TOKEN);
 
-    let mut update_params_builder = GetUpdatesParamsBuilder::default();
-    update_params_builder.allowed_updates(vec!["message".to_string()]);
-
-    let mut update_params = update_params_builder.build().unwrap();
+    let update_params_builder =
+        GetUpdatesParams::builder().allowed_updates(vec!["message".to_string()]);
+    let mut update_params = update_params_builder.clone().build();
 
     loop {
         let result = api.get_updates(&update_params);
@@ -22,21 +21,20 @@ fn main() {
             Ok(response) => {
                 for update in response.result {
                     if let Some(message) = update.message {
-                        let send_message_params = SendMessageParamsBuilder::default()
+                        let send_message_params = SendMessageParams::builder()
                             .chat_id(message.chat.id)
                             .text("hello")
                             .reply_to_message_id(message.message_id)
-                            .build()
-                            .unwrap();
+                            .build();
 
                         if let Err(err) = api.send_message(&send_message_params) {
                             println!("Failed to send message: {:?}", err);
                         }
 
                         update_params = update_params_builder
+                            .clone()
                             .offset(update.update_id + 1)
-                            .build()
-                            .unwrap();
+                            .build();
                     }
                 }
             }

--- a/src/api/async_telegram_api_impl.rs
+++ b/src/api/async_telegram_api_impl.rs
@@ -178,18 +178,17 @@ impl AsyncTelegramApi for AsyncApi {
 mod async_tests {
     use super::AsyncApi;
     use super::Error;
-    use crate::api_params::SendMessageParamsBuilder;
+    use crate::api_params::SendMessageParams;
     use crate::api_traits::ErrorResponse;
     use crate::AsyncTelegramApi;
 
     #[tokio::test]
     async fn async_send_message_success() {
         let response_string = "{\"ok\":true,\"result\":{\"message_id\":2746,\"from\":{\"id\":1276618370,\"is_bot\":true,\"first_name\":\"test_el_bot\",\"username\":\"el_mon_test_bot\"},\"date\":1618207352,\"chat\":{\"id\":275808073,\"type\":\"private\",\"username\":\"Ayrat555\",\"first_name\":\"Ayrat\",\"last_name\":\"Badykov\"},\"text\":\"Hello!\"}}";
-        let params = SendMessageParamsBuilder::default()
+        let params = SendMessageParams::builder()
             .chat_id(275808073)
             .text("Hello!")
-            .build()
-            .unwrap();
+            .build();
         let _m = mockito::mock("POST", "/sendMessage")
             .with_status(200)
             .with_body(response_string)
@@ -206,11 +205,10 @@ mod async_tests {
     async fn send_message_failure() {
         let response_string =
             "{\"ok\":false,\"description\":\"Bad Request: chat not found\",\"error_code\":400}";
-        let params = SendMessageParamsBuilder::default()
+        let params = SendMessageParams::builder()
             .chat_id(1)
             .text("Hello!")
-            .build()
-            .unwrap();
+            .build();
         let _m = mockito::mock("POST", "/sendMessage")
             .with_status(400)
             .with_body(response_string)

--- a/src/api/telegram_api_impl.rs
+++ b/src/api/telegram_api_impl.rs
@@ -185,78 +185,78 @@ impl TelegramApi for Api {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::api_params::AnswerCallbackQueryParamsBuilder;
-    use crate::api_params::AnswerInlineQueryParamsBuilder;
-    use crate::api_params::BanChatMemberParamsBuilder;
+    use crate::api_params::AnswerCallbackQueryParams;
+    use crate::api_params::AnswerInlineQueryParams;
+    use crate::api_params::BanChatMemberParams;
     use crate::api_params::BotCommandScope;
     use crate::api_params::BotCommandScopeChat;
     use crate::api_params::ChatAction;
     use crate::api_params::ChatId;
-    use crate::api_params::CopyMessageParamsBuilder;
-    use crate::api_params::CreateChatInviteLinkParamsBuilder;
-    use crate::api_params::DeleteChatPhotoParamsBuilder;
-    use crate::api_params::DeleteChatStickerSetParamsBuilder;
-    use crate::api_params::DeleteMessageParamsBuilder;
-    use crate::api_params::DeleteMyCommandsParamsBuilder;
-    use crate::api_params::DeleteWebhookParamsBuilder;
-    use crate::api_params::EditChatInviteLinkParamsBuilder;
-    use crate::api_params::EditMessageCaptionParamsBuilder;
-    use crate::api_params::EditMessageLiveLocationParamsBuilder;
-    use crate::api_params::EditMessageMediaParamsBuilder;
-    use crate::api_params::EditMessageTextParamsBuilder;
-    use crate::api_params::ExportChatInviteLinkParamsBuilder;
+    use crate::api_params::CopyMessageParams;
+    use crate::api_params::CreateChatInviteLinkParams;
+    use crate::api_params::DeleteChatPhotoParams;
+    use crate::api_params::DeleteChatStickerSetParams;
+    use crate::api_params::DeleteMessageParams;
+    use crate::api_params::DeleteMyCommandsParams;
+    use crate::api_params::DeleteWebhookParams;
+    use crate::api_params::EditChatInviteLinkParams;
+    use crate::api_params::EditMessageCaptionParams;
+    use crate::api_params::EditMessageLiveLocationParams;
+    use crate::api_params::EditMessageMediaParams;
+    use crate::api_params::EditMessageTextParams;
+    use crate::api_params::ExportChatInviteLinkParams;
     use crate::api_params::File;
-    use crate::api_params::ForwardMessageParamsBuilder;
-    use crate::api_params::GetChatAdministratorsParamsBuilder;
-    use crate::api_params::GetChatMemberCountParamsBuilder;
-    use crate::api_params::GetChatMemberParamsBuilder;
-    use crate::api_params::GetChatParamsBuilder;
-    use crate::api_params::GetFileParamsBuilder;
-    use crate::api_params::GetMyCommandsParamsBuilder;
-    use crate::api_params::GetStickerSetParamsBuilder;
-    use crate::api_params::GetUpdatesParamsBuilder;
-    use crate::api_params::GetUserProfilePhotosParamsBuilder;
+    use crate::api_params::ForwardMessageParams;
+    use crate::api_params::GetChatAdministratorsParams;
+    use crate::api_params::GetChatMemberCountParams;
+    use crate::api_params::GetChatMemberParams;
+    use crate::api_params::GetChatParams;
+    use crate::api_params::GetFileParams;
+    use crate::api_params::GetMyCommandsParams;
+    use crate::api_params::GetStickerSetParams;
+    use crate::api_params::GetUpdatesParams;
+    use crate::api_params::GetUserProfilePhotosParams;
     use crate::api_params::InlineQueryResult;
     use crate::api_params::InputFile;
     use crate::api_params::InputMedia;
-    use crate::api_params::InputMediaPhotoBuilder;
-    use crate::api_params::LeaveChatParamsBuilder;
+    use crate::api_params::InputMediaPhoto;
+    use crate::api_params::LeaveChatParams;
     use crate::api_params::Media;
-    use crate::api_params::PinChatMessageParamsBuilder;
-    use crate::api_params::PromoteChatMemberParamsBuilder;
-    use crate::api_params::RestrictChatMemberParamsBuilder;
-    use crate::api_params::RevokeChatInviteLinkParamsBuilder;
-    use crate::api_params::SendAnimationParamsBuilder;
-    use crate::api_params::SendAudioParamsBuilder;
-    use crate::api_params::SendChatActionParamsBuilder;
-    use crate::api_params::SendContactParamsBuilder;
-    use crate::api_params::SendDiceParamsBuilder;
-    use crate::api_params::SendDocumentParamsBuilder;
-    use crate::api_params::SendLocationParamsBuilder;
-    use crate::api_params::SendMediaGroupParamsBuilder;
-    use crate::api_params::SendMessageParamsBuilder;
-    use crate::api_params::SendPhotoParamsBuilder;
-    use crate::api_params::SendPollParamsBuilder;
-    use crate::api_params::SendStickerParamsBuilder;
-    use crate::api_params::SendVenueParamsBuilder;
-    use crate::api_params::SendVideoNoteParamsBuilder;
-    use crate::api_params::SendVideoParamsBuilder;
-    use crate::api_params::SendVoiceParamsBuilder;
-    use crate::api_params::SetChatAdministratorCustomTitleParamsBuilder;
-    use crate::api_params::SetChatDescriptionParamsBuilder;
-    use crate::api_params::SetChatPermissionsParamsBuilder;
-    use crate::api_params::SetChatPhotoParamsBuilder;
-    use crate::api_params::SetChatStickerSetParamsBuilder;
-    use crate::api_params::SetChatTitleParamsBuilder;
-    use crate::api_params::SetMyCommandsParamsBuilder;
-    use crate::api_params::SetWebhookParamsBuilder;
-    use crate::api_params::StopMessageLiveLocationParamsBuilder;
-    use crate::api_params::StopPollParamsBuilder;
-    use crate::api_params::UnbanChatMemberParamsBuilder;
-    use crate::api_params::UnpinChatMessageParamsBuilder;
-    use crate::objects::BotCommandBuilder;
-    use crate::objects::ChatPermissionsBuilder;
-    use crate::objects::InlineQueryResultVenueBuilder;
+    use crate::api_params::PinChatMessageParams;
+    use crate::api_params::PromoteChatMemberParams;
+    use crate::api_params::RestrictChatMemberParams;
+    use crate::api_params::RevokeChatInviteLinkParams;
+    use crate::api_params::SendAnimationParams;
+    use crate::api_params::SendAudioParams;
+    use crate::api_params::SendChatActionParams;
+    use crate::api_params::SendContactParams;
+    use crate::api_params::SendDiceParams;
+    use crate::api_params::SendDocumentParams;
+    use crate::api_params::SendLocationParams;
+    use crate::api_params::SendMediaGroupParams;
+    use crate::api_params::SendMessageParams;
+    use crate::api_params::SendPhotoParams;
+    use crate::api_params::SendPollParams;
+    use crate::api_params::SendStickerParams;
+    use crate::api_params::SendVenueParams;
+    use crate::api_params::SendVideoNoteParams;
+    use crate::api_params::SendVideoParams;
+    use crate::api_params::SendVoiceParams;
+    use crate::api_params::SetChatAdministratorCustomTitleParams;
+    use crate::api_params::SetChatDescriptionParams;
+    use crate::api_params::SetChatPermissionsParams;
+    use crate::api_params::SetChatPhotoParams;
+    use crate::api_params::SetChatStickerSetParams;
+    use crate::api_params::SetChatTitleParams;
+    use crate::api_params::SetMyCommandsParams;
+    use crate::api_params::SetWebhookParams;
+    use crate::api_params::StopMessageLiveLocationParams;
+    use crate::api_params::StopPollParams;
+    use crate::api_params::UnbanChatMemberParams;
+    use crate::api_params::UnpinChatMessageParams;
+    use crate::objects::BotCommand;
+    use crate::objects::ChatPermissions;
+    use crate::objects::InlineQueryResultVenue;
 
     #[test]
     fn new_sets_correct_url() {
@@ -268,10 +268,9 @@ mod tests {
     #[test]
     fn get_updates_success() {
         let response_string = "{\"ok\":true,\"result\":[{\"update_id\":379656753,\"message\":{\"message_id\":2741,\"from\":{\"id\":275808073,\"is_bot\":false,\"first_name\":\"Ayrat\",\"last_name\":\"Badykov\",\"username\":\"Ayrat555\",\"language_code\":\"en\"},\"date\":1618149703,\"chat\":{\"id\":275808073,\"type\":\"private\",\"username\":\"Ayrat555\",\"first_name\":\"Ayrat\",\"last_name\":\"Badykov\"},\"text\":\"dsaf\"}}]}";
-        let params = GetUpdatesParamsBuilder::default()
+        let params = GetUpdatesParams::builder()
             .allowed_updates(vec!["message".to_string()])
-            .build()
-            .unwrap();
+            .build();
 
         let _m = mockito::mock("POST", "/getUpdates")
             .with_status(200)
@@ -294,11 +293,10 @@ mod tests {
     #[test]
     fn send_message_success() {
         let response_string = "{\"ok\":true,\"result\":{\"message_id\":2746,\"from\":{\"id\":1276618370,\"is_bot\":true,\"first_name\":\"test_el_bot\",\"username\":\"el_mon_test_bot\"},\"date\":1618207352,\"chat\":{\"id\":275808073,\"type\":\"private\",\"username\":\"Ayrat555\",\"first_name\":\"Ayrat\",\"last_name\":\"Badykov\"},\"text\":\"Hello!\"}}";
-        let params = SendMessageParamsBuilder::default()
+        let params = SendMessageParams::builder()
             .chat_id(275808073)
             .text("Hello!")
-            .build()
-            .unwrap();
+            .build();
         let _m = mockito::mock("POST", "/sendMessage")
             .with_status(200)
             .with_body(response_string)
@@ -315,11 +313,10 @@ mod tests {
     fn send_message_failure() {
         let response_string =
             "{\"ok\":false,\"description\":\"Bad Request: chat not found\",\"error_code\":400}";
-        let params = SendMessageParamsBuilder::default()
+        let params = SendMessageParams::builder()
             .chat_id(1)
             .text("Hello!")
-            .build()
-            .unwrap();
+            .build();
         let _m = mockito::mock("POST", "/sendMessage")
             .with_status(400)
             .with_body(response_string)
@@ -343,7 +340,7 @@ mod tests {
     fn set_webhook_success() {
         let response_string =
             "{\"ok\":true,\"result\":true,\"description\":\"Webhook is already deleted\"}";
-        let params = SetWebhookParamsBuilder::default().url("").build().unwrap();
+        let params = SetWebhookParams::builder().url("").build();
         let _m = mockito::mock("POST", "/setWebhook")
             .with_status(200)
             .with_body(response_string)
@@ -360,7 +357,7 @@ mod tests {
     fn delete_webhook_success() {
         let response_string =
             "{\"ok\":true,\"result\":true,\"description\":\"Webhook is already deleted\"}";
-        let params = DeleteWebhookParamsBuilder::default().build().unwrap();
+        let params = DeleteWebhookParams::builder().build();
         let _m = mockito::mock("POST", "/deleteWebhook")
             .with_status(200)
             .with_body(response_string)
@@ -452,12 +449,11 @@ mod tests {
     #[test]
     fn forward_message_success() {
         let response_string = "{\"ok\":true,\"result\":{\"message_id\":2747,\"from\":{\"id\":1276618370,\"is_bot\":true,\"first_name\":\"test_el_bot\",\"username\":\"el_mon_test_bot\"},\"date\":1618294971,\"chat\":{\"id\":275808073,\"type\":\"private\",\"username\":\"Ayrat555\",\"first_name\":\"Ayrat\",\"last_name\":\"Badykov\"},\"text\":\"Hello\"}}";
-        let params = ForwardMessageParamsBuilder::default()
+        let params = ForwardMessageParams::builder()
             .chat_id(275808073)
             .from_chat_id(275808073)
             .message_id(2747)
-            .build()
-            .unwrap();
+            .build();
 
         let _m = mockito::mock("POST", "/forwardMessage")
             .with_status(200)
@@ -474,12 +470,11 @@ mod tests {
     #[test]
     fn copy_message_success() {
         let response_string = "{\"ok\":true,\"result\":{\"message_id\":2749}}";
-        let params = CopyMessageParamsBuilder::default()
+        let params = CopyMessageParams::builder()
             .chat_id(275808073)
             .from_chat_id(275808073)
             .message_id(2747)
-            .build()
-            .unwrap();
+            .build();
 
         let _m = mockito::mock("POST", "/copyMessage")
             .with_status(200)
@@ -496,12 +491,11 @@ mod tests {
     #[test]
     fn send_location_success() {
         let response_string = "{\"ok\":true,\"result\":{\"message_id\":2750,\"from\":{\"id\":1276618370,\"is_bot\":true,\"first_name\":\"test_el_bot\",\"username\":\"el_mon_test_bot\"},\"date\":1618382060,\"chat\":{\"id\":275808073,\"type\":\"private\",\"username\":\"Ayrat555\",\"first_name\":\"Ayrat\",\"last_name\":\"Badykov\"},\"location\":{\"longitude\":6.949981,\"latitude\":49.700002}}}";
-        let params = SendLocationParamsBuilder::default()
+        let params = SendLocationParams::builder()
             .chat_id(275808073)
             .latitude(49.7)
             .longitude(6.95)
-            .build()
-            .unwrap();
+            .build();
 
         let _m = mockito::mock("POST", "/sendLocation")
             .with_status(200)
@@ -518,13 +512,12 @@ mod tests {
     #[test]
     fn edit_message_live_location_success() {
         let response_string = "{\"ok\":true,\"result\":{\"message_id\":2752,\"from\":{\"id\":1276618370,\"is_bot\":true,\"first_name\":\"test_el_bot\",\"username\":\"el_mon_test_bot\"},\"date\":1618382998,\"chat\":{\"id\":275808073,\"type\":\"private\",\"username\":\"Ayrat555\",\"first_name\":\"Ayrat\",\"last_name\":\"Badykov\"},\"edit_date\":1618383189,\"location\":{\"longitude\":6.96,\"latitude\":49.800009,\"live_period\":300}}}";
-        let params = EditMessageLiveLocationParamsBuilder::default()
+        let params = EditMessageLiveLocationParams::builder()
             .chat_id(275808073)
             .message_id(2752)
             .latitude(49.7)
             .longitude(6.95)
-            .build()
-            .unwrap();
+            .build();
 
         let _m = mockito::mock("POST", "/editMessageLiveLocation")
             .with_status(200)
@@ -541,11 +534,10 @@ mod tests {
     #[test]
     fn stop_message_live_location_success() {
         let response_string = "{\"ok\":true,\"result\":{\"message_id\":2752,\"from\":{\"id\":1276618370,\"is_bot\":true,\"first_name\":\"test_el_bot\",\"username\":\"el_mon_test_bot\"},\"date\":1618382998,\"chat\":{\"id\":275808073,\"type\":\"private\",\"username\":\"Ayrat555\",\"first_name\":\"Ayrat\",\"last_name\":\"Badykov\"},\"edit_date\":1618383189,\"location\":{\"longitude\":6.96,\"latitude\":49.800009,\"live_period\":300}}}";
-        let params = StopMessageLiveLocationParamsBuilder::default()
+        let params = StopMessageLiveLocationParams::builder()
             .chat_id(275808073)
             .message_id(2752)
-            .build()
-            .unwrap();
+            .build();
 
         let _m = mockito::mock("POST", "/stopMessageLiveLocation")
             .with_status(200)
@@ -562,14 +554,13 @@ mod tests {
     #[test]
     fn send_venue_success() {
         let response_string = "{\"ok\":true,\"result\":{\"message_id\":2754,\"from\":{\"id\":1276618370,\"is_bot\":true,\"first_name\":\"test_el_bot\",\"username\":\"el_mon_test_bot\"},\"date\":1618410490,\"chat\":{\"id\":275808073,\"type\":\"private\",\"username\":\"Ayrat555\",\"first_name\":\"Ayrat\",\"last_name\":\"Badykov\"},\"venue\":{\"location\":{\"longitude\":6.949981,\"latitude\":49.700002},\"title\":\"Meow\",\"address\":\"Hoof\"},\"location\":{\"longitude\":6.949981,\"latitude\":49.700002}}}";
-        let params = SendVenueParamsBuilder::default()
+        let params = SendVenueParams::builder()
             .chat_id(275808073)
             .latitude(49.7)
             .longitude(6.95)
             .title("Meow")
             .address("Hoof")
-            .build()
-            .unwrap();
+            .build();
 
         let _m = mockito::mock("POST", "/sendVenue")
             .with_status(200)
@@ -586,12 +577,11 @@ mod tests {
     #[test]
     fn send_contact_success() {
         let response_string = "{\"ok\":true,\"result\":{\"message_id\":2755,\"from\":{\"id\":1276618370,\"is_bot\":true,\"first_name\":\"test_el_bot\",\"username\":\"el_mon_test_bot\"},\"date\":1618465934,\"chat\":{\"id\":275808073,\"type\":\"private\",\"username\":\"Ayrat555\",\"first_name\":\"Ayrat\",\"last_name\":\"Badykov\"},\"contact\":{\"phone_number\":\"49\",\"first_name\":\"Meow\"}}}";
-        let params = SendContactParamsBuilder::default()
+        let params = SendContactParams::builder()
             .chat_id(275808073)
             .phone_number("49")
             .first_name("Meow")
-            .build()
-            .unwrap();
+            .build();
 
         let _m = mockito::mock("POST", "/sendContact")
             .with_status(200)
@@ -608,12 +598,11 @@ mod tests {
     #[test]
     fn send_poll_success() {
         let response_string = "{\"ok\":true,\"result\":{\"message_id\":2756,\"from\":{\"id\":1276618370,\"is_bot\":true,\"first_name\":\"test_el_bot\",\"username\":\"el_mon_test_bot\"},\"date\":1618466302,\"chat\":{\"id\":275808073,\"type\":\"private\",\"username\":\"Ayrat555\",\"first_name\":\"Ayrat\",\"last_name\":\"Badykov\"},\"poll\":{\"id\":\"5458519832506925078\",\"question\":\"are you?\",\"options\":[{\"text\":\"1\",\"voter_count\":0},{\"text\":\"2\",\"voter_count\":0}],\"total_voter_count\":0,\"is_closed\":false,\"is_anonymous\":true,\"type\":\"regular\",\"allows_multiple_answers\":false}}}";
-        let params = SendPollParamsBuilder::default()
+        let params = SendPollParams::builder()
             .chat_id(275808073)
             .question("are you?")
             .options(vec!["1".to_string(), "2".to_string()])
-            .build()
-            .unwrap();
+            .build();
 
         let _m = mockito::mock("POST", "/sendPoll")
             .with_status(200)
@@ -630,10 +619,7 @@ mod tests {
     #[test]
     fn send_dice_success() {
         let response_string = "{\"ok\":true,\"result\":{\"message_id\":2757,\"from\":{\"id\":1276618370,\"is_bot\":true,\"first_name\":\"test_el_bot\",\"username\":\"el_mon_test_bot\"},\"date\":1618467133,\"chat\":{\"id\":275808073,\"type\":\"private\",\"username\":\"Ayrat555\",\"first_name\":\"Ayrat\",\"last_name\":\"Badykov\"},\"dice\":{\"emoji\":\"🎲\",\"value\":5}}}";
-        let params = SendDiceParamsBuilder::default()
-            .chat_id(275808073)
-            .build()
-            .unwrap();
+        let params = SendDiceParams::builder().chat_id(275808073).build();
 
         let _m = mockito::mock("POST", "/sendDice")
             .with_status(200)
@@ -650,11 +636,10 @@ mod tests {
     #[test]
     fn send_chat_action_success() {
         let response_string = "{\"ok\":true,\"result\":true}";
-        let params = SendChatActionParamsBuilder::default()
+        let params = SendChatActionParams::builder()
             .chat_id(275808073)
             .action(ChatAction::Typing)
-            .build()
-            .unwrap();
+            .build();
 
         let _m = mockito::mock("POST", "/sendChatAction")
             .with_status(200)
@@ -671,10 +656,9 @@ mod tests {
     #[test]
     fn get_user_profile_photos_success() {
         let response_string = "{\"ok\":true,\"result\":{\"total_count\":3,\"photos\":[[{\"file_id\":\"AgACAgIAAxUAAWB332IlzabFGWzaMrOdQ4ODVLyaAAKypzEbSX9wEEzMxT7F-grc3UA5DwAEAQADAgADYQADg0kCAAEfBA\",\"file_unique_id\":\"AQAD3UA5DwAEg0kCAAE\",\"width\":160,\"height\":160,\"file_size\":8068},{\"file_id\":\"AgACAgIAAxUAAWB332IlzabFGWzaMrOdQ4ODVLyaAAKypzEbSX9wEEzMxT7F-grc3UA5DwAEAQADAgADYgADhEkCAAEfBA\",\"file_unique_id\":\"AQAD3UA5DwAEhEkCAAE\",\"width\":320,\"height\":320,\"file_size\":22765},{\"file_id\":\"AgACAgIAAxUAAWB332IlzabFGWzaMrOdQ4ODVLyaAAKypzEbSX9wEEzMxT7F-grc3UA5DwAEAQADAgADYwADhUkCAAEfBA\",\"file_unique_id\":\"AQAD3UA5DwAEhUkCAAE\",\"width\":640,\"height\":640,\"file_size\":65663}],[{\"file_id\":\"AgACAgIAAxUAAWB332JpnZNv9ZNeZeIt1FFCdOroAAKwpzEbSX9wEOb5okUMX3tVSRdLDQAEAQADAgADYQADZj0KAAEfBA\",\"file_unique_id\":\"AQADSRdLDQAEZj0KAAE\",\"width\":160,\"height\":160,\"file_size\":13459},{\"file_id\":\"AgACAgIAAxUAAWB332JpnZNv9ZNeZeIt1FFCdOroAAKwpzEbSX9wEOb5okUMX3tVSRdLDQAEAQADAgADYgADZz0KAAEfBA\",\"file_unique_id\":\"AQADSRdLDQAEZz0KAAE\",\"width\":320,\"height\":320,\"file_size\":41243},{\"file_id\":\"AgACAgIAAxUAAWB332JpnZNv9ZNeZeIt1FFCdOroAAKwpzEbSX9wEOb5okUMX3tVSRdLDQAEAQADAgADYwADaD0KAAEfBA\",\"file_unique_id\":\"AQADSRdLDQAEaD0KAAE\",\"width\":640,\"height\":640,\"file_size\":114427}],[{\"file_id\":\"AgACAgIAAxUAAWB332ISVowq4pXLx3y1o-7WQteeAAKvpzEbSX9wEBlOkdDjqlYW1Du3DQAEAQADAgADYQADdkwAAh8E\",\"file_unique_id\":\"AQAD1Du3DQAEdkwAAg\",\"width\":160,\"height\":160,\"file_size\":6631},{\"file_id\":\"AgACAgIAAxUAAWB332ISVowq4pXLx3y1o-7WQteeAAKvpzEbSX9wEBlOkdDjqlYW1Du3DQAEAQADAgADYgADd0wAAh8E\",\"file_unique_id\":\"AQAD1Du3DQAEd0wAAg\",\"width\":320,\"height\":320,\"file_size\":20495},{\"file_id\":\"AgACAgIAAxUAAWB332ISVowq4pXLx3y1o-7WQteeAAKvpzEbSX9wEBlOkdDjqlYW1Du3DQAEAQADAgADYwADeEwAAh8E\",\"file_unique_id\":\"AQAD1Du3DQAEeEwAAg\",\"width\":640,\"height\":640,\"file_size\":54395}]]}}";
-        let params = GetUserProfilePhotosParamsBuilder::default()
+        let params = GetUserProfilePhotosParams::builder()
             .user_id(275808073_u64)
-            .build()
-            .unwrap();
+            .build();
 
         let _m = mockito::mock("POST", "/getUserProfilePhotos")
             .with_status(200)
@@ -691,10 +675,9 @@ mod tests {
     #[test]
     fn get_file_success() {
         let response_string = "{\"ok\":true,\"result\":{\"file_id\":\"AgACAgIAAxUAAWB332IlzabFGWzaMrOdQ4ODVLyaAAKypzEbSX9wEEzMxT7F-grc3UA5DwAEAQADAgADYQADg0kCAAEfBA\",\"file_unique_id\":\"AQAD3UA5DwAEg0kCAAE\",\"file_size\":8068,\"file_path\":\"photos/file_0.jpg\"}}";
-        let  params = GetFileParamsBuilder::default()
+        let  params = GetFileParams::builder()
             .file_id("AgACAgIAAxUAAWB332IlzabFGWzaMrOdQ4ODVLyaAAKypzEbSX9wEEzMxT7F-grc3UA5DwAEAQADAgADYQADg0kCAAEfBA")
-            .build()
-            .unwrap();
+            .build();
 
         let _m = mockito::mock("POST", "/getFile")
             .with_status(200)
@@ -711,11 +694,10 @@ mod tests {
     #[test]
     fn ban_chat_member_success() {
         let response_string = "{\"ok\":true,\"result\":true}";
-        let params = BanChatMemberParamsBuilder::default()
+        let params = BanChatMemberParams::builder()
             .chat_id(-1001368460856)
             .user_id(275808073_u64)
-            .build()
-            .unwrap();
+            .build();
 
         let _m = mockito::mock("POST", "/banChatMember")
             .with_status(200)
@@ -732,11 +714,10 @@ mod tests {
     #[test]
     fn unban_chat_member_success() {
         let response_string = "{\"ok\":true,\"result\":true}";
-        let params = UnbanChatMemberParamsBuilder::default()
+        let params = UnbanChatMemberParams::builder()
             .chat_id(-1001368460856)
             .user_id(275808072_u64)
-            .build()
-            .unwrap();
+            .build();
 
         let _m = mockito::mock("POST", "/unbanChatMember")
             .with_status(200)
@@ -753,17 +734,15 @@ mod tests {
     #[test]
     fn restrict_chat_member_success() {
         let response_string = "{\"ok\":true,\"result\":true}";
-        let perm = ChatPermissionsBuilder::default()
+        let perm = ChatPermissions::builder()
             .can_add_web_page_previews(true)
-            .build()
-            .unwrap();
+            .build();
 
-        let params = RestrictChatMemberParamsBuilder::default()
+        let params = RestrictChatMemberParams::builder()
             .chat_id(-1001368460856)
             .user_id(275808073_u64)
             .permissions(perm)
-            .build()
-            .unwrap();
+            .build();
 
         let _m = mockito::mock("POST", "/restrictChatMember")
             .with_status(200)
@@ -780,12 +759,11 @@ mod tests {
     #[test]
     fn promote_chat_member_success() {
         let response_string = "{\"ok\":true,\"result\":true}";
-        let params = PromoteChatMemberParamsBuilder::default()
+        let params = PromoteChatMemberParams::builder()
             .chat_id(-1001368460856)
             .user_id(275808073_u64)
             .can_change_info(true)
-            .build()
-            .unwrap();
+            .build();
 
         let _m = mockito::mock("POST", "/promoteChatMember")
             .with_status(200)
@@ -802,12 +780,11 @@ mod tests {
     #[test]
     fn set_chat_administrator_custom_title_success() {
         let response_string = "{\"ok\":true,\"result\":true}";
-        let params = SetChatAdministratorCustomTitleParamsBuilder::default()
+        let params = SetChatAdministratorCustomTitleParams::builder()
             .chat_id(-1001368460856)
             .user_id(275808073_u64)
             .custom_title("King")
-            .build()
-            .unwrap();
+            .build();
 
         let _m = mockito::mock("POST", "/setChatAdministratorCustomTitle")
             .with_status(200)
@@ -824,16 +801,14 @@ mod tests {
     #[test]
     fn set_chat_permissions_success() {
         let response_string = "{\"ok\":true,\"result\":true}";
-        let perm = ChatPermissionsBuilder::default()
+        let perm = ChatPermissions::builder()
             .can_add_web_page_previews(true)
-            .build()
-            .unwrap();
+            .build();
 
-        let params = SetChatPermissionsParamsBuilder::default()
+        let params = SetChatPermissionsParams::builder()
             .chat_id(-1001368460856)
             .permissions(perm)
-            .build()
-            .unwrap();
+            .build();
 
         let _m = mockito::mock("POST", "/setChatPermissions")
             .with_status(200)
@@ -851,10 +826,9 @@ mod tests {
     fn export_chat_invite_link_success() {
         let response_string = "{\"ok\":true,\"result\":\"https://t.me/joinchat/txIUDwjfk7M2ODEy\"}";
 
-        let params = ExportChatInviteLinkParamsBuilder::default()
+        let params = ExportChatInviteLinkParams::builder()
             .chat_id(-1001368460856)
-            .build()
-            .unwrap();
+            .build();
 
         let _m = mockito::mock("POST", "/exportChatInviteLink")
             .with_status(200)
@@ -872,10 +846,9 @@ mod tests {
     fn create_chat_invite_link_success() {
         let response_string = "{\"ok\":true,\"result\":{\"invite_link\":\"https://t.me/joinchat/yFEnSaeiQm83ZTNi\",\"creator\":{\"id\":1276618370,\"is_bot\":true,\"first_name\":\"test_el_bot\",\"username\":\"el_mon_test_bot\"},\"creates_join_request\":false,\"is_primary\":false,\"is_revoked\":false}}";
 
-        let params = CreateChatInviteLinkParamsBuilder::default()
+        let params = CreateChatInviteLinkParams::builder()
             .chat_id(-1001368460856)
-            .build()
-            .unwrap();
+            .build();
 
         let _m = mockito::mock("POST", "/createChatInviteLink")
             .with_status(200)
@@ -893,11 +866,10 @@ mod tests {
     fn edit_chat_invite_link_success() {
         let response_string = "{\"ok\":true,\"result\":{\"invite_link\":\"https://t.me/joinchat/O458bA8hQ0MzNmQy\",\"creator\":{\"id\":1276618370,\"is_bot\":true,\"first_name\":\"test_el_bot\",\"username\":\"el_mon_test_bot\"},\"creates_join_request\":false,\"is_primary\":false,\"is_revoked\":false}}";
 
-        let params = EditChatInviteLinkParamsBuilder::default()
+        let params = EditChatInviteLinkParams::builder()
             .chat_id(-1001368460856)
             .invite_link("https://t.me/joinchat/O458bA8hQ0MzNmQy")
-            .build()
-            .unwrap();
+            .build();
 
         let _m = mockito::mock("POST", "/editChatInviteLink")
             .with_status(200)
@@ -915,11 +887,10 @@ mod tests {
     fn revoke_chat_invite_link_success() {
         let response_string = "{\"ok\":true,\"result\":{\"invite_link\":\"https://t.me/joinchat/O458bA8hQ0MzNmQy\",\"creator\":{\"id\":1276618370,\"is_bot\":true,\"first_name\":\"test_el_bot\",\"username\":\"el_mon_test_bot\"},\"creates_join_request\":false,\"is_primary\":false,\"is_revoked\":true}}";
 
-        let params = RevokeChatInviteLinkParamsBuilder::default()
+        let params = RevokeChatInviteLinkParams::builder()
             .chat_id(-1001368460856)
             .invite_link("https://t.me/joinchat/O458bA8hQ0MzNmQy")
-            .build()
-            .unwrap();
+            .build();
 
         let _m = mockito::mock("POST", "/revokeChatInviteLink")
             .with_status(200)
@@ -936,10 +907,9 @@ mod tests {
     #[test]
     fn delete_chat_photo_success() {
         let response_string = "{\"ok\":true,\"result\":true}";
-        let params = DeleteChatPhotoParamsBuilder::default()
+        let params = DeleteChatPhotoParams::builder()
             .chat_id(-1001368460856)
-            .build()
-            .unwrap();
+            .build();
 
         let _m = mockito::mock("POST", "/deleteChatPhoto")
             .with_status(200)
@@ -957,11 +927,10 @@ mod tests {
     fn send_photo_success() {
         let response_string = "{\"ok\":true,\"result\":{\"message_id\":2763,\"from\":{\"id\":1276618370,\"is_bot\":true,\"first_name\":\"test_el_bot\",\"username\":\"el_mon_test_bot\"},\"date\":1618730180,\"chat\":{\"id\":275808073,\"type\":\"private\",\"username\":\"Ayrat555\",\"first_name\":\"Ayrat\",\"last_name\":\"Badykov\"},\"photo\":[{\"file_id\":\"AgACAgIAAxkDAAIKy2B73MQXIhoDDmLXjcUjgqGf-m8bAALjsDEbORLgS-s4BkBzcC5DYvIBny4AAwEAAwIAA20AA0U3AwABHwQ\",\"file_unique_id\":\"AQADYvIBny4AA0U3AwAB\",\"width\":320,\"height\":320,\"file_size\":19968},{\"file_id\":\"AgACAgIAAxkDAAIKy2B73MQXIhoDDmLXjcUjgqGf-m8bAALjsDEbORLgS-s4BkBzcC5DYvIBny4AAwEAAwIAA3gAA0Y3AwABHwQ\",\"file_unique_id\":\"AQADYvIBny4AA0Y3AwAB\",\"width\":799,\"height\":800,\"file_size\":63581},{\"file_id\":\"AgACAgIAAxkDAAIKy2B73MQXIhoDDmLXjcUjgqGf-m8bAALjsDEbORLgS-s4BkBzcC5DYvIBny4AAwEAAwIAA3kAA0M3AwABHwQ\",\"file_unique_id\":\"AQADYvIBny4AA0M3AwAB\",\"width\":847,\"height\":848,\"file_size\":63763}]}}";
         let file = std::path::PathBuf::from("./frankenstein_logo.png");
-        let params = SendPhotoParamsBuilder::default()
+        let params = SendPhotoParams::builder()
             .chat_id(275808073)
             .photo(file)
-            .build()
-            .unwrap();
+            .build();
 
         let _m = mockito::mock("POST", "/sendPhoto")
             .with_status(200)
@@ -979,11 +948,10 @@ mod tests {
     fn send_audio_file_success() {
         let response_string = "{\"ok\":true,\"result\":{\"message_id\":2766,\"from\":{\"id\":1276618370,\"is_bot\":true,\"first_name\":\"test_el_bot\",\"username\":\"el_mon_test_bot\"},\"date\":1618735176,\"chat\":{\"id\":275808073,\"type\":\"private\",\"username\":\"Ayrat555\",\"first_name\":\"Ayrat\",\"last_name\":\"Badykov\"},\"audio\":{\"file_id\":\"CQACAgIAAxkDAAIKzmB78EjK-iOHo-HKC-M6p4r0jGdmAALkDAACORLgS5co1z0uFAKgHwQ\",\"file_unique_id\":\"AgAD5AwAAjkS4Es\",\"duration\":123,\"title\":\"Way Back Home\",\"file_name\":\"audio.mp3\",\"mime_type\":\"audio/mpeg\",\"file_size\":2957092}}}";
         let file = std::path::PathBuf::from("./frankenstein_logo.png");
-        let params = SendAudioParamsBuilder::default()
+        let params = SendAudioParams::builder()
             .chat_id(275808073)
             .audio(file)
-            .build()
-            .unwrap();
+            .build();
         let _m = mockito::mock("POST", "/sendAudio")
             .with_status(200)
             .with_body(response_string)
@@ -1001,12 +969,11 @@ mod tests {
         let response_string = "{\"ok\":true,\"result\":{\"message_id\":2766,\"from\":{\"id\":1276618370,\"is_bot\":true,\"first_name\":\"test_el_bot\",\"username\":\"el_mon_test_bot\"},\"date\":1618735176,\"chat\":{\"id\":275808073,\"type\":\"private\",\"username\":\"Ayrat555\",\"first_name\":\"Ayrat\",\"last_name\":\"Badykov\"},\"audio\":{\"file_id\":\"CQACAgIAAxkDAAIKzmB78EjK-iOHo-HKC-M6p4r0jGdmAALkDAACORLgS5co1z0uFAKgHwQ\",\"file_unique_id\":\"AgAD5AwAAjkS4Es\",\"duration\":123,\"title\":\"Way Back Home\",\"file_name\":\"audio.mp3\",\"mime_type\":\"audio/mpeg\",\"file_size\":2957092}}}";
 
         let file = std::path::PathBuf::from("./frankenstein_logo.png");
-        let params = SendAudioParamsBuilder::default()
+        let params = SendAudioParams::builder()
             .chat_id(275808073)
             .audio(file.clone())
             .thumb(file)
-            .build()
-            .unwrap();
+            .build();
         let _m = mockito::mock("POST", "/sendAudio")
             .with_status(200)
             .with_body(response_string)
@@ -1025,11 +992,10 @@ mod tests {
         let file = File::String(
             "CQACAgIAAxkDAAIKzmB78EjK-iOHo-HKC-M6p4r0jGdmAALkDAACORLgS5co1z0uFAKgHwQ".to_string(),
         );
-        let params = SendAudioParamsBuilder::default()
+        let params = SendAudioParams::builder()
             .chat_id(275808073)
             .audio(file)
-            .build()
-            .unwrap();
+            .build();
 
         let _m = mockito::mock("POST", "/sendAudio")
             .with_status(200)
@@ -1048,11 +1014,10 @@ mod tests {
         let response_string = "{\"ok\":true,\"result\":{\"message_id\":2770,\"from\":{\"id\":1276618370,\"is_bot\":true,\"first_name\":\"test_el_bot\",\"username\":\"el_mon_test_bot\"},\"date\":1618737593,\"chat\":{\"id\":275808073,\"type\":\"private\",\"username\":\"Ayrat555\",\"first_name\":\"Ayrat\",\"last_name\":\"Badykov\"},\"audio\":{\"file_id\":\"CQACAgIAAxkDAAIK0mB7-bnnewABfdaFKK4NzVLQ7BvgCwAC6gwAAjkS4Et_njaNR8IUMB8E\",\"file_unique_id\":\"AgAD6gwAAjkS4Es\",\"duration\":123,\"title\":\"Way Back Home\",\"file_name\":\"audio.mp3\",\"mime_type\":\"audio/mpeg\",\"file_size\":2957092}}}";
 
         let file = std::path::PathBuf::from("./frankenstein_logo.png");
-        let params = SendDocumentParamsBuilder::default()
+        let params = SendDocumentParams::builder()
             .chat_id(275808073)
             .document(file)
-            .build()
-            .unwrap();
+            .build();
 
         let _m = mockito::mock("POST", "/sendDocument")
             .with_status(200)
@@ -1071,11 +1036,10 @@ mod tests {
         let response_string = "{\"ok\":true,\"result\":{\"message_id\":2770,\"from\":{\"id\":1276618370,\"is_bot\":true,\"first_name\":\"test_el_bot\",\"username\":\"el_mon_test_bot\"},\"date\":1618737593,\"chat\":{\"id\":275808073,\"type\":\"private\",\"username\":\"Ayrat555\",\"first_name\":\"Ayrat\",\"last_name\":\"Badykov\"},\"audio\":{\"file_id\":\"CQACAgIAAxkDAAIK0mB7-bnnewABfdaFKK4NzVLQ7BvgCwAC6gwAAjkS4Et_njaNR8IUMB8E\",\"file_unique_id\":\"AgAD6gwAAjkS4Es\",\"duration\":123,\"title\":\"Way Back Home\",\"file_name\":\"audio.mp3\",\"mime_type\":\"audio/mpeg\",\"file_size\":2957092}}}";
 
         let file = std::path::PathBuf::from("./frankenstein_logo.png");
-        let params = SendVideoParamsBuilder::default()
+        let params = SendVideoParams::builder()
             .chat_id(275808073)
             .video(file)
-            .build()
-            .unwrap();
+            .build();
 
         let _m = mockito::mock("POST", "/sendVideo")
             .with_status(200)
@@ -1094,11 +1058,10 @@ mod tests {
         let response_string = "{\"ok\":true,\"result\":{\"message_id\":2770,\"from\":{\"id\":1276618370,\"is_bot\":true,\"first_name\":\"test_el_bot\",\"username\":\"el_mon_test_bot\"},\"date\":1618737593,\"chat\":{\"id\":275808073,\"type\":\"private\",\"username\":\"Ayrat555\",\"first_name\":\"Ayrat\",\"last_name\":\"Badykov\"},\"audio\":{\"file_id\":\"CQACAgIAAxkDAAIK0mB7-bnnewABfdaFKK4NzVLQ7BvgCwAC6gwAAjkS4Et_njaNR8IUMB8E\",\"file_unique_id\":\"AgAD6gwAAjkS4Es\",\"duration\":123,\"title\":\"Way Back Home\",\"file_name\":\"audio.mp3\",\"mime_type\":\"audio/mpeg\",\"file_size\":2957092}}}";
 
         let file = std::path::PathBuf::from("./frankenstein_logo.png");
-        let params = SendAnimationParamsBuilder::default()
+        let params = SendAnimationParams::builder()
             .chat_id(275808073)
             .animation(file)
-            .build()
-            .unwrap();
+            .build();
 
         let _m = mockito::mock("POST", "/sendAnimation")
             .with_status(200)
@@ -1116,11 +1079,10 @@ mod tests {
     fn send_voice_success() {
         let response_string = "{\"ok\":true,\"result\":{\"message_id\":2770,\"from\":{\"id\":1276618370,\"is_bot\":true,\"first_name\":\"test_el_bot\",\"username\":\"el_mon_test_bot\"},\"date\":1618737593,\"chat\":{\"id\":275808073,\"type\":\"private\",\"username\":\"Ayrat555\",\"first_name\":\"Ayrat\",\"last_name\":\"Badykov\"},\"audio\":{\"file_id\":\"CQACAgIAAxkDAAIK0mB7-bnnewABfdaFKK4NzVLQ7BvgCwAC6gwAAjkS4Et_njaNR8IUMB8E\",\"file_unique_id\":\"AgAD6gwAAjkS4Es\",\"duration\":123,\"title\":\"Way Back Home\",\"file_name\":\"audio.mp3\",\"mime_type\":\"audio/mpeg\",\"file_size\":2957092}}}";
         let file = std::path::PathBuf::from("./frankenstein_logo.png");
-        let params = SendVoiceParamsBuilder::default()
+        let params = SendVoiceParams::builder()
             .chat_id(275808073)
             .voice(file)
-            .build()
-            .unwrap();
+            .build();
         let _m = mockito::mock("POST", "/sendVoice")
             .with_status(200)
             .with_body(response_string)
@@ -1137,11 +1099,10 @@ mod tests {
     fn send_video_note_success() {
         let response_string = "{\"ok\":true,\"result\":{\"message_id\":2770,\"from\":{\"id\":1276618370,\"is_bot\":true,\"first_name\":\"test_el_bot\",\"username\":\"el_mon_test_bot\"},\"date\":1618737593,\"chat\":{\"id\":275808073,\"type\":\"private\",\"username\":\"Ayrat555\",\"first_name\":\"Ayrat\",\"last_name\":\"Badykov\"},\"audio\":{\"file_id\":\"CQACAgIAAxkDAAIK0mB7-bnnewABfdaFKK4NzVLQ7BvgCwAC6gwAAjkS4Et_njaNR8IUMB8E\",\"file_unique_id\":\"AgAD6gwAAjkS4Es\",\"duration\":123,\"title\":\"Way Back Home\",\"file_name\":\"audio.mp3\",\"mime_type\":\"audio/mpeg\",\"file_size\":2957092}}}";
         let file = std::path::PathBuf::from("./frankenstein_logo.png");
-        let params = SendVideoNoteParamsBuilder::default()
+        let params = SendVideoNoteParams::builder()
             .chat_id(275808073)
             .video_note(file)
-            .build()
-            .unwrap();
+            .build();
         let _m = mockito::mock("POST", "/sendVideoNote")
             .with_status(200)
             .with_body(response_string)
@@ -1161,11 +1122,10 @@ mod tests {
         let file = InputFile {
             path: std::path::PathBuf::from("./frankenstein_logo.png"),
         };
-        let params = SetChatPhotoParamsBuilder::default()
+        let params = SetChatPhotoParams::builder()
             .chat_id(275808073)
             .photo(file)
-            .build()
-            .unwrap();
+            .build();
         let _m = mockito::mock("POST", "/setChatPhoto")
             .with_status(200)
             .with_body(response_string)
@@ -1181,11 +1141,10 @@ mod tests {
     #[test]
     fn set_chat_title_success() {
         let response_string = "{\"ok\":true,\"result\":true}";
-        let params = SetChatTitleParamsBuilder::default()
+        let params = SetChatTitleParams::builder()
             .chat_id(-1001368460856)
             .title("Frankenstein")
-            .build()
-            .unwrap();
+            .build();
 
         let _m = mockito::mock("POST", "/setChatTitle")
             .with_status(200)
@@ -1202,11 +1161,10 @@ mod tests {
     #[test]
     fn set_chat_description_success() {
         let response_string = "{\"ok\":true,\"result\":true}";
-        let params = SetChatDescriptionParamsBuilder::default()
+        let params = SetChatDescriptionParams::builder()
             .chat_id(-1001368460856)
             .description("Frankenstein group")
-            .build()
-            .unwrap();
+            .build();
 
         let _m = mockito::mock("POST", "/setChatDescription")
             .with_status(200)
@@ -1223,11 +1181,10 @@ mod tests {
     #[test]
     fn pin_chat_message_success() {
         let response_string = "{\"ok\":true,\"result\":true}";
-        let params = PinChatMessageParamsBuilder::default()
+        let params = PinChatMessageParams::builder()
             .chat_id(275808073)
             .message_id(2766)
-            .build()
-            .unwrap();
+            .build();
 
         let _m = mockito::mock("POST", "/pinChatMessage")
             .with_status(200)
@@ -1244,10 +1201,7 @@ mod tests {
     #[test]
     fn unpin_chat_message_success() {
         let response_string = "{\"ok\":true,\"result\":true}";
-        let params = UnpinChatMessageParamsBuilder::default()
-            .chat_id(275808073)
-            .build()
-            .unwrap();
+        let params = UnpinChatMessageParams::builder().chat_id(275808073).build();
 
         let _m = mockito::mock("POST", "/unpinChatMessage")
             .with_status(200)
@@ -1264,10 +1218,7 @@ mod tests {
     #[test]
     fn leave_chat_success() {
         let response_string = "{\"ok\":true,\"result\":true}";
-        let params = LeaveChatParamsBuilder::default()
-            .chat_id(-1001368460856)
-            .build()
-            .unwrap();
+        let params = LeaveChatParams::builder().chat_id(-1001368460856).build();
 
         let _m = mockito::mock("POST", "/leaveChat")
             .with_status(200)
@@ -1284,10 +1235,7 @@ mod tests {
     #[test]
     fn get_chat_success() {
         let response_string = "{\"ok\":true,\"result\":{\"id\":-1001368460856,\"type\":\"supergroup\",\"title\":\"Frankenstein\",\"photo\":{\"small_file_id\":\"AQADAgAT-kgrmy4AAwIAA8jhydkW____s1Cm6Dc_w8Ge7QUAAR8E\",\"small_file_unique_id\":\"AQAD-kgrmy4AA57tBQAB\",\"big_file_id\":\"AQADAgAT-kgrmy4AAwMAA8jhydkW____s1Cm6Dc_w8Gg7QUAAR8E\",\"big_file_unique_id\":\"AQAD-kgrmy4AA6DtBQAB\"},\"description\":\"Frankenstein group\",\"invite_link\":\"https://t.me/joinchat/smSXMzNKTwA0ZjFi\",\"permissions\":{\"can_send_messages\":true,\"can_send_media_messages\":true,\"can_send_polls\":true,\"can_send_other_messages\":true,\"can_add_web_page_previews\":true,\"can_change_info\":true,\"can_invite_users\":true,\"can_pin_messages\":true}}}";
-        let params = GetChatParamsBuilder::default()
-            .chat_id(-1001368460856)
-            .build()
-            .unwrap();
+        let params = GetChatParams::builder().chat_id(-1001368460856).build();
 
         let _m = mockito::mock("POST", "/getChat")
             .with_status(200)
@@ -1304,10 +1252,9 @@ mod tests {
     #[test]
     fn get_chat_administrators_success() {
         let response_string = "{\"ok\":true,\"result\":[{\"status\":\"administrator\",\"user\":{\"id\":1276618370,\"is_bot\":true,\"first_name\":\"test_el_bot\",\"username\":\"el_mon_test_bot\"},\"can_be_edited\":false,\"is_anonymous\":true,\"can_manage_chat\":true,\"can_delete_messages\":true,\"can_manage_voice_chats\":true,\"can_restrict_members\":true,\"can_promote_members\":false,\"can_change_info\":true,\"can_invite_users\":true,\"can_pin_messages\":true},{\"status\":\"creator\",\"user\":{\"id\":275808073,\"is_bot\":false,\"first_name\":\"Ayrat\",\"last_name\":\"Badykov\",\"username\":\"Ayrat555\",\"language_code\":\"en\"},\"is_anonymous\":false}]}";
-        let params = GetChatAdministratorsParamsBuilder::default()
+        let params = GetChatAdministratorsParams::builder()
             .chat_id(-1001368460856)
-            .build()
-            .unwrap();
+            .build();
 
         let _m = mockito::mock("POST", "/getChatAdministrators")
             .with_status(200)
@@ -1324,10 +1271,9 @@ mod tests {
     #[test]
     fn get_chat_members_count_success() {
         let response_string = "{\"ok\":true,\"result\":4}";
-        let params = GetChatMemberCountParamsBuilder::default()
+        let params = GetChatMemberCountParams::builder()
             .chat_id(-1001368460856)
-            .build()
-            .unwrap();
+            .build();
 
         let _m = mockito::mock("POST", "/getChatMemberCount")
             .with_status(200)
@@ -1344,11 +1290,10 @@ mod tests {
     #[test]
     fn get_chat_member_success() {
         let response_string = "{\"ok\":true,\"result\":{\"status\":\"creator\",\"user\":{\"id\":275808073,\"is_bot\":false,\"first_name\":\"Ayrat\",\"last_name\":\"Badykov\",\"username\":\"Ayrat555\",\"language_code\":\"en\"},\"is_anonymous\":false}}";
-        let params = GetChatMemberParamsBuilder::default()
+        let params = GetChatMemberParams::builder()
             .chat_id(-1001368460856)
             .user_id(275808073_u64)
-            .build()
-            .unwrap();
+            .build();
 
         let _m = mockito::mock("POST", "/getChatMember")
             .with_status(200)
@@ -1365,11 +1310,10 @@ mod tests {
     #[test]
     fn set_chat_sticker_set_success() {
         let response_string = "{\"ok\":true,\"result\":true}";
-        let params = SetChatStickerSetParamsBuilder::default()
+        let params = SetChatStickerSetParams::builder()
             .chat_id(-1001368460856)
             .sticker_set_name("GBTDPack")
-            .build()
-            .unwrap();
+            .build();
 
         let _m = mockito::mock("POST", "/setChatStickerSet")
             .with_status(200)
@@ -1386,10 +1330,9 @@ mod tests {
     #[test]
     fn delete_chat_sticker_set_success() {
         let response_string = "{\"ok\":true,\"result\":true}";
-        let params = DeleteChatStickerSetParamsBuilder::default()
+        let params = DeleteChatStickerSetParams::builder()
             .chat_id(-1001368460856)
-            .build()
-            .unwrap();
+            .build();
 
         let _m = mockito::mock("POST", "/deleteChatStickerSet")
             .with_status(200)
@@ -1406,11 +1349,10 @@ mod tests {
     #[test]
     fn answer_callback_query_success() {
         let response_string = "{\"ok\":true,\"result\":true}";
-        let params = AnswerCallbackQueryParamsBuilder::default()
+        let params = AnswerCallbackQueryParams::builder()
             .callback_query_id("id")
             .text("text")
-            .build()
-            .unwrap();
+            .build();
 
         let _m = mockito::mock("POST", "/answerCallbackQuery")
             .with_status(200)
@@ -1427,21 +1369,18 @@ mod tests {
     #[test]
     fn set_my_commands_success() {
         let response_string = "{\"ok\":true,\"result\":true}";
-        let params = SetMyCommandsParamsBuilder::default()
+        let params = SetMyCommandsParams::builder()
             .commands(vec![
-                BotCommandBuilder::default()
+                BotCommand::builder()
                     .command("meow")
                     .description("mewo")
-                    .build()
-                    .unwrap(),
-                BotCommandBuilder::default()
+                    .build(),
+                BotCommand::builder()
                     .command("meow1")
                     .description("mewo1")
-                    .build()
-                    .unwrap(),
+                    .build(),
             ])
-            .build()
-            .unwrap();
+            .build();
 
         let _m = mockito::mock("POST", "/setMyCommands")
             .with_status(200)
@@ -1458,22 +1397,19 @@ mod tests {
     #[test]
     fn set_my_commands_default_scope_success() {
         let response_string = "{\"ok\":true,\"result\":true}";
-        let params = SetMyCommandsParamsBuilder::default()
+        let params = SetMyCommandsParams::builder()
             .commands(vec![
-                BotCommandBuilder::default()
+                BotCommand::builder()
                     .command("meow")
                     .description("mewo")
-                    .build()
-                    .unwrap(),
-                BotCommandBuilder::default()
+                    .build(),
+                BotCommand::builder()
                     .command("meow1")
                     .description("mewo1")
-                    .build()
-                    .unwrap(),
+                    .build(),
             ])
             .scope(BotCommandScope::Default)
-            .build()
-            .unwrap();
+            .build();
 
         let _m = mockito::mock("POST", "/setMyCommands")
             .with_status(200)
@@ -1493,11 +1429,10 @@ mod tests {
         let scope = BotCommandScope::Chat(BotCommandScopeChat {
             chat_id: ChatId::Integer(275808073),
         });
-        let params = DeleteMyCommandsParamsBuilder::default()
+        let params = DeleteMyCommandsParams::builder()
             .scope(scope)
             .language_code("es")
-            .build()
-            .unwrap();
+            .build();
 
         let _m = mockito::mock("POST", "/deleteMyCommands")
             .with_status(200)
@@ -1515,7 +1450,7 @@ mod tests {
     fn get_my_commands_success() {
         let response_string = "{\"ok\":true,\"result\":[{\"command\":\"meow\",\"description\":\"mewo\"},{\"command\":\"meow1\",\"description\":\"mewo1\"}]}";
 
-        let params = GetMyCommandsParamsBuilder::default().build().unwrap();
+        let params = GetMyCommandsParams::builder().build();
         let _m = mockito::mock("POST", "/getMyCommands")
             .with_status(200)
             .with_body(response_string)
@@ -1535,10 +1470,7 @@ mod tests {
         let scope = BotCommandScope::Chat(BotCommandScopeChat {
             chat_id: ChatId::Integer(275808073),
         });
-        let params = GetMyCommandsParamsBuilder::default()
-            .scope(scope)
-            .build()
-            .unwrap();
+        let params = GetMyCommandsParams::builder().scope(scope).build();
 
         let _m = mockito::mock("POST", "/getMyCommands")
             .with_status(200)
@@ -1557,21 +1489,19 @@ mod tests {
         let response_string = "{\"ok\":true,\"result\":true}";
 
         let venue_result = InlineQueryResult::Venue(
-            InlineQueryResultVenueBuilder::default()
+            InlineQueryResultVenue::builder()
                 .id("hey9sdfasdflasdfadsfasd")
                 .latitude(40.0)
                 .longitude(40.0)
                 .title("title")
                 .address("address")
-                .build()
-                .unwrap(),
+                .build(),
         );
 
-        let params = AnswerInlineQueryParamsBuilder::default()
+        let params = AnswerInlineQueryParams::builder()
             .inline_query_id("inline_query.id()")
             .results(vec![venue_result])
-            .build()
-            .unwrap();
+            .build();
 
         let _m = mockito::mock("POST", "/answerInlineQuery")
             .with_status(200)
@@ -1590,12 +1520,11 @@ mod tests {
     fn edit_message_text_success() {
         let response_string = "{\"ok\":true,\"result\":{\"message_id\":2782,\"from\":{\"id\":1276618370,\"is_bot\":true,\"first_name\":\"test_el_bot\",\"username\":\"el_mon_test_bot\"},\"date\":1619158127,\"chat\":{\"id\":275808073,\"type\":\"private\",\"username\":\"Ayrat555\",\"first_name\":\"Ayrat\",\"last_name\":\"Badykov\"},\"edit_date\":1619158446,\"text\":\"Hi!!\"}}";
 
-        let params = EditMessageTextParamsBuilder::default()
+        let params = EditMessageTextParams::builder()
             .text("Hi!!")
             .chat_id(275808073)
             .message_id(2782)
-            .build()
-            .unwrap();
+            .build();
 
         let _m = mockito::mock("POST", "/editMessageText")
             .with_status(200)
@@ -1613,12 +1542,11 @@ mod tests {
     fn edit_message_caption_success() {
         let response_string = "{\"ok\":true,\"result\":{\"message_id\":2784,\"from\":{\"id\":1276618370,\"is_bot\":true,\"first_name\":\"test_el_bot\",\"username\":\"el_mon_test_bot\"},\"date\":1619159414,\"chat\":{\"id\":275808073,\"type\":\"private\",\"username\":\"Ayrat555\",\"first_name\":\"Ayrat\",\"last_name\":\"Badykov\"},\"edit_date\":1619159461,\"photo\":[{\"file_id\":\"AgACAgIAAxkDAAIK4GCCaaWDayYgzQ-BykVy8LYkW0wzAAL-rzEbRx8RSCnCkWjXtdN9ZNLmny4AAwEAAwIAA20AA1hCAAIfBA\",\"file_unique_id\":\"AQADZNLmny4AA1hCAAI\",\"width\":320,\"height\":320,\"file_size\":19162},{\"file_id\":\"AgACAgIAAxkDAAIK4GCCaaWDayYgzQ-BykVy8LYkW0wzAAL-rzEbRx8RSCnCkWjXtdN9ZNLmny4AAwEAAwIAA3gAA1lCAAIfBA\",\"file_unique_id\":\"AQADZNLmny4AA1lCAAI\",\"width\":800,\"height\":800,\"file_size\":65697},{\"file_id\":\"AgACAgIAAxkDAAIK4GCCaaWDayYgzQ-BykVy8LYkW0wzAAL-rzEbRx8RSCnCkWjXtdN9ZNLmny4AAwEAAwIAA3kAA1pCAAIfBA\",\"file_unique_id\":\"AQADZNLmny4AA1pCAAI\",\"width\":1146,\"height\":1146,\"file_size\":101324}],\"caption\":\"Caption\"}}";
 
-        let params = EditMessageCaptionParamsBuilder::default()
+        let params = EditMessageCaptionParams::builder()
             .chat_id(275808073)
             .message_id(2784)
             .caption("Caption")
-            .build()
-            .unwrap();
+            .build();
 
         let _m = mockito::mock("POST", "/editMessageCaption")
             .with_status(200)
@@ -1636,11 +1564,10 @@ mod tests {
     fn stop_poll_success() {
         let response_string = "{\"ok\":true,\"result\":{\"id\":\"5195109123171024927\",\"question\":\"are you?\",\"options\":[{\"text\":\"1\",\"voter_count\":1},{\"text\":\"2\",\"voter_count\":0}],\"total_voter_count\":1,\"is_closed\":true,\"is_anonymous\":true,\"type\":\"regular\",\"allows_multiple_answers\":false}}";
 
-        let params = StopPollParamsBuilder::default()
+        let params = StopPollParams::builder()
             .chat_id(-1001368460856)
             .message_id(495)
-            .build()
-            .unwrap();
+            .build();
 
         let _m = mockito::mock("POST", "/stopPoll")
             .with_status(200)
@@ -1658,11 +1585,10 @@ mod tests {
     fn delete_message_success() {
         let response_string = "{\"ok\":true,\"result\":true}";
 
-        let params = DeleteMessageParamsBuilder::default()
+        let params = DeleteMessageParams::builder()
             .chat_id(275808073)
             .message_id(2784)
-            .build()
-            .unwrap();
+            .build();
 
         let _m = mockito::mock("POST", "/deleteMessage")
             .with_status(200)
@@ -1681,11 +1607,10 @@ mod tests {
         let response_string = "{\"ok\":true,\"result\":{\"message_id\":2788,\"from\":{\"id\":1276618370,\"is_bot\":true,\"first_name\":\"test_el_bot\",\"username\":\"el_mon_test_bot\"},\"date\":1619245784,\"chat\":{\"id\":275808073,\"type\":\"private\",\"username\":\"Ayrat555\",\"first_name\":\"Ayrat\",\"last_name\":\"Badykov\"},\"sticker\":{\"file_id\":\"CAACAgIAAxkDAAIK5GCDutgNxc07rqqtjkGWrGskbHfQAAIMEAACRx8ZSKJ6Z5GkdVHcHwQ\",\"file_unique_id\":\"AgADDBAAAkcfGUg\",\"width\":512,\"height\":512,\"is_animated\":false,\"is_video\":false,\"thumb\":{\"file_id\":\"AAMCAgADGQMAAgrkYIO62A3FzTuuqq2OQZasayRsd9AAAgwQAAJHHxlIonpnkaR1Udz29bujLgADAQAHbQADzR4AAh8E\",\"file_unique_id\":\"AQAD9vW7oy4AA80eAAI\",\"width\":320,\"height\":320,\"file_size\":19264},\"file_size\":36596}}}";
 
         let file = std::path::PathBuf::from("./frankenstein_logo.png");
-        let params = SendStickerParamsBuilder::default()
+        let params = SendStickerParams::builder()
             .chat_id(275808073)
             .sticker(file)
-            .build()
-            .unwrap();
+            .build();
 
         let _m = mockito::mock("POST", "/sendSticker")
             .with_status(200)
@@ -1702,10 +1627,7 @@ mod tests {
     #[test]
     fn get_sticker_set_success() {
         let response_string = "{\"ok\":true,\"result\":{\"name\":\"unocards\",\"title\":\"UNO Bot\",\"is_animated\":false,\"is_video\":false,\"contains_masks\":false,\"stickers\":[{\"file_id\":\"CAACAgQAAxUAAWCDxAQVJ6X7FGiBD5NyjN5DDvgfAALZAQACX1eZAAEqnpNt3SpG_x8E\",\"file_unique_id\":\"AgAD2QEAAl9XmQAB\",\"width\":342,\"height\":512,\"is_animated\":false,\"is_video\":false,\"thumb\":{\"file_id\":\"AAMCBAADFQABYIPEBBUnpfsUaIEPk3KM3kMO-B8AAtkBAAJfV5kAASqek23dKkb_P75BGQAEAQAHbQADBBEAAh8E\",\"file_unique_id\":\"AQADP75BGQAEBBEAAg\",\"width\":85,\"height\":128,\"file_size\":2452},\"emoji\":\"dd\",\"set_name\":\"unocards\",\"file_size\":8898}]}}";
-        let params = GetStickerSetParamsBuilder::default()
-            .name("unocards")
-            .build()
-            .unwrap();
+        let params = GetStickerSetParams::builder().name("unocards").build();
         let _m = mockito::mock("POST", "/getStickerSet")
             .with_status(200)
             .with_body(response_string)
@@ -1724,17 +1646,13 @@ mod tests {
 
         let file = std::path::PathBuf::from("./frankenstein_logo.png");
 
-        let photo = InputMediaPhotoBuilder::default()
-            .media(file)
-            .build()
-            .unwrap();
+        let photo = InputMediaPhoto::builder().media(file).build();
         let medias = vec![Media::Photo(photo.clone()), Media::Photo(photo)];
 
-        let params = SendMediaGroupParamsBuilder::default()
+        let params = SendMediaGroupParams::builder()
             .chat_id(-1001368460856)
             .media(medias)
-            .build()
-            .unwrap();
+            .build();
 
         let _m = mockito::mock("POST", "/sendMediaGroup")
             .with_status(200)
@@ -1754,17 +1672,13 @@ mod tests {
 
         let file = std::path::PathBuf::from("./frankenstein_logo.png");
 
-        let params = EditMessageMediaParamsBuilder::default()
+        let params = EditMessageMediaParams::builder()
             .media(InputMedia::Photo(
-                InputMediaPhotoBuilder::default()
-                    .media(file)
-                    .build()
-                    .unwrap(),
+                InputMediaPhoto::builder().media(file).build(),
             ))
             .chat_id(-1001368460856)
             .message_id(513)
-            .build()
-            .unwrap();
+            .build();
 
         let _m = mockito::mock("POST", "/editMessageMedia")
             .with_status(200)
@@ -1781,10 +1695,9 @@ mod tests {
     #[test]
     fn returns_decode_error_if_response_can_not_be_decoded() {
         let response_string = "{hey this json is invalid}";
-        let params = GetUpdatesParamsBuilder::default()
+        let params = GetUpdatesParams::builder()
             .allowed_updates(vec!["message".to_string()])
-            .build()
-            .unwrap();
+            .build();
 
         let _m = mockito::mock("POST", "/getUpdates")
             .with_status(200)

--- a/src/api_params.rs
+++ b/src/api_params.rs
@@ -14,10 +14,10 @@ use crate::objects::{
     ShippingOption,
 };
 use crate::ParseMode;
-use derive_builder::Builder;
 use serde::Deserialize;
 use serde::Serialize;
 use std::path::PathBuf;
+use typed_builder::TypedBuilder as Builder;
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 #[serde(untagged)]
@@ -206,555 +206,562 @@ pub enum BotCommandScope {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct BotCommandScopeChat {
+    #[builder(setter(into))]
     pub chat_id: ChatId,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct BotCommandScopeChatAdministrators {
+    #[builder(setter(into))]
     pub chat_id: ChatId,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct BotCommandScopeChatMember {
+    #[builder(setter(into))]
     pub chat_id: ChatId,
     pub user_id: u64,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct InputFile {
     pub path: PathBuf,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct GetUpdatesParams {
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub offset: Option<u32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub limit: Option<u32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub timeout: Option<u32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub allowed_updates: Option<Vec<String>>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct SetWebhookParams {
+    #[builder(setter(into))]
     pub url: String,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub certificate: Option<InputFile>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub ip_address: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub max_connections: Option<u32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub allowed_updates: Option<Vec<String>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub drop_pending_updates: Option<bool>,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Builder)]
-#[builder(setter(into))]
 pub struct DeleteWebhookParams {
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub drop_pending_updates: Option<bool>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct SendMessageParams {
+    #[builder(setter(into))]
     pub chat_id: ChatId,
 
+    #[builder(setter(into))]
     pub text: String,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub parse_mode: Option<ParseMode>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub entities: Option<Vec<MessageEntity>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub disable_web_page_preview: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub disable_notification: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub protect_content: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub reply_to_message_id: Option<i32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub allow_sending_without_reply: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub reply_markup: Option<ReplyMarkup>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct ForwardMessageParams {
+    #[builder(setter(into))]
     pub chat_id: ChatId,
 
+    #[builder(setter(into))]
     pub from_chat_id: ChatId,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub disable_notification: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub protect_content: Option<bool>,
 
     pub message_id: i32,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct CopyMessageParams {
+    #[builder(setter(into))]
     pub chat_id: ChatId,
 
+    #[builder(setter(into))]
     pub from_chat_id: ChatId,
 
     pub message_id: i32,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub caption: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub parse_mode: Option<ParseMode>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub caption_entities: Option<Vec<MessageEntity>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub disable_notification: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub protect_content: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub reply_to_message_id: Option<i32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub allow_sending_without_reply: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub reply_markup: Option<ReplyMarkup>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct SendPhotoParams {
+    #[builder(setter(into))]
     pub chat_id: ChatId,
 
+    #[builder(setter(into))]
     pub photo: File,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub caption: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub parse_mode: Option<ParseMode>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub caption_entities: Option<Vec<MessageEntity>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub disable_notification: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub protect_content: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub reply_to_message_id: Option<i32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub allow_sending_without_reply: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub reply_markup: Option<ReplyMarkup>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct SendAudioParams {
+    #[builder(setter(into))]
     pub chat_id: ChatId,
 
+    #[builder(setter(into))]
     pub audio: File,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub caption: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub parse_mode: Option<ParseMode>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub caption_entities: Option<Vec<MessageEntity>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub duration: Option<u32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub performer: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub title: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub thumb: Option<File>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub disable_notification: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub protect_content: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub reply_to_message_id: Option<i32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub allow_sending_without_reply: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub reply_markup: Option<ReplyMarkup>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct SendDocumentParams {
+    #[builder(setter(into))]
     pub chat_id: ChatId,
 
+    #[builder(setter(into))]
     pub document: File,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub thumb: Option<File>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub caption: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub parse_mode: Option<ParseMode>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub caption_entities: Option<Vec<MessageEntity>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub disable_content_type_detection: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub disable_notification: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub protect_content: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub reply_to_message_id: Option<i32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub allow_sending_without_reply: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub reply_markup: Option<ReplyMarkup>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct SendVideoParams {
+    #[builder(setter(into))]
     pub chat_id: ChatId,
 
+    #[builder(setter(into))]
     pub video: File,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub duration: Option<u32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub width: Option<u32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub height: Option<u32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub thumb: Option<File>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub caption: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub parse_mode: Option<ParseMode>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub caption_entities: Option<Vec<MessageEntity>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub supports_streaming: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub disable_notification: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub protect_content: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub reply_to_message_id: Option<i32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub allow_sending_without_reply: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub reply_markup: Option<ReplyMarkup>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct SendAnimationParams {
+    #[builder(setter(into))]
     pub chat_id: ChatId,
 
+    #[builder(setter(into))]
     pub animation: File,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub duration: Option<u32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub width: Option<u32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub height: Option<u32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub thumb: Option<File>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub caption: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub parse_mode: Option<ParseMode>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub caption_entities: Option<Vec<MessageEntity>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub disable_notification: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub protect_content: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub reply_to_message_id: Option<i32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub allow_sending_without_reply: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub reply_markup: Option<ReplyMarkup>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct SendVoiceParams {
+    #[builder(setter(into))]
     pub chat_id: ChatId,
 
+    #[builder(setter(into))]
     pub voice: File,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub caption: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub parse_mode: Option<ParseMode>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub caption_entities: Option<Vec<MessageEntity>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub duration: Option<u32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub disable_notification: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub protect_content: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub reply_to_message_id: Option<i32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub allow_sending_without_reply: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub reply_markup: Option<ReplyMarkup>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct SendVideoNoteParams {
+    #[builder(setter(into))]
     pub chat_id: ChatId,
 
+    #[builder(setter(into))]
     pub video_note: File,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub duration: Option<u32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub length: Option<u32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub thumb: Option<File>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub disable_notification: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub protect_content: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub reply_to_message_id: Option<i32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub allow_sending_without_reply: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub reply_markup: Option<ReplyMarkup>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct SendMediaGroupParams {
+    #[builder(setter(into))]
     pub chat_id: ChatId,
 
     pub media: Vec<Media>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub disable_notification: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub protect_content: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub reply_to_message_id: Option<i32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub allow_sending_without_reply: Option<bool>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct SendLocationParams {
+    #[builder(setter(into))]
     pub chat_id: ChatId,
 
     pub latitude: f64,
@@ -762,55 +769,54 @@ pub struct SendLocationParams {
     pub longitude: f64,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub horizontal_accuracy: Option<f64>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub live_period: Option<u32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub heading: Option<u16>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub proximity_alert_radius: Option<u32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub disable_notification: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub protect_content: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub reply_to_message_id: Option<i32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub allow_sending_without_reply: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub reply_markup: Option<ReplyMarkup>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct EditMessageLiveLocationParams {
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub chat_id: Option<ChatId>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub message_id: Option<i32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub inline_message_id: Option<String>,
 
     pub latitude: f64,
@@ -818,289 +824,292 @@ pub struct EditMessageLiveLocationParams {
     pub longitude: f64,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub horizontal_accuracy: Option<f64>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub heading: Option<u16>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub proximity_alert_radius: Option<u32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub reply_markup: Option<InlineKeyboardMarkup>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct StopMessageLiveLocationParams {
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub chat_id: Option<ChatId>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub message_id: Option<i32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub inline_message_id: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub reply_markup: Option<InlineKeyboardMarkup>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct SendVenueParams {
+    #[builder(setter(into))]
     pub chat_id: ChatId,
 
     pub latitude: f64,
 
     pub longitude: f64,
 
+    #[builder(setter(into))]
     pub title: String,
 
+    #[builder(setter(into))]
     pub address: String,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub foursquare_id: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub foursquare_type: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub google_place_id: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub google_place_type: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub disable_notification: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub protect_content: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub reply_to_message_id: Option<i32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub allow_sending_without_reply: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub reply_markup: Option<ReplyMarkup>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct SendContactParams {
+    #[builder(setter(into))]
     pub chat_id: ChatId,
 
+    #[builder(setter(into))]
     pub phone_number: String,
 
+    #[builder(setter(into))]
     pub first_name: String,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub last_name: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub vcard: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub disable_notification: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub protect_content: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub reply_to_message_id: Option<i32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub allow_sending_without_reply: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub reply_markup: Option<ReplyMarkup>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct SendPollParams {
+    #[builder(setter(into))]
     pub chat_id: ChatId,
 
+    #[builder(setter(into))]
     pub question: String,
 
     pub options: Vec<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub is_anonymous: Option<bool>,
     #[serde(rename = "type")]
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub type_field: Option<PollType>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub allows_multiple_answers: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub correct_option_id: Option<u8>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub explanation: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub explanation_parse_mode: Option<ParseMode>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub explanation_entities: Option<Vec<MessageEntity>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub open_period: Option<u32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub close_date: Option<u64>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub is_closed: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub disable_notification: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub protect_content: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub reply_to_message_id: Option<i32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub allow_sending_without_reply: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub reply_markup: Option<ReplyMarkup>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct SendDiceParams {
+    #[builder(setter(into))]
     pub chat_id: ChatId,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub emoji: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub disable_notification: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub protect_content: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub reply_to_message_id: Option<i32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub allow_sending_without_reply: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub reply_markup: Option<ReplyMarkup>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct SendChatActionParams {
+    #[builder(setter(into))]
     pub chat_id: ChatId,
 
     pub action: ChatAction,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Builder)]
-#[builder(setter(into))]
 pub struct GetUserProfilePhotosParams {
     pub user_id: u64,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub offset: Option<u32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub limit: Option<u32>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct GetFileParams {
+    #[builder(setter(into))]
     pub file_id: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct BanChatMemberParams {
+    #[builder(setter(into))]
     pub chat_id: ChatId,
 
     pub user_id: u64,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub until_date: Option<u64>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub revoke_messages: Option<bool>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct UnbanChatMemberParams {
+    #[builder(setter(into))]
     pub chat_id: ChatId,
 
     pub user_id: u64,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub only_if_banned: Option<bool>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct RestrictChatMemberParams {
+    #[builder(setter(into))]
     pub chat_id: ChatId,
 
     pub user_id: u64,
@@ -1108,502 +1117,502 @@ pub struct RestrictChatMemberParams {
     pub permissions: ChatPermissions,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub until_date: Option<u64>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct PromoteChatMemberParams {
+    #[builder(setter(into))]
     pub chat_id: ChatId,
 
     pub user_id: u64,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub is_anonymous: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub can_manage_chat: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub can_post_messages: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub can_edit_messages: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub can_delete_messages: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub can_manage_voice_chats: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub can_restrict_members: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub can_promote_members: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub can_change_info: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub can_invite_users: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub can_pin_messages: Option<bool>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct SetChatAdministratorCustomTitleParams {
+    #[builder(setter(into))]
     pub chat_id: ChatId,
 
     pub user_id: u64,
 
+    #[builder(setter(into))]
     pub custom_title: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct BanChatSenderChatParams {
+    #[builder(setter(into))]
     pub chat_id: ChatId,
 
     pub sender_chat_id: i64,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct UnbanChatSenderChatParams {
+    #[builder(setter(into))]
     pub chat_id: ChatId,
 
     pub sender_chat_id: i64,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct SetChatPermissionsParams {
+    #[builder(setter(into))]
     pub chat_id: ChatId,
 
     pub permissions: ChatPermissions,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct ExportChatInviteLinkParams {
+    #[builder(setter(into))]
     pub chat_id: ChatId,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct CreateChatInviteLinkParams {
+    #[builder(setter(into))]
     pub chat_id: ChatId,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub name: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub expire_date: Option<u64>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub member_limit: Option<u32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub creates_join_request: Option<bool>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct EditChatInviteLinkParams {
+    #[builder(setter(into))]
     pub chat_id: ChatId,
 
+    #[builder(setter(into))]
     pub invite_link: String,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub name: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub expire_date: Option<u64>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub member_limit: Option<u32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub creates_join_request: Option<bool>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct RevokeChatInviteLinkParams {
+    #[builder(setter(into))]
     pub chat_id: ChatId,
 
+    #[builder(setter(into))]
     pub invite_link: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct ApproveChatJoinRequestParams {
+    #[builder(setter(into))]
     pub chat_id: ChatId,
 
     pub user_id: u64,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct DeclineChatJoinRequestParams {
+    #[builder(setter(into))]
     pub chat_id: ChatId,
 
     pub user_id: u64,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct SetChatPhotoParams {
+    #[builder(setter(into))]
     pub chat_id: ChatId,
 
     pub photo: InputFile,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct DeleteChatPhotoParams {
+    #[builder(setter(into))]
     pub chat_id: ChatId,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct SetChatTitleParams {
+    #[builder(setter(into))]
     pub chat_id: ChatId,
 
+    #[builder(setter(into))]
     pub title: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct SetChatDescriptionParams {
+    #[builder(setter(into))]
     pub chat_id: ChatId,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub description: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct PinChatMessageParams {
+    #[builder(setter(into))]
     pub chat_id: ChatId,
 
     pub message_id: i32,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub disable_notification: Option<bool>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct UnpinChatMessageParams {
+    #[builder(setter(into))]
     pub chat_id: ChatId,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub message_id: Option<i32>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct UnpinAllChatMessagesParams {
+    #[builder(setter(into))]
     pub chat_id: ChatId,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct LeaveChatParams {
+    #[builder(setter(into))]
     pub chat_id: ChatId,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct GetChatParams {
+    #[builder(setter(into))]
     pub chat_id: ChatId,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct GetChatAdministratorsParams {
+    #[builder(setter(into))]
     pub chat_id: ChatId,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct GetChatMemberCountParams {
+    #[builder(setter(into))]
     pub chat_id: ChatId,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct GetChatMemberParams {
+    #[builder(setter(into))]
     pub chat_id: ChatId,
 
     pub user_id: u64,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct SetChatStickerSetParams {
+    #[builder(setter(into))]
     pub chat_id: ChatId,
 
+    #[builder(setter(into))]
     pub sticker_set_name: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct DeleteChatStickerSetParams {
+    #[builder(setter(into))]
     pub chat_id: ChatId,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct AnswerCallbackQueryParams {
+    #[builder(setter(into))]
     pub callback_query_id: String,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub text: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub show_alert: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub url: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub cache_time: Option<u32>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct SetMyCommandsParams {
     pub commands: Vec<BotCommand>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub scope: Option<BotCommandScope>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub language_code: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct GetMyCommandsParams {
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub scope: Option<BotCommandScope>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub language_code: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct DeleteMyCommandsParams {
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub scope: Option<BotCommandScope>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub language_code: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct EditMessageTextParams {
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub chat_id: Option<ChatId>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub message_id: Option<i32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub inline_message_id: Option<String>,
 
+    #[builder(setter(into))]
     pub text: String,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub parse_mode: Option<ParseMode>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub entities: Option<Vec<MessageEntity>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub disable_web_page_preview: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub reply_markup: Option<InlineKeyboardMarkup>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct EditMessageCaptionParams {
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub chat_id: Option<ChatId>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub message_id: Option<i32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub inline_message_id: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub caption: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub parse_mode: Option<ParseMode>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub caption_entities: Option<Vec<MessageEntity>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub reply_markup: Option<InlineKeyboardMarkup>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct EditMessageMediaParams {
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub chat_id: Option<ChatId>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub message_id: Option<i32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub inline_message_id: Option<String>,
 
+    #[builder(setter(into))]
     pub media: InputMedia,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub reply_markup: Option<InlineKeyboardMarkup>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct EditMessageReplyMarkupParams {
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub chat_id: Option<ChatId>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub message_id: Option<i32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub inline_message_id: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub reply_markup: Option<InlineKeyboardMarkup>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct StopPollParams {
+    #[builder(setter(into))]
     pub chat_id: ChatId,
 
     pub message_id: i32,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub reply_markup: Option<InlineKeyboardMarkup>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct DeleteMessageParams {
+    #[builder(setter(into))]
     pub chat_id: ChatId,
 
     pub message_id: i32,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct SendStickerParams {
+    #[builder(setter(into))]
     pub chat_id: ChatId,
 
+    #[builder(setter(into))]
     pub sticker: File,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub disable_notification: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub protect_content: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub reply_to_message_id: Option<i32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub allow_sending_without_reply: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub reply_markup: Option<ReplyMarkup>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct GetStickerSetParams {
+    #[builder(setter(into))]
     pub name: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct UploadStickerFileParams {
     pub user_id: u64,
 
@@ -1611,245 +1620,251 @@ pub struct UploadStickerFileParams {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct CreateNewStickerSetParams {
     pub user_id: u64,
 
+    #[builder(setter(into))]
     pub name: String,
 
+    #[builder(setter(into))]
     pub title: String,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub png_sticker: Option<File>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub tgs_sticker: Option<InputFile>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub webm_sticker: Option<InputFile>,
 
+    #[builder(setter(into))]
     pub emojis: String,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub contains_masks: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub mask_position: Option<MaskPosition>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct AddStickerToSetParams {
     pub user_id: u64,
 
+    #[builder(setter(into))]
     pub name: String,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub png_sticker: Option<File>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub tgs_sticker: Option<InputFile>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub webm_sticker: Option<InputFile>,
 
+    #[builder(setter(into))]
     pub emojis: String,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub mask_position: Option<MaskPosition>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct SetStickerPositionInSetParams {
+    #[builder(setter(into))]
     pub sticker: String,
 
     pub position: u32,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct DeleteStickerFromSetParams {
+    #[builder(setter(into))]
     pub sticker: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct SetStickerSetThumbParams {
+    #[builder(setter(into))]
     pub name: String,
 
     pub user_id: u64,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub thumb: Option<File>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct AnswerInlineQueryParams {
+    #[builder(setter(into))]
     pub inline_query_id: String,
 
     pub results: Vec<InlineQueryResult>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub cache_time: Option<u32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub is_personal: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub next_offset: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub switch_pm_text: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub switch_pm_parameter: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct SendInvoiceParams {
     pub chat_id: i64,
 
+    #[builder(setter(into))]
     pub title: String,
 
+    #[builder(setter(into))]
     pub description: String,
 
+    #[builder(setter(into))]
     pub payload: String,
 
+    #[builder(setter(into))]
     pub provider_token: String,
 
+    #[builder(setter(into))]
     pub currency: String,
 
     pub prices: Vec<LabeledPrice>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub max_tip_amount: Option<u32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub suggested_tip_amounts: Option<Vec<u32>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub start_parameter: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub provider_data: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub photo_url: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub photo_size: Option<u32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub photo_width: Option<u32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub photo_height: Option<u32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub need_name: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub need_phone_number: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub need_email: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub need_shipping_address: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub send_phone_number_to_provider: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub send_email_to_provider: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub is_flexible: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub disable_notification: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub protect_content: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub reply_to_message_id: Option<i32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub allow_sending_without_reply: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub reply_markup: Option<InlineKeyboardMarkup>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct AnswerShippingQueryParams {
+    #[builder(setter(into))]
     pub shipping_query_id: String,
 
     pub ok: bool,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub shipping_options: Option<Vec<ShippingOption>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub error_message: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct AnswerPreCheckoutQueryParams {
+    #[builder(setter(into))]
     pub pre_checkout_query_id: String,
 
     pub ok: bool,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub error_message: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct SetPassportDataErrorsParams {
     pub user_id: u64,
 
@@ -1857,225 +1872,223 @@ pub struct SetPassportDataErrorsParams {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct SendGameParams {
     pub chat_id: i64,
 
+    #[builder(setter(into))]
     pub game_short_name: String,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub disable_notification: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub protect_content: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub reply_to_message_id: Option<i32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub allow_sending_without_reply: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub reply_markup: Option<InlineKeyboardMarkup>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct SetGameScoreParams {
     pub user_id: u64,
 
     pub score: i32,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub force: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub disable_edit_message: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub chat_id: Option<i64>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub message_id: Option<i32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub inline_message_id: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct GetGameHighScoresParams {
     pub user_id: u64,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub chat_id: Option<i64>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub message_id: Option<i32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub inline_message_id: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct InputMediaPhoto {
+    #[builder(setter(into))]
     pub media: File,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub caption: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub parse_mode: Option<ParseMode>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub caption_entities: Option<Vec<MessageEntity>>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct InputMediaVideo {
+    #[builder(setter(into))]
     pub media: File,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub thumb: Option<File>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub caption: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub parse_mode: Option<ParseMode>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub caption_entities: Option<Vec<MessageEntity>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub width: Option<u32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub height: Option<u32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub duration: Option<u32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub supports_streaming: Option<bool>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct InputMediaAnimation {
+    #[builder(setter(into))]
     pub media: File,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub thumb: Option<File>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub caption: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub parse_mode: Option<ParseMode>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub caption_entities: Option<Vec<MessageEntity>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub width: Option<u32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub height: Option<u32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub duration: Option<u32>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct InputMediaAudio {
+    #[builder(setter(into))]
     pub media: File,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub thumb: Option<File>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub caption: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub parse_mode: Option<ParseMode>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub caption_entities: Option<Vec<MessageEntity>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub duration: Option<u32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub performer: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub title: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct InputMediaDocument {
+    #[builder(setter(into))]
     pub media: File,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub thumb: Option<File>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub caption: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub parse_mode: Option<ParseMode>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub caption_entities: Option<Vec<MessageEntity>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub disable_content_type_detection: Option<bool>,
 }

--- a/src/objects.rs
+++ b/src/objects.rs
@@ -1,5 +1,5 @@
-use derive_builder::Builder;
 use serde::{Deserialize, Serialize};
+use typed_builder::TypedBuilder as Builder;
 
 use crate::ParseMode;
 
@@ -146,26 +146,24 @@ pub enum PassportElementErrorTranslationFileType {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct ChatMemberOwner {
     pub user: User,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub custom_title: Option<String>,
 
     pub is_anonymous: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct ChatMemberAdministrator {
     pub user: User,
 
     pub can_be_edited: bool,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub custom_title: Option<String>,
 
     pub is_anonymous: bool,
@@ -173,11 +171,11 @@ pub struct ChatMemberAdministrator {
     pub can_manage_chat: bool,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub can_post_messages: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub can_edit_messages: Option<bool>,
 
     pub can_delete_messages: bool,
@@ -193,18 +191,16 @@ pub struct ChatMemberAdministrator {
     pub can_invite_users: bool,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub can_pin_messages: Option<bool>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct ChatMemberMember {
     pub user: User,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct ChatMemberRestricted {
     pub user: User,
 
@@ -215,7 +211,7 @@ pub struct ChatMemberRestricted {
     pub can_invite_users: bool,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub can_pin_messages: Option<bool>,
 
     pub can_send_messages: bool,
@@ -232,12 +228,10 @@ pub struct ChatMemberRestricted {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct ChatMemberLeft {
     pub user: User,
 }
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct ChatMemberBanned {
     pub user: User,
 
@@ -245,84 +239,80 @@ pub struct ChatMemberBanned {
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Builder)]
-#[builder(setter(into))]
 pub struct VoiceChatStarted {}
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Builder)]
-#[builder(setter(into))]
 pub struct VoiceChatScheduled {
     pub start_date: u64,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Builder)]
-#[builder(setter(into))]
 pub struct CallbackGame {}
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct Update {
     pub update_id: u32,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub message: Option<Message>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub edited_message: Option<Message>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub channel_post: Option<Message>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub edited_channel_post: Option<Message>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub inline_query: Option<InlineQuery>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub chosen_inline_result: Option<ChosenInlineResult>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub callback_query: Option<CallbackQuery>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub shipping_query: Option<ShippingQuery>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub pre_checkout_query: Option<PreCheckoutQuery>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub poll: Option<Poll>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub poll_answer: Option<PollAnswer>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub my_chat_member: Option<ChatMemberUpdated>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub chat_member: Option<ChatMemberUpdated>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub chat_join_request: Option<ChatJoinRequest>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct WebhookInfo {
+    #[builder(setter(into))]
     pub url: String,
 
     pub has_custom_certificate: bool,
@@ -330,62 +320,61 @@ pub struct WebhookInfo {
     pub pending_update_count: u32,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub ip_address: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub last_error_date: Option<u64>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub last_error_message: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub max_connections: Option<u16>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub allowed_updates: Option<Vec<String>>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct User {
     pub id: u64,
 
     pub is_bot: bool,
 
+    #[builder(setter(into))]
     pub first_name: String,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub last_name: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub username: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub language_code: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub can_join_groups: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub can_read_all_group_messages: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub supports_inline_queries: Option<bool>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct Chat {
     pub id: i64,
 
@@ -393,89 +382,88 @@ pub struct Chat {
     pub type_field: ChatType,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub title: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub username: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub first_name: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub last_name: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub photo: Option<ChatPhoto>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub bio: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub has_private_forwards: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub description: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub invite_link: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub pinned_message: Option<Box<Message>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub permissions: Option<ChatPermissions>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub slow_mode_delay: Option<u16>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub message_auto_delete_time: Option<u32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub has_protected_content: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub sticker_set_name: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub can_set_sticker_set: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub linked_chat_id: Option<i64>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub location: Option<ChatLocation>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct Message {
     pub message_id: i32,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub from: Option<User>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub sender_chat: Option<Chat>,
 
     pub date: u64,
@@ -483,226 +471,224 @@ pub struct Message {
     pub chat: Chat,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub forward_from: Option<User>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub forward_from_chat: Option<Chat>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub forward_from_message_id: Option<i32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub forward_signature: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub forward_sender_name: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub forward_date: Option<u64>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub is_automatic_forward: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub reply_to_message: Option<Box<Message>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub via_bot: Option<User>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub edit_date: Option<u64>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub has_protected_content: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub media_group_id: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub author_signature: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub text: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub entities: Option<Vec<MessageEntity>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub animation: Option<Animation>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub audio: Option<Audio>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub document: Option<Document>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub photo: Option<Vec<PhotoSize>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub sticker: Option<Sticker>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub video: Option<Video>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub video_note: Option<VideoNote>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub voice: Option<Voice>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub caption: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub caption_entities: Option<Vec<MessageEntity>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub contact: Option<Contact>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub dice: Option<Dice>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub game: Option<Game>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub poll: Option<Poll>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub venue: Option<Venue>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub location: Option<Location>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub new_chat_members: Option<Vec<User>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub left_chat_member: Option<User>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub new_chat_title: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub new_chat_photo: Option<Vec<PhotoSize>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub delete_chat_photo: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub group_chat_created: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub supergroup_chat_created: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub channel_chat_created: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub message_auto_delete_timer_changed: Option<MessageAutoDeleteTimerChanged>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub migrate_to_chat_id: Option<i64>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub migrate_from_chat_id: Option<i64>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub pinned_message: Option<Box<Message>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub invoice: Option<Invoice>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub successful_payment: Option<SuccessfulPayment>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub connected_website: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub passport_data: Option<PassportData>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub proximity_alert_triggered: Option<ProximityAlertTriggered>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub voice_chat_started: Option<VoiceChatStarted>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub voice_chat_ended: Option<VoiceChatEnded>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub voice_chat_scheduled: Option<VoiceChatScheduled>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub voice_chat_participants_invited: Option<VoiceChatParticipantsInvited>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub reply_markup: Option<InlineKeyboardMarkup>,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Builder)]
-#[builder(setter(into))]
 pub struct MessageId {
     pub message_id: i32,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct MessageEntity {
     #[serde(rename = "type")]
     pub type_field: MessageEntityType,
@@ -712,23 +698,24 @@ pub struct MessageEntity {
     pub length: u16,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub url: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub user: Option<User>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub language: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct PhotoSize {
+    #[builder(setter(into))]
     pub file_id: String,
 
+    #[builder(setter(into))]
     pub file_unique_id: String,
 
     pub width: u32,
@@ -736,15 +723,16 @@ pub struct PhotoSize {
     pub height: u32,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub file_size: Option<u32>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct Animation {
+    #[builder(setter(into))]
     pub file_id: String,
 
+    #[builder(setter(into))]
     pub file_unique_id: String,
 
     pub width: u32,
@@ -754,85 +742,88 @@ pub struct Animation {
     pub duration: u32,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub thumb: Option<PhotoSize>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub file_name: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub mime_type: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub file_size: Option<u32>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct Audio {
+    #[builder(setter(into))]
     pub file_id: String,
 
+    #[builder(setter(into))]
     pub file_unique_id: String,
 
     pub duration: u32,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub performer: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub title: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub file_name: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub mime_type: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub file_size: Option<u32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub thumb: Option<PhotoSize>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct Document {
+    #[builder(setter(into))]
     pub file_id: String,
 
+    #[builder(setter(into))]
     pub file_unique_id: String,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub thumb: Option<PhotoSize>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub file_name: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub mime_type: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub file_size: Option<u32>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct Video {
+    #[builder(setter(into))]
     pub file_id: String,
 
+    #[builder(setter(into))]
     pub file_unique_id: String,
 
     pub width: u32,
@@ -842,27 +833,28 @@ pub struct Video {
     pub duration: u32,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub thumb: Option<PhotoSize>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub file_name: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub mime_type: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub file_size: Option<u32>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct VideoNote {
+    #[builder(setter(into))]
     pub file_id: String,
 
+    #[builder(setter(into))]
     pub file_unique_id: String,
 
     pub length: u32,
@@ -870,71 +862,73 @@ pub struct VideoNote {
     pub duration: u32,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub thumb: Option<PhotoSize>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub file_size: Option<u32>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct Voice {
+    #[builder(setter(into))]
     pub file_id: String,
 
+    #[builder(setter(into))]
     pub file_unique_id: String,
 
     pub duration: u32,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub mime_type: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub file_size: Option<u32>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct Contact {
+    #[builder(setter(into))]
     pub phone_number: String,
 
+    #[builder(setter(into))]
     pub first_name: String,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub last_name: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub user_id: Option<u64>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub vcard: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct Dice {
+    #[builder(setter(into))]
     pub emoji: String,
 
     pub value: u8,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct PollOption {
+    #[builder(setter(into))]
     pub text: String,
 
     pub voter_count: u32,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct PollAnswer {
+    #[builder(setter(into))]
     pub poll_id: String,
 
     pub user: User,
@@ -943,10 +937,11 @@ pub struct PollAnswer {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct Poll {
+    #[builder(setter(into))]
     pub id: String,
 
+    #[builder(setter(into))]
     pub question: String,
 
     pub options: Vec<PollOption>,
@@ -962,78 +957,77 @@ pub struct Poll {
     pub allows_multiple_answers: bool,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub correct_option_id: Option<u8>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub explanation: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub explanation_entities: Option<Vec<MessageEntity>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub open_period: Option<u32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub close_date: Option<u64>,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct Location {
     pub longitude: f64,
 
     pub latitude: f64,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub horizontal_accuracy: Option<f64>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub live_period: Option<u32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub heading: Option<u16>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub proximity_alert_radius: Option<u32>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct Venue {
     pub location: Location,
 
+    #[builder(setter(into))]
     pub title: String,
 
+    #[builder(setter(into))]
     pub address: String,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub foursquare_id: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub foursquare_type: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub google_place_id: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub google_place_type: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct ProximityAlertTriggered {
     pub traveler: User,
 
@@ -1043,27 +1037,23 @@ pub struct ProximityAlertTriggered {
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Builder)]
-#[builder(setter(into))]
 pub struct MessageAutoDeleteTimerChanged {
     pub message_auto_delete_time: u32,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Builder)]
-#[builder(setter(into))]
 pub struct VoiceChatEnded {
     pub duration: u32,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct VoiceChatParticipantsInvited {
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub users: Option<Vec<User>>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct UserProfilePhotos {
     pub total_count: u32,
 
@@ -1071,193 +1061,193 @@ pub struct UserProfilePhotos {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct File {
+    #[builder(setter(into))]
     pub file_id: String,
 
+    #[builder(setter(into))]
     pub file_unique_id: String,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub file_size: Option<u32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub file_path: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct ReplyKeyboardMarkup {
     pub keyboard: Vec<Vec<KeyboardButton>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub resize_keyboard: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub one_time_keyboard: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub input_field_placeholder: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub selective: Option<bool>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct KeyboardButton {
+    #[builder(setter(into))]
     pub text: String,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub request_contact: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub request_location: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub request_poll: Option<KeyboardButtonPollType>,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Builder)]
-#[builder(setter(into))]
 pub struct KeyboardButtonPollType {
     #[serde(rename = "type")]
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub type_field: Option<PollType>,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Builder)]
-#[builder(setter(into))]
 pub struct ReplyKeyboardRemove {
     pub remove_keyboard: bool,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub selective: Option<bool>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct InlineKeyboardMarkup {
     pub inline_keyboard: Vec<Vec<InlineKeyboardButton>>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct InlineKeyboardButton {
+    #[builder(setter(into))]
     pub text: String,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub url: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub login_url: Option<LoginUrl>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub callback_data: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub switch_inline_query: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub switch_inline_query_current_chat: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub callback_game: Option<CallbackGame>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub pay: Option<bool>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct LoginUrl {
+    #[builder(setter(into))]
     pub url: String,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub forward_text: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub bot_username: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub request_write_access: Option<bool>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct CallbackQuery {
+    #[builder(setter(into))]
     pub id: String,
 
     pub from: User,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub message: Option<Message>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub inline_message_id: Option<String>,
 
+    #[builder(setter(into))]
     pub chat_instance: String,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub data: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub game_short_name: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct ForceReply {
     pub force_reply: bool,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub input_field_placeholder: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub selective: Option<bool>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct ChatPhoto {
+    #[builder(setter(into))]
     pub small_file_id: String,
 
+    #[builder(setter(into))]
     pub small_file_unique_id: String,
 
+    #[builder(setter(into))]
     pub big_file_id: String,
 
+    #[builder(setter(into))]
     pub big_file_unique_id: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct ChatInviteLink {
+    #[builder(setter(into))]
     pub invite_link: String,
 
     pub creator: User,
@@ -1269,24 +1259,23 @@ pub struct ChatInviteLink {
     pub is_revoked: bool,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub name: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub expire_date: Option<u64>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub member_limit: Option<u32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub pending_join_request_count: Option<u32>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct ChatMemberUpdated {
     pub chat: Chat,
 
@@ -1299,12 +1288,11 @@ pub struct ChatMemberUpdated {
     pub new_chat_member: ChatMember,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub invite_link: Option<ChatInviteLink>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct ChatJoinRequest {
     pub chat: Chat,
 
@@ -1313,83 +1301,83 @@ pub struct ChatJoinRequest {
     pub date: u64,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub bio: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub invite_link: Option<ChatInviteLink>,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Builder)]
-#[builder(setter(into))]
 pub struct ChatPermissions {
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub can_send_messages: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub can_send_media_messages: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub can_send_polls: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub can_send_other_messages: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub can_add_web_page_previews: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub can_change_info: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub can_invite_users: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub can_pin_messages: Option<bool>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct ChatLocation {
     pub location: Location,
 
+    #[builder(setter(into))]
     pub address: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct BotCommand {
+    #[builder(setter(into))]
     pub command: String,
 
+    #[builder(setter(into))]
     pub description: String,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Builder)]
-#[builder(setter(into))]
 pub struct ResponseParameters {
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub migrate_to_chat_id: Option<i64>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub retry_after: Option<u16>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct Sticker {
+    #[builder(setter(into))]
     pub file_id: String,
 
+    #[builder(setter(into))]
     pub file_unique_id: String,
 
     pub width: u32,
@@ -1401,31 +1389,32 @@ pub struct Sticker {
     pub is_video: bool,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub thumb: Option<PhotoSize>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub emoji: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub set_name: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub mask_position: Option<MaskPosition>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub file_size: Option<u32>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct StickerSet {
+    #[builder(setter(into))]
     pub name: String,
 
+    #[builder(setter(into))]
     pub title: String,
 
     pub is_animated: bool,
@@ -1437,13 +1426,13 @@ pub struct StickerSet {
     pub stickers: Vec<Sticker>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub thumb: Option<PhotoSize>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct MaskPosition {
+    #[builder(setter(into))]
     pub point: String,
 
     pub x_shift: f64,
@@ -1454,1071 +1443,1127 @@ pub struct MaskPosition {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct InlineQuery {
+    #[builder(setter(into))]
     pub id: String,
 
     pub from: User,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub location: Option<Location>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub chat_type: Option<String>,
 
+    #[builder(setter(into))]
     pub query: String,
 
+    #[builder(setter(into))]
     pub offset: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct InlineQueryResultArticle {
+    #[builder(setter(into))]
     pub id: String,
 
+    #[builder(setter(into))]
     pub title: String,
 
     pub input_message_content: InputMessageContent,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub reply_markup: Option<InlineKeyboardMarkup>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub url: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub hide_url: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub description: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub thumb_url: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub thumb_width: Option<u32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub thumb_height: Option<u32>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct InlineQueryResultPhoto {
+    #[builder(setter(into))]
     pub id: String,
 
+    #[builder(setter(into))]
     pub photo_url: String,
 
+    #[builder(setter(into))]
     pub thumb_url: String,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub photo_width: Option<u32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub photo_height: Option<u32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub title: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub description: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub caption: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub parse_mode: Option<ParseMode>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub caption_entities: Option<Vec<MessageEntity>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub reply_markup: Option<InlineKeyboardMarkup>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub input_message_content: Option<InputMessageContent>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct InlineQueryResultGif {
+    #[builder(setter(into))]
     pub id: String,
 
+    #[builder(setter(into))]
     pub gif_url: String,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub gif_width: Option<u32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub gif_height: Option<u32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub gif_duration: Option<u32>,
 
+    #[builder(setter(into))]
     pub thumb_url: String,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub thumb_mime_type: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub title: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub caption: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub parse_mode: Option<ParseMode>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub caption_entities: Option<Vec<MessageEntity>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub reply_markup: Option<InlineKeyboardMarkup>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub input_message_content: Option<InputMessageContent>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct InlineQueryResultMpeg4Gif {
+    #[builder(setter(into))]
     pub id: String,
 
+    #[builder(setter(into))]
     pub mpeg4_url: String,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub mpeg4_width: Option<u32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub mpeg4_height: Option<u32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub mpeg4_duration: Option<u32>,
 
+    #[builder(setter(into))]
     pub thumb_url: String,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub thumb_mime_type: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub title: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub caption: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub parse_mode: Option<ParseMode>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub caption_entities: Option<Vec<MessageEntity>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub reply_markup: Option<InlineKeyboardMarkup>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub input_message_content: Option<InputMessageContent>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct InlineQueryResultVideo {
+    #[builder(setter(into))]
     pub id: String,
 
+    #[builder(setter(into))]
     pub video_url: String,
 
+    #[builder(setter(into))]
     pub mime_type: String,
 
+    #[builder(setter(into))]
     pub thumb_url: String,
 
+    #[builder(setter(into))]
     pub title: String,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub caption: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub parse_mode: Option<ParseMode>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub caption_entities: Option<Vec<MessageEntity>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub video_width: Option<u32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub video_height: Option<u32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub video_duration: Option<u32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub description: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub reply_markup: Option<InlineKeyboardMarkup>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub input_message_content: Option<InputMessageContent>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct InlineQueryResultAudio {
+    #[builder(setter(into))]
     pub id: String,
 
+    #[builder(setter(into))]
     pub audio_url: String,
 
+    #[builder(setter(into))]
     pub title: String,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub caption: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub parse_mode: Option<ParseMode>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub caption_entities: Option<Vec<MessageEntity>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub performer: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub audio_duration: Option<u32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub reply_markup: Option<InlineKeyboardMarkup>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub input_message_content: Option<InputMessageContent>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct InlineQueryResultVoice {
+    #[builder(setter(into))]
     pub id: String,
 
+    #[builder(setter(into))]
     pub voice_url: String,
 
+    #[builder(setter(into))]
     pub title: String,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub caption: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub parse_mode: Option<ParseMode>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub caption_entities: Option<Vec<MessageEntity>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub voice_duration: Option<u32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub reply_markup: Option<InlineKeyboardMarkup>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub input_message_content: Option<InputMessageContent>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct InlineQueryResultDocument {
+    #[builder(setter(into))]
     pub id: String,
 
+    #[builder(setter(into))]
     pub title: String,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub caption: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub parse_mode: Option<ParseMode>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub caption_entities: Option<Vec<MessageEntity>>,
 
+    #[builder(setter(into))]
     pub document_url: String,
 
+    #[builder(setter(into))]
     pub mime_type: String,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub description: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub reply_markup: Option<InlineKeyboardMarkup>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub input_message_content: Option<InputMessageContent>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub thumb_url: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub thumb_width: Option<u32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub thumb_height: Option<u32>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct InlineQueryResultLocation {
+    #[builder(setter(into))]
     pub id: String,
 
     pub latitude: f64,
 
     pub longitude: f64,
 
+    #[builder(setter(into))]
     pub title: String,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub horizontal_accuracy: Option<f64>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub live_period: Option<u32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub heading: Option<u16>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub proximity_alert_radius: Option<u32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub reply_markup: Option<InlineKeyboardMarkup>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub input_message_content: Option<InputMessageContent>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub thumb_url: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub thumb_width: Option<u32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub thumb_height: Option<u32>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct InlineQueryResultVenue {
+    #[builder(setter(into))]
     pub id: String,
 
     pub latitude: f64,
 
     pub longitude: f64,
 
+    #[builder(setter(into))]
     pub title: String,
 
+    #[builder(setter(into))]
     pub address: String,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub foursquare_id: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub foursquare_type: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub google_place_id: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub google_place_type: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub reply_markup: Option<InlineKeyboardMarkup>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub input_message_content: Option<InputMessageContent>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub thumb_url: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub thumb_width: Option<u32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub thumb_height: Option<u32>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct InlineQueryResultContact {
+    #[builder(setter(into))]
     pub id: String,
 
+    #[builder(setter(into))]
     pub phone_number: String,
 
+    #[builder(setter(into))]
     pub first_name: String,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub last_name: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub vcard: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub reply_markup: Option<InlineKeyboardMarkup>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub input_message_content: Option<InputMessageContent>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub thumb_url: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub thumb_width: Option<u32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub thumb_height: Option<u32>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct InlineQueryResultGame {
+    #[builder(setter(into))]
     pub id: String,
 
+    #[builder(setter(into))]
     pub game_short_name: String,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub reply_markup: Option<InlineKeyboardMarkup>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct InlineQueryResultCachedPhoto {
+    #[builder(setter(into))]
     pub id: String,
 
+    #[builder(setter(into))]
     pub photo_file_id: String,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub title: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub description: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub caption: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub parse_mode: Option<ParseMode>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub caption_entities: Option<Vec<MessageEntity>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub reply_markup: Option<InlineKeyboardMarkup>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub input_message_content: Option<InputMessageContent>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct InlineQueryResultCachedGif {
+    #[builder(setter(into))]
     pub id: String,
 
+    #[builder(setter(into))]
     pub gif_file_id: String,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub title: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub caption: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub parse_mode: Option<ParseMode>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub caption_entities: Option<Vec<MessageEntity>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub reply_markup: Option<InlineKeyboardMarkup>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub input_message_content: Option<InputMessageContent>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct InlineQueryResultCachedMpeg4Gif {
+    #[builder(setter(into))]
     pub id: String,
 
+    #[builder(setter(into))]
     pub mpeg4_file_id: String,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub title: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub caption: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub parse_mode: Option<ParseMode>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub caption_entities: Option<Vec<MessageEntity>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub reply_markup: Option<InlineKeyboardMarkup>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub input_message_content: Option<InputMessageContent>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct InlineQueryResultCachedSticker {
+    #[builder(setter(into))]
     pub id: String,
 
+    #[builder(setter(into))]
     pub sticker_file_id: String,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub reply_markup: Option<InlineKeyboardMarkup>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub input_message_content: Option<InputMessageContent>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct InlineQueryResultCachedDocument {
+    #[builder(setter(into))]
     pub id: String,
 
+    #[builder(setter(into))]
     pub title: String,
 
+    #[builder(setter(into))]
     pub document_file_id: String,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub description: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub caption: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub parse_mode: Option<ParseMode>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub caption_entities: Option<Vec<MessageEntity>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub reply_markup: Option<InlineKeyboardMarkup>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub input_message_content: Option<InputMessageContent>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct InlineQueryResultCachedVideo {
+    #[builder(setter(into))]
     pub id: String,
 
+    #[builder(setter(into))]
     pub video_file_id: String,
 
+    #[builder(setter(into))]
     pub title: String,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub description: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub caption: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub parse_mode: Option<ParseMode>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub caption_entities: Option<Vec<MessageEntity>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub reply_markup: Option<InlineKeyboardMarkup>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub input_message_content: Option<InputMessageContent>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct InlineQueryResultCachedVoice {
+    #[builder(setter(into))]
     pub id: String,
 
+    #[builder(setter(into))]
     pub voice_file_id: String,
 
+    #[builder(setter(into))]
     pub title: String,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub caption: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub parse_mode: Option<ParseMode>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub caption_entities: Option<Vec<MessageEntity>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub reply_markup: Option<InlineKeyboardMarkup>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub input_message_content: Option<InputMessageContent>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct InlineQueryResultCachedAudio {
+    #[builder(setter(into))]
     pub id: String,
 
+    #[builder(setter(into))]
     pub audio_file_id: String,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub caption: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub parse_mode: Option<ParseMode>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub caption_entities: Option<Vec<MessageEntity>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub reply_markup: Option<InlineKeyboardMarkup>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub input_message_content: Option<InputMessageContent>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct InputTextMessageContent {
+    #[builder(setter(into))]
     pub message_text: String,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub parse_mode: Option<ParseMode>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub entities: Option<Vec<MessageEntity>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub disable_web_page_preview: Option<bool>,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct InputLocationMessageContent {
     pub latitude: f64,
 
     pub longitude: f64,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub horizontal_accuracy: Option<f64>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub live_period: Option<u32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub heading: Option<u16>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub proximity_alert_radius: Option<u32>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct InputInvoiceMessageContent {
+    #[builder(setter(into))]
     pub title: String,
 
+    #[builder(setter(into))]
     pub description: String,
 
+    #[builder(setter(into))]
     pub payload: String,
 
+    #[builder(setter(into))]
     pub provider_token: String,
 
+    #[builder(setter(into))]
     pub currency: String,
 
     pub prices: Vec<LabeledPrice>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub max_tip_amount: Option<u32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub suggested_tip_amounts: Option<Vec<u32>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub provider_data: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub photo_url: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub photo_size: Option<u32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub photo_width: Option<u32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub photo_height: Option<u32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub need_name: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub need_phone_number: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub need_email: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub need_shipping_address: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub send_phone_number_to_provider: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub send_email_to_provider: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub is_flexible: Option<bool>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct InputVenueMessageContent {
     pub latitude: f64,
 
     pub longitude: f64,
 
+    #[builder(setter(into))]
     pub title: String,
 
+    #[builder(setter(into))]
     pub address: String,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub foursquare_id: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub foursquare_type: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub google_place_id: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub google_place_type: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct InputContactMessageContent {
+    #[builder(setter(into))]
     pub phone_number: String,
 
+    #[builder(setter(into))]
     pub first_name: String,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub last_name: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub vcard: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct ChosenInlineResult {
+    #[builder(setter(into))]
     pub result_id: String,
 
     pub from: User,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub location: Option<Location>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub inline_message_id: Option<String>,
 
+    #[builder(setter(into))]
     pub query: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct LabeledPrice {
+    #[builder(setter(into))]
     pub label: String,
 
     pub amount: u32,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct Invoice {
+    #[builder(setter(into))]
     pub title: String,
 
+    #[builder(setter(into))]
     pub description: String,
 
+    #[builder(setter(into))]
     pub start_parameter: String,
 
+    #[builder(setter(into))]
     pub currency: String,
 
     pub total_amount: u32,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct ShippingAddress {
+    #[builder(setter(into))]
     pub country_code: String,
 
+    #[builder(setter(into))]
     pub state: String,
 
+    #[builder(setter(into))]
     pub city: String,
 
+    #[builder(setter(into))]
     pub street_line1: String,
 
+    #[builder(setter(into))]
     pub street_line2: String,
 
+    #[builder(setter(into))]
     pub post_code: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct OrderInfo {
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub name: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub phone_number: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub email: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub shipping_address: Option<ShippingAddress>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct ShippingOption {
+    #[builder(setter(into))]
     pub id: String,
 
+    #[builder(setter(into))]
     pub title: String,
 
     pub prices: Vec<LabeledPrice>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct SuccessfulPayment {
+    #[builder(setter(into))]
     pub currency: String,
 
     pub total_amount: u32,
 
+    #[builder(setter(into))]
     pub invoice_payload: String,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub shipping_option_id: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub order_info: Option<OrderInfo>,
 
+    #[builder(setter(into))]
     pub telegram_payment_charge_id: String,
 
+    #[builder(setter(into))]
     pub provider_payment_charge_id: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct ShippingQuery {
+    #[builder(setter(into))]
     pub id: String,
 
     pub from: User,
 
+    #[builder(setter(into))]
     pub invoice_payload: String,
 
     pub shipping_address: ShippingAddress,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct PreCheckoutQuery {
+    #[builder(setter(into))]
     pub id: String,
 
     pub from: User,
 
+    #[builder(setter(into))]
     pub currency: String,
 
     pub total_amount: u32,
 
+    #[builder(setter(into))]
     pub invoice_payload: String,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub shipping_option_id: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub order_info: Option<OrderInfo>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct PassportData {
     pub data: Vec<EncryptedPassportElement>,
 
@@ -2526,10 +2571,11 @@ pub struct PassportData {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct PassportFile {
+    #[builder(setter(into))]
     pub file_id: String,
 
+    #[builder(setter(into))]
     pub file_unique_id: String,
 
     pub file_size: u32,
@@ -2538,181 +2584,191 @@ pub struct PassportFile {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct EncryptedPassportElement {
     #[serde(rename = "type")]
     pub type_field: EncryptedPassportElementType,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub data: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub phone_number: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub email: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub files: Option<Vec<PassportFile>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub front_side: Option<PassportFile>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub reverse_side: Option<PassportFile>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub selfie: Option<PassportFile>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub translation: Option<Vec<PassportFile>>,
 
+    #[builder(setter(into))]
     pub hash: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct EncryptedCredentials {
+    #[builder(setter(into))]
     pub data: String,
 
+    #[builder(setter(into))]
     pub hash: String,
 
+    #[builder(setter(into))]
     pub secret: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct PassportElementErrorDataField {
     #[serde(rename = "type")]
     pub type_field: PassportElementErrorDataFieldType,
 
+    #[builder(setter(into))]
     pub field_name: String,
 
+    #[builder(setter(into))]
     pub data_hash: String,
 
+    #[builder(setter(into))]
     pub message: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct PassportElementErrorFrontSide {
     #[serde(rename = "type")]
     pub type_field: PassportElementErrorFrontSideType,
 
+    #[builder(setter(into))]
     pub file_hash: String,
 
+    #[builder(setter(into))]
     pub message: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct PassportElementErrorReverseSide {
     #[serde(rename = "type")]
     pub type_field: PassportElementErrorReverseSideType,
 
+    #[builder(setter(into))]
     pub file_hash: String,
 
+    #[builder(setter(into))]
     pub message: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct PassportElementErrorSelfie {
     #[serde(rename = "type")]
     pub type_field: PassportElementErrorSelfieType,
 
+    #[builder(setter(into))]
     pub file_hash: String,
 
+    #[builder(setter(into))]
     pub message: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct PassportElementErrorFile {
     #[serde(rename = "type")]
     pub type_field: PassportElementErrorFileType,
 
+    #[builder(setter(into))]
     pub file_hash: String,
 
+    #[builder(setter(into))]
     pub message: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct PassportElementErrorFiles {
     #[serde(rename = "type")]
     pub type_field: PassportElementErrorFileType,
 
     pub file_hashes: Vec<String>,
 
+    #[builder(setter(into))]
     pub message: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct PassportElementErrorTranslationFile {
     #[serde(rename = "type")]
     pub type_field: PassportElementErrorTranslationFileType,
 
+    #[builder(setter(into))]
     pub file_hash: String,
 
+    #[builder(setter(into))]
     pub message: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct PassportElementErrorTranslationFiles {
     #[serde(rename = "type")]
     pub type_field: PassportElementErrorTranslationFileType,
 
     pub file_hashes: Vec<String>,
 
+    #[builder(setter(into))]
     pub message: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct PassportElementErrorUnspecified {
     #[serde(rename = "type")]
     pub type_field: EncryptedPassportElementType,
 
+    #[builder(setter(into))]
     pub element_hash: String,
 
+    #[builder(setter(into))]
     pub message: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct Game {
+    #[builder(setter(into))]
     pub title: String,
 
+    #[builder(setter(into))]
     pub description: String,
 
     pub photo: Vec<PhotoSize>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub text: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub text_entities: Option<Vec<MessageEntity>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(strip_option), default)]
+    #[builder(setter(into, strip_option), default)]
     pub animation: Option<Animation>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into))]
 pub struct GameHighScore {
     pub position: u32,
 


### PR DESCRIPTION
I tested this in one repo and it worked fine. As this touches basically everything it should be checked more carefully I guess.

closes #46

BREAKING CHANGES:
- FooBarBuilder::default() → FooBar::builder()
- build().unwrap() → build()