### PR TITLE
Bot api 6 changes without web apps changes

### DIFF
--- a/src/api/telegram_api_impl.rs
+++ b/src/api/telegram_api_impl.rs
@@ -1251,7 +1251,7 @@ mod tests {
 
     #[test]
     fn get_chat_administrators_success() {
-        let response_string = "{\"ok\":true,\"result\":[{\"status\":\"administrator\",\"user\":{\"id\":1276618370,\"is_bot\":true,\"first_name\":\"test_el_bot\",\"username\":\"el_mon_test_bot\"},\"can_be_edited\":false,\"is_anonymous\":true,\"can_manage_chat\":true,\"can_delete_messages\":true,\"can_manage_voice_chats\":true,\"can_restrict_members\":true,\"can_promote_members\":false,\"can_change_info\":true,\"can_invite_users\":true,\"can_pin_messages\":true},{\"status\":\"creator\",\"user\":{\"id\":275808073,\"is_bot\":false,\"first_name\":\"Ayrat\",\"last_name\":\"Badykov\",\"username\":\"Ayrat555\",\"language_code\":\"en\"},\"is_anonymous\":false}]}";
+        let response_string = "{\"ok\":true,\"result\":[{\"status\":\"administrator\",\"user\":{\"id\":1276618370,\"is_bot\":true,\"first_name\":\"test_el_bot\",\"username\":\"el_mon_test_bot\"},\"can_be_edited\":false,\"is_anonymous\":true,\"can_manage_chat\":true,\"can_delete_messages\":true,\"can_manage_video_chats\":true,\"can_restrict_members\":true,\"can_promote_members\":false,\"can_change_info\":true,\"can_invite_users\":true,\"can_pin_messages\":true},{\"status\":\"creator\",\"user\":{\"id\":275808073,\"is_bot\":false,\"first_name\":\"Ayrat\",\"last_name\":\"Badykov\",\"username\":\"Ayrat555\",\"language_code\":\"en\"},\"is_anonymous\":false}]}";
         let params = GetChatAdministratorsParams::builder()
             .chat_id(-1001368460856)
             .build();

--- a/src/api_params.rs
+++ b/src/api_params.rs
@@ -1,14 +1,14 @@
 use crate::objects::{
-    BotCommand, ChatPermissions, ForceReply, InlineKeyboardMarkup, InlineQueryResultArticle,
-    InlineQueryResultAudio, InlineQueryResultCachedAudio, InlineQueryResultCachedDocument,
-    InlineQueryResultCachedGif, InlineQueryResultCachedMpeg4Gif, InlineQueryResultCachedPhoto,
-    InlineQueryResultCachedSticker, InlineQueryResultCachedVideo, InlineQueryResultCachedVoice,
-    InlineQueryResultContact, InlineQueryResultDocument, InlineQueryResultGame,
-    InlineQueryResultGif, InlineQueryResultLocation, InlineQueryResultMpeg4Gif,
-    InlineQueryResultPhoto, InlineQueryResultVenue, InlineQueryResultVideo, InlineQueryResultVoice,
-    LabeledPrice, MaskPosition, MessageEntity, PassportElementErrorDataField,
-    PassportElementErrorFile, PassportElementErrorFiles, PassportElementErrorFrontSide,
-    PassportElementErrorReverseSide, PassportElementErrorSelfie,
+    BotCommand, ChatAdministratorRights, ChatPermissions, ForceReply, InlineKeyboardMarkup,
+    InlineQueryResultArticle, InlineQueryResultAudio, InlineQueryResultCachedAudio,
+    InlineQueryResultCachedDocument, InlineQueryResultCachedGif, InlineQueryResultCachedMpeg4Gif,
+    InlineQueryResultCachedPhoto, InlineQueryResultCachedSticker, InlineQueryResultCachedVideo,
+    InlineQueryResultCachedVoice, InlineQueryResultContact, InlineQueryResultDocument,
+    InlineQueryResultGame, InlineQueryResultGif, InlineQueryResultLocation,
+    InlineQueryResultMpeg4Gif, InlineQueryResultPhoto, InlineQueryResultVenue,
+    InlineQueryResultVideo, InlineQueryResultVoice, LabeledPrice, MaskPosition, MessageEntity,
+    PassportElementErrorDataField, PassportElementErrorFile, PassportElementErrorFiles,
+    PassportElementErrorFrontSide, PassportElementErrorReverseSide, PassportElementErrorSelfie,
     PassportElementErrorTranslationFile, PassportElementErrorTranslationFiles,
     PassportElementErrorUnspecified, PollType, ReplyKeyboardMarkup, ReplyKeyboardRemove,
     ShippingOption,
@@ -1150,7 +1150,7 @@ pub struct PromoteChatMemberParams {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(setter(into, strip_option), default)]
-    pub can_manage_voice_chats: Option<bool>,
+    pub can_manage_video_chats: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(setter(into, strip_option), default)]
@@ -2091,4 +2091,20 @@ pub struct InputMediaDocument {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(setter(into, strip_option), default)]
     pub disable_content_type_detection: Option<bool>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
+pub struct SetMyDefaultAdministratorRightsParams {
+    pub rights: ChatAdministratorRights,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[builder(setter(into, strip_option), default)]
+    pub for_channels: Option<bool>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
+pub struct GetMyDefaultAdministratorRights {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[builder(setter(into, strip_option), default)]
+    pub for_channels: Option<bool>,
 }

--- a/src/api_traits/async_telegram_api.rs
+++ b/src/api_traits/async_telegram_api.rs
@@ -34,6 +34,7 @@ use crate::api_params::GetChatParams;
 use crate::api_params::GetFileParams;
 use crate::api_params::GetGameHighScoresParams;
 use crate::api_params::GetMyCommandsParams;
+use crate::api_params::GetMyDefaultAdministratorRights;
 use crate::api_params::GetStickerSetParams;
 use crate::api_params::GetUpdatesParams;
 use crate::api_params::GetUserProfilePhotosParams;
@@ -70,6 +71,7 @@ use crate::api_params::SetChatStickerSetParams;
 use crate::api_params::SetChatTitleParams;
 use crate::api_params::SetGameScoreParams;
 use crate::api_params::SetMyCommandsParams;
+use crate::api_params::SetMyDefaultAdministratorRightsParams;
 use crate::api_params::SetStickerPositionInSetParams;
 use crate::api_params::SetStickerSetThumbParams;
 use crate::api_params::SetWebhookParams;
@@ -81,6 +83,7 @@ use crate::api_params::UnpinChatMessageParams;
 use crate::api_params::UploadStickerFileParams;
 use crate::objects::BotCommand;
 use crate::objects::Chat;
+use crate::objects::ChatAdministratorRights;
 use crate::objects::ChatInviteLink;
 use crate::objects::ChatMember;
 use crate::objects::File as FileObject;
@@ -992,6 +995,22 @@ pub trait AsyncTelegramApi {
         params: &GetGameHighScoresParams,
     ) -> Result<MethodResponse<Vec<GameHighScore>>, Self::Error> {
         self.request("getGameHighScores", Some(params)).await
+    }
+
+    async fn set_my_default_administrator_rights(
+        &self,
+        params: &SetMyDefaultAdministratorRightsParams,
+    ) -> Result<MethodResponse<bool>, Self::Error> {
+        self.request("setMyDefaultAdministratorRights", Some(params))
+            .await
+    }
+
+    async fn get_my_default_administrator_rights(
+        &self,
+        params: &GetMyDefaultAdministratorRights,
+    ) -> Result<MethodResponse<ChatAdministratorRights>, Self::Error> {
+        self.request("getMyDefaultAdministratorRights", Some(params))
+            .await
     }
 
     async fn request_without_body<T: serde::de::DeserializeOwned>(

--- a/src/api_traits/telegram_api.rs
+++ b/src/api_traits/telegram_api.rs
@@ -34,6 +34,7 @@ use crate::api_params::GetChatParams;
 use crate::api_params::GetFileParams;
 use crate::api_params::GetGameHighScoresParams;
 use crate::api_params::GetMyCommandsParams;
+use crate::api_params::GetMyDefaultAdministratorRights;
 use crate::api_params::GetStickerSetParams;
 use crate::api_params::GetUpdatesParams;
 use crate::api_params::GetUserProfilePhotosParams;
@@ -70,6 +71,7 @@ use crate::api_params::SetChatStickerSetParams;
 use crate::api_params::SetChatTitleParams;
 use crate::api_params::SetGameScoreParams;
 use crate::api_params::SetMyCommandsParams;
+use crate::api_params::SetMyDefaultAdministratorRightsParams;
 use crate::api_params::SetStickerPositionInSetParams;
 use crate::api_params::SetStickerSetThumbParams;
 use crate::api_params::SetWebhookParams;
@@ -81,6 +83,7 @@ use crate::api_params::UnpinChatMessageParams;
 use crate::api_params::UploadStickerFileParams;
 use crate::objects::BotCommand;
 use crate::objects::Chat;
+use crate::objects::ChatAdministratorRights;
 use crate::objects::ChatInviteLink;
 use crate::objects::ChatMember;
 use crate::objects::File as FileObject;
@@ -938,6 +941,20 @@ pub trait TelegramApi {
         params: &GetGameHighScoresParams,
     ) -> Result<MethodResponse<Vec<GameHighScore>>, Self::Error> {
         self.request("getGameHighScores", Some(params))
+    }
+
+    fn set_my_default_administrator_rights(
+        &self,
+        params: &SetMyDefaultAdministratorRightsParams,
+    ) -> Result<MethodResponse<bool>, Self::Error> {
+        self.request("setMyDefaultAdministratorRights", Some(params))
+    }
+
+    fn get_my_default_administrator_rights(
+        &self,
+        params: &GetMyDefaultAdministratorRights,
+    ) -> Result<MethodResponse<ChatAdministratorRights>, Self::Error> {
+        self.request("getMyDefaultAdministratorRights", Some(params))
     }
 
     fn request_without_body<T: serde::de::DeserializeOwned>(

--- a/src/objects.rs
+++ b/src/objects.rs
@@ -180,7 +180,7 @@ pub struct ChatMemberAdministrator {
 
     pub can_delete_messages: bool,
 
-    pub can_manage_voice_chats: bool,
+    pub can_manage_video_chats: bool,
 
     pub can_restrict_members: bool,
 
@@ -239,10 +239,10 @@ pub struct ChatMemberBanned {
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Builder)]
-pub struct VoiceChatStarted {}
+pub struct VideoChatStarted {}
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Builder)]
-pub struct VoiceChatScheduled {
+pub struct VideoChatScheduled {
     pub start_date: u64,
 }
 
@@ -330,6 +330,10 @@ pub struct WebhookInfo {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(setter(into, strip_option), default)]
     pub last_error_message: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[builder(setter(into, strip_option), default)]
+    pub last_synchronization_error_date: Option<u64>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(setter(into, strip_option), default)]
@@ -664,19 +668,19 @@ pub struct Message {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(setter(into, strip_option), default)]
-    pub voice_chat_started: Option<VoiceChatStarted>,
+    pub video_chat_started: Option<VideoChatStarted>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(setter(into, strip_option), default)]
-    pub voice_chat_ended: Option<VoiceChatEnded>,
+    pub video_chat_ended: Option<VideoChatEnded>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(setter(into, strip_option), default)]
-    pub voice_chat_scheduled: Option<VoiceChatScheduled>,
+    pub video_chat_scheduled: Option<VideoChatScheduled>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(setter(into, strip_option), default)]
-    pub voice_chat_participants_invited: Option<VoiceChatParticipantsInvited>,
+    pub video_chat_participants_invited: Option<VideoChatParticipantsInvited>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(setter(into, strip_option), default)]
@@ -1042,12 +1046,12 @@ pub struct MessageAutoDeleteTimerChanged {
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Builder)]
-pub struct VoiceChatEnded {
+pub struct VideoChatEnded {
     pub duration: u32,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-pub struct VoiceChatParticipantsInvited {
+pub struct VideoChatParticipantsInvited {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(setter(into, strip_option), default)]
     pub users: Option<Vec<User>>,
@@ -2775,4 +2779,35 @@ pub struct GameHighScore {
     pub user: User,
 
     pub score: i32,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Builder)]
+pub struct ChatAdministratorRights {
+    pub is_anonymous: bool,
+
+    pub can_manage_chat: bool,
+
+    pub can_delete_messages: bool,
+
+    pub can_manage_video_chats: bool,
+
+    pub can_restrict_members: bool,
+
+    pub can_promote_members: bool,
+
+    pub can_change_info: bool,
+
+    pub can_invite_users: bool,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[builder(setter(into, strip_option), default)]
+    pub can_post_messages: Option<bool>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[builder(setter(into, strip_option), default)]
+    pub can_edit_messages: Option<bool>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[builder(setter(into, strip_option), default)]
+    pub can_pin_messages: Option<bool>,
 }


### PR DESCRIPTION
* Added the class ChatAdministratorRights and the methods
setMyDefaultAdministratorRights and getMyDefaultAdministratorRights
for managing the bot's default administrator rights.

* Added the field last_synchronization_error_date to the class
WebhookInfo.

* Renamed the field can_manage_voice_chats to can_manage_video_chats
in the class ChatMemberAdministrator. The old field will remain
temporarily available.

* Renamed the parameter can_manage_voice_chats to
can_manage_video_chats in the method promoteChatMember. The old
parameter will remain temporarily available.

* Renamed the fields voice_chat_scheduled, voice_chat_started,
voice_chat_ended, and voice_chat_participants_invited to
video_chat_scheduled, video_chat_started, video_chat_ended, and
video_chat_participants_invited in the class Message. The old fields
will remain temporarily available.