### PR TITLE
Bot API v6 web apps changes

### DIFF
--- a/src/api_params.rs
+++ b/src/api_params.rs
@@ -2103,8 +2103,15 @@ pub struct SetMyDefaultAdministratorRightsParams {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-pub struct GetMyDefaultAdministratorRights {
+pub struct GetMyDefaultAdministratorRightsParams {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(setter(into, strip_option), default)]
     pub for_channels: Option<bool>,
+}
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
+pub struct AnswerWebAppQueryParams {
+    #[builder(setter(into))]
+    pub web_app_query_id: String,
+
+    pub result: InlineQueryResult,
 }

--- a/src/api_params.rs
+++ b/src/api_params.rs
@@ -6,12 +6,12 @@ use crate::objects::{
     InlineQueryResultCachedVoice, InlineQueryResultContact, InlineQueryResultDocument,
     InlineQueryResultGame, InlineQueryResultGif, InlineQueryResultLocation,
     InlineQueryResultMpeg4Gif, InlineQueryResultPhoto, InlineQueryResultVenue,
-    InlineQueryResultVideo, InlineQueryResultVoice, LabeledPrice, MaskPosition, MessageEntity,
-    PassportElementErrorDataField, PassportElementErrorFile, PassportElementErrorFiles,
-    PassportElementErrorFrontSide, PassportElementErrorReverseSide, PassportElementErrorSelfie,
-    PassportElementErrorTranslationFile, PassportElementErrorTranslationFiles,
-    PassportElementErrorUnspecified, PollType, ReplyKeyboardMarkup, ReplyKeyboardRemove,
-    ShippingOption,
+    InlineQueryResultVideo, InlineQueryResultVoice, LabeledPrice, MaskPosition, MenuButton,
+    MessageEntity, PassportElementErrorDataField, PassportElementErrorFile,
+    PassportElementErrorFiles, PassportElementErrorFrontSide, PassportElementErrorReverseSide,
+    PassportElementErrorSelfie, PassportElementErrorTranslationFile,
+    PassportElementErrorTranslationFiles, PassportElementErrorUnspecified, PollType,
+    ReplyKeyboardMarkup, ReplyKeyboardRemove, ShippingOption,
 };
 use crate::ParseMode;
 use serde::Deserialize;
@@ -2114,4 +2114,22 @@ pub struct AnswerWebAppQueryParams {
     pub web_app_query_id: String,
 
     pub result: InlineQueryResult,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
+pub struct SetChatMenuButtonParams {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[builder(setter(into, strip_option), default)]
+    pub chat_id: Option<i64>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[builder(setter(into, strip_option), default)]
+    pub menu_button: Option<MenuButton>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
+pub struct GetChatMenuButtonParams {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[builder(setter(into, strip_option), default)]
+    pub chat_id: Option<i64>,
 }

--- a/src/api_traits/async_telegram_api.rs
+++ b/src/api_traits/async_telegram_api.rs
@@ -31,6 +31,7 @@ use crate::api_params::ForwardMessageParams;
 use crate::api_params::GetChatAdministratorsParams;
 use crate::api_params::GetChatMemberCountParams;
 use crate::api_params::GetChatMemberParams;
+use crate::api_params::GetChatMenuButtonParams;
 use crate::api_params::GetChatParams;
 use crate::api_params::GetFileParams;
 use crate::api_params::GetGameHighScoresParams;
@@ -66,6 +67,7 @@ use crate::api_params::SendVideoParams;
 use crate::api_params::SendVoiceParams;
 use crate::api_params::SetChatAdministratorCustomTitleParams;
 use crate::api_params::SetChatDescriptionParams;
+use crate::api_params::SetChatMenuButtonParams;
 use crate::api_params::SetChatPermissionsParams;
 use crate::api_params::SetChatPhotoParams;
 use crate::api_params::SetChatStickerSetParams;
@@ -89,6 +91,7 @@ use crate::objects::ChatInviteLink;
 use crate::objects::ChatMember;
 use crate::objects::File as FileObject;
 use crate::objects::GameHighScore;
+use crate::objects::MenuButton;
 use crate::objects::Message;
 use crate::objects::MessageId;
 use crate::objects::Poll;
@@ -1020,6 +1023,20 @@ pub trait AsyncTelegramApi {
         params: &AnswerWebAppQueryParams,
     ) -> Result<MethodResponse<SentWebAppMessage>, Self::Error> {
         self.request("answerWebAppQuery", Some(params)).await
+    }
+
+    async fn set_chat_menu_button(
+        &self,
+        params: SetChatMenuButtonParams,
+    ) -> Result<MethodResponse<bool>, Self::Error> {
+        self.request("setChatMenuButton", Some(params)).await
+    }
+
+    async fn get_chat_menu_button(
+        &self,
+        params: GetChatMenuButtonParams,
+    ) -> Result<MethodResponse<MenuButton>, Self::Error> {
+        self.request("getChatMenuButton", Some(params)).await
     }
 
     async fn request_without_body<T: serde::de::DeserializeOwned>(

--- a/src/api_traits/async_telegram_api.rs
+++ b/src/api_traits/async_telegram_api.rs
@@ -5,6 +5,7 @@ use crate::api_params::AnswerCallbackQueryParams;
 use crate::api_params::AnswerInlineQueryParams;
 use crate::api_params::AnswerPreCheckoutQueryParams;
 use crate::api_params::AnswerShippingQueryParams;
+use crate::api_params::AnswerWebAppQueryParams;
 use crate::api_params::ApproveChatJoinRequestParams;
 use crate::api_params::BanChatMemberParams;
 use crate::api_params::BanChatSenderChatParams;
@@ -34,7 +35,7 @@ use crate::api_params::GetChatParams;
 use crate::api_params::GetFileParams;
 use crate::api_params::GetGameHighScoresParams;
 use crate::api_params::GetMyCommandsParams;
-use crate::api_params::GetMyDefaultAdministratorRights;
+use crate::api_params::GetMyDefaultAdministratorRightsParams;
 use crate::api_params::GetStickerSetParams;
 use crate::api_params::GetUpdatesParams;
 use crate::api_params::GetUserProfilePhotosParams;
@@ -91,6 +92,7 @@ use crate::objects::GameHighScore;
 use crate::objects::Message;
 use crate::objects::MessageId;
 use crate::objects::Poll;
+use crate::objects::SentWebAppMessage;
 use crate::objects::StickerSet;
 use crate::objects::Update;
 use crate::objects::User;
@@ -1007,10 +1009,17 @@ pub trait AsyncTelegramApi {
 
     async fn get_my_default_administrator_rights(
         &self,
-        params: &GetMyDefaultAdministratorRights,
+        params: &GetMyDefaultAdministratorRightsParams,
     ) -> Result<MethodResponse<ChatAdministratorRights>, Self::Error> {
         self.request("getMyDefaultAdministratorRights", Some(params))
             .await
+    }
+
+    async fn answer_web_app_query(
+        &self,
+        params: &AnswerWebAppQueryParams,
+    ) -> Result<MethodResponse<SentWebAppMessage>, Self::Error> {
+        self.request("answerWebAppQuery", Some(params)).await
     }
 
     async fn request_without_body<T: serde::de::DeserializeOwned>(

--- a/src/api_traits/telegram_api.rs
+++ b/src/api_traits/telegram_api.rs
@@ -5,6 +5,7 @@ use crate::api_params::AnswerCallbackQueryParams;
 use crate::api_params::AnswerInlineQueryParams;
 use crate::api_params::AnswerPreCheckoutQueryParams;
 use crate::api_params::AnswerShippingQueryParams;
+use crate::api_params::AnswerWebAppQueryParams;
 use crate::api_params::ApproveChatJoinRequestParams;
 use crate::api_params::BanChatMemberParams;
 use crate::api_params::BanChatSenderChatParams;
@@ -34,7 +35,7 @@ use crate::api_params::GetChatParams;
 use crate::api_params::GetFileParams;
 use crate::api_params::GetGameHighScoresParams;
 use crate::api_params::GetMyCommandsParams;
-use crate::api_params::GetMyDefaultAdministratorRights;
+use crate::api_params::GetMyDefaultAdministratorRightsParams;
 use crate::api_params::GetStickerSetParams;
 use crate::api_params::GetUpdatesParams;
 use crate::api_params::GetUserProfilePhotosParams;
@@ -91,6 +92,7 @@ use crate::objects::GameHighScore;
 use crate::objects::Message;
 use crate::objects::MessageId;
 use crate::objects::Poll;
+use crate::objects::SentWebAppMessage;
 use crate::objects::StickerSet;
 use crate::objects::Update;
 use crate::objects::User;
@@ -952,9 +954,16 @@ pub trait TelegramApi {
 
     fn get_my_default_administrator_rights(
         &self,
-        params: &GetMyDefaultAdministratorRights,
+        params: &GetMyDefaultAdministratorRightsParams,
     ) -> Result<MethodResponse<ChatAdministratorRights>, Self::Error> {
         self.request("getMyDefaultAdministratorRights", Some(params))
+    }
+
+    fn answer_web_app_query(
+        &self,
+        params: &AnswerWebAppQueryParams,
+    ) -> Result<MethodResponse<SentWebAppMessage>, Self::Error> {
+        self.request("answerWebAppQuery", Some(params))
     }
 
     fn request_without_body<T: serde::de::DeserializeOwned>(

--- a/src/api_traits/telegram_api.rs
+++ b/src/api_traits/telegram_api.rs
@@ -31,6 +31,7 @@ use crate::api_params::ForwardMessageParams;
 use crate::api_params::GetChatAdministratorsParams;
 use crate::api_params::GetChatMemberCountParams;
 use crate::api_params::GetChatMemberParams;
+use crate::api_params::GetChatMenuButtonParams;
 use crate::api_params::GetChatParams;
 use crate::api_params::GetFileParams;
 use crate::api_params::GetGameHighScoresParams;
@@ -66,6 +67,7 @@ use crate::api_params::SendVideoParams;
 use crate::api_params::SendVoiceParams;
 use crate::api_params::SetChatAdministratorCustomTitleParams;
 use crate::api_params::SetChatDescriptionParams;
+use crate::api_params::SetChatMenuButtonParams;
 use crate::api_params::SetChatPermissionsParams;
 use crate::api_params::SetChatPhotoParams;
 use crate::api_params::SetChatStickerSetParams;
@@ -89,6 +91,7 @@ use crate::objects::ChatInviteLink;
 use crate::objects::ChatMember;
 use crate::objects::File as FileObject;
 use crate::objects::GameHighScore;
+use crate::objects::MenuButton;
 use crate::objects::Message;
 use crate::objects::MessageId;
 use crate::objects::Poll;
@@ -964,6 +967,20 @@ pub trait TelegramApi {
         params: &AnswerWebAppQueryParams,
     ) -> Result<MethodResponse<SentWebAppMessage>, Self::Error> {
         self.request("answerWebAppQuery", Some(params))
+    }
+
+    fn set_chat_menu_button(
+        &self,
+        params: SetChatMenuButtonParams,
+    ) -> Result<MethodResponse<bool>, Self::Error> {
+        self.request("setChatMenuButton", Some(params))
+    }
+
+    fn get_chat_menu_button(
+        &self,
+        params: GetChatMenuButtonParams,
+    ) -> Result<MethodResponse<MenuButton>, Self::Error> {
+        self.request("getChatMenuButton", Some(params))
     }
 
     fn request_without_body<T: serde::de::DeserializeOwned>(

--- a/src/objects.rs
+++ b/src/objects.rs
@@ -145,6 +145,25 @@ pub enum PassportElementErrorTranslationFileType {
     TemporaryRegistration,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "type")]
+pub enum MenuButton {
+    #[serde(rename = "commands")]
+    Commands,
+    #[serde(rename = "web_app")]
+    WebApp(MenuButtonWebApp),
+    #[serde(rename = "default")]
+    Default,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+pub struct MenuButtonWebApp {
+    #[builder(setter(into))]
+    pub text: String,
+
+    pub web_app: WebAppInfo,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
 pub struct ChatMemberOwner {
     pub user: User,

--- a/src/objects.rs
+++ b/src/objects.rs
@@ -684,6 +684,10 @@ pub struct Message {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(setter(into, strip_option), default)]
+    pub web_app_data: Option<WebAppData>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[builder(setter(into, strip_option), default)]
     pub reply_markup: Option<InlineKeyboardMarkup>,
 }
 
@@ -1118,6 +1122,10 @@ pub struct KeyboardButton {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(setter(into, strip_option), default)]
     pub request_poll: Option<KeyboardButtonPollType>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[builder(setter(into, strip_option), default)]
+    pub web_app: Option<WebAppInfo>,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Builder)]
@@ -1158,6 +1166,10 @@ pub struct InlineKeyboardButton {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(setter(into, strip_option), default)]
     pub callback_data: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[builder(setter(into, strip_option), default)]
+    pub web_app: Option<WebAppInfo>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(setter(into, strip_option), default)]
@@ -2810,4 +2822,25 @@ pub struct ChatAdministratorRights {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(setter(into, strip_option), default)]
     pub can_pin_messages: Option<bool>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+pub struct WebAppInfo {
+    #[builder(setter(into))]
+    pub url: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+pub struct SentWebAppMessage {
+    #[builder(setter(into))]
+    pub inline_message_id: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+pub struct WebAppData {
+    #[builder(setter(into))]
+    pub data: String,
+
+    #[builder(setter(into))]
+    pub button_text: String,
 }


### PR DESCRIPTION
- Added support for Web Apps, see the [detailed manual here](https://core.telegram.org/bots/webapps). ([blog announcement](https://telegram.org/blog/notifications-bots))
- Added the class [WebAppInfo](https://core.telegram.org/bots/api#webappinfo) and the fields web_app to the classes [KeyboardButton](https://core.telegram.org/bots/api#keyboardbutton) and [InlineKeyboardButton](https://core.telegram.org/bots/api#inlinekeyboardbutton).
- Added the class [SentWebAppMessage](https://core.telegram.org/bots/api#sentwebappmessage) and the method [answerWebAppQuery](https://core.telegram.org/bots/api#answerwebappquery) for sending an answer to a Web App query, which originated from an inline button of the 'web_app' type.
- Added the class [WebAppData](https://core.telegram.org/bots/api#webappdata) and the field web_app_data to the class [Message](https://core.telegram.org/bots/api#message).
- Added the class [MenuButton](https://core.telegram.org/bots/api#menubutton) and the methods [setChatMenuButton](https://core.telegram.org/bots/api#setchatmenubutton) and [getChatMenuButton](https://core.telegram.org/bots/api#getchatmenubutton) for managing the behavior of the bot's menu button in private chats.