### PR TITLE
Use client timeout of 500 seconds

### DIFF
--- a/src/api/async_telegram_api_impl.rs
+++ b/src/api/async_telegram_api_impl.rs
@@ -15,7 +15,7 @@ pub struct AsyncApi {
     #[builder(setter(into))]
     pub api_url: String,
     #[builder(
-        default_code = "reqwest::ClientBuilder::new().connect_timeout(Duration::from_secs(10)).timeout(Duration::from_secs(10)).build().unwrap()"
+        default_code = "reqwest::ClientBuilder::new().connect_timeout(Duration::from_secs(500)).timeout(Duration::from_secs(500)).build().unwrap()"
     )]
     pub client: reqwest::Client,
 }

--- a/src/api/telegram_api_impl.rs
+++ b/src/api/telegram_api_impl.rs
@@ -13,7 +13,7 @@ use ureq::Response;
 pub struct Api {
     #[builder(setter(into))]
     pub api_url: String,
-    #[builder(default_code = "ureq::builder().timeout(Duration::from_secs(10)).build()")]
+    #[builder(default_code = "ureq::builder().timeout(Duration::from_secs(500)).build()")]
     pub request_agent: ureq::Agent,
 }
 


### PR DESCRIPTION
Increase the client timeout to 500s. The bot API itself also has 500 seconds of timeout (thats where the magic number 500 comes from).

The actual number is just copied over from this discussion in grammY, a Telegram Bot Library for Deno/Node.js: https://github.com/grammyjs/grammY/pull/79#discussion_r746618466
grammY uses the 500s timeout for 5 months now without any known issues.
Here are the official docs for it in grammY: https://doc.deno.land/https://deno.land/x/grammy@v1.9.2/mod.ts/~/ApiClientOptions#timeoutSeconds

Yes, I have seen the issue #74 and I am not sure if that's really something a default should handle. I don't want to repeat the discussion of the grammY PR I linked, it discussed a lot of specifics there.

The reason why I noticed it: My bot uploads multiple hundreds of MB (with a selfhosted tdlib server). This runs on a VPS with gigabit connection so its mostly no problem, except for the bigger ones. Which turn out to require about 20 seconds. #77 changed this default timeout of the sync client from 60s → 10s and the issue is since I updated `frankenstein` to the version containing #77. 20s worked with 60s but fails with the newly introduced 10s timeout.
Thanks to @KnorpelSenf for thinking with me about my issue and for helping me pinpoint it to its root cause!