### PR TITLE
examples: fix cases when offset was not updated

### DIFF
--- a/examples/async_reply_to_message_updates.rs
+++ b/examples/async_reply_to_message_updates.rs
@@ -27,12 +27,11 @@ async fn main() {
                         tokio::spawn(async move {
                             process_message(message, api_clone).await;
                         });
-
-                        update_params = update_params_builder
-                            .clone()
-                            .offset(update.update_id + 1)
-                            .build();
                     }
+                    update_params = update_params_builder
+                        .clone()
+                        .offset(update.update_id + 1)
+                        .build();
                 }
             }
             Err(error) => {

--- a/examples/reply_to_message_updates.rs
+++ b/examples/reply_to_message_updates.rs
@@ -29,12 +29,11 @@ fn main() {
                         if let Err(err) = api.send_message(&send_message_params) {
                             println!("Failed to send message: {:?}", err);
                         }
-
-                        update_params = update_params_builder
-                            .clone()
-                            .offset(update.update_id + 1)
-                            .build();
                     }
+                    update_params = update_params_builder
+                        .clone()
+                        .offset(update.update_id + 1)
+                        .build();
                 }
             }
             Err(error) => {


### PR DESCRIPTION
This change moves `update_params` creation out of the case, when response is recognized as a message. If the response wasn't a message, the code might enter an infinite loop.