### PR TITLE
fix icon_custom_emoji_id type

### DIFF
--- a/src/api_params.rs
+++ b/src/api_params.rs
@@ -1481,7 +1481,7 @@ pub struct CreateForumTopicParams {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(setter(into, strip_option), default)]
-    pub icon_custom_emoji_id: Option<String>,
+    pub icon_custom_emoji_id: Option<u128>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
@@ -1496,7 +1496,7 @@ pub struct EditForumTopicParams {
     pub name: String,
 
     #[builder(setter(into))]
-    pub icon_custom_emoji_id: String,
+    pub icon_custom_emoji_id: u128,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]

--- a/src/api_params.rs
+++ b/src/api_params.rs
@@ -1481,7 +1481,7 @@ pub struct CreateForumTopicParams {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(setter(into, strip_option), default)]
-    pub icon_custom_emoji_id: Option<u128>,
+    pub icon_custom_emoji_id: Option<u64>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
@@ -1496,7 +1496,7 @@ pub struct EditForumTopicParams {
     pub name: String,
 
     #[builder(setter(into))]
-    pub icon_custom_emoji_id: u128,
+    pub icon_custom_emoji_id: u64,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]

--- a/src/objects.rs
+++ b/src/objects.rs
@@ -1143,7 +1143,7 @@ pub struct ForumTopicCreated {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(setter(into, strip_option), default)]
-    pub icon_custom_emoji_id: Option<String>,
+    pub icon_custom_emoji_id: Option<u128>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
@@ -1486,7 +1486,7 @@ pub struct ForumTopic {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(setter(into, strip_option), default)]
-    pub icon_custom_emoji_id: Option<String>,
+    pub icon_custom_emoji_id: Option<u128>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]

--- a/src/objects.rs
+++ b/src/objects.rs
@@ -1143,7 +1143,7 @@ pub struct ForumTopicCreated {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(setter(into, strip_option), default)]
-    pub icon_custom_emoji_id: Option<u128>,
+    pub icon_custom_emoji_id: Option<u64>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
@@ -1486,7 +1486,7 @@ pub struct ForumTopic {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(setter(into, strip_option), default)]
-    pub icon_custom_emoji_id: Option<u128>,
+    pub icon_custom_emoji_id: Option<u64>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]


### PR DESCRIPTION
It seems there is an error in docs. icon_custom_emoji_id is of type integer

Example 5418172437281907576