### PR TITLE
refactor: adopt breaking lints

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -17,13 +17,13 @@ pub static BASE_API_URL: &str = "https://api.telegram.org/bot";
 #[serde(untagged)]
 pub enum Error {
     #[error("{0}")]
-    HttpError(HttpError),
+    Http(HttpError),
     #[error("Api Error {0:?}")]
-    ApiError(ErrorResponse),
+    Api(ErrorResponse),
     #[error("Decode Error {0}")]
-    DecodeError(String),
+    Decode(String),
     #[error("Encode Error {0}")]
-    EncodeError(String),
+    Encode(String),
 }
 
 #[derive(PartialEq, Debug, Serialize, Deserialize, thiserror::Error)]

--- a/src/objects.rs
+++ b/src/objects.rs
@@ -545,7 +545,7 @@ pub struct Message {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(setter(into, strip_option), default)]
-    pub entities: Option<Vec<Box<MessageEntity>>>,
+    pub entities: Option<Vec<MessageEntity>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(setter(into, strip_option), default)]
@@ -561,7 +561,7 @@ pub struct Message {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(setter(into, strip_option), default)]
-    pub photo: Option<Vec<Box<PhotoSize>>>,
+    pub photo: Option<Vec<PhotoSize>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(setter(into, strip_option), default)]
@@ -585,7 +585,7 @@ pub struct Message {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(setter(into, strip_option), default)]
-    pub caption_entities: Option<Vec<Box<MessageEntity>>>,
+    pub caption_entities: Option<Vec<MessageEntity>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(setter(into, strip_option), default)]
@@ -613,7 +613,7 @@ pub struct Message {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(setter(into, strip_option), default)]
-    pub new_chat_members: Option<Vec<Box<User>>>,
+    pub new_chat_members: Option<Vec<User>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(setter(into, strip_option), default)]
@@ -625,7 +625,7 @@ pub struct Message {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(setter(into, strip_option), default)]
-    pub new_chat_photo: Option<Vec<Box<PhotoSize>>>,
+    pub new_chat_photo: Option<Vec<PhotoSize>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(setter(into, strip_option), default)]

--- a/src/parse_mode.rs
+++ b/src/parse_mode.rs
@@ -28,7 +28,7 @@ impl FromStr for ParseMode {
 }
 
 impl ParseMode {
-    pub const fn to_str(&self) -> &'static str {
+    pub const fn to_str(self) -> &'static str {
         match self {
             ParseMode::Html => "HTML",
             ParseMode::MarkdownV2 => "MarkdownV2",


### PR DESCRIPTION
This is a breaking change but it improves efficiency or readability

- https://rust-lang.github.io/rust-clippy/master/index.html#vec_box
- https://rust-lang.github.io/rust-clippy/master/index.html#enum_variant_names
- https://rust-lang.github.io/rust-clippy/master/index.html#trivially_copy_pass_by_ref