### PR TITLE
refactor(lint): adapt to lints

### DIFF
--- a/src/api/async_telegram_api_impl.rs
+++ b/src/api/async_telegram_api_impl.rs
@@ -150,14 +150,14 @@ impl AsyncTelegramApi for AsyncApi {
             .collect();
 
         let mut form = multipart::Form::new();
-        for (key, val) in json_struct.as_object().unwrap().iter() {
+        for (key, val) in json_struct.as_object().unwrap() {
             if !file_keys.contains(&key.as_str()) {
                 let val = match val {
-                    &Value::String(ref val) => val.to_string(),
+                    Value::String(val) => val.to_string(),
                     other => other.to_string(),
                 };
 
-                form = form.text(key.clone(), val.clone());
+                form = form.text(key.clone(), val);
             }
         }
 

--- a/src/api/telegram_api_impl.rs
+++ b/src/api/telegram_api_impl.rs
@@ -134,10 +134,10 @@ impl TelegramApi for Api {
             .collect();
 
         let mut form = Multipart::new();
-        for (key, val) in json_struct.as_object().unwrap().iter() {
+        for (key, val) in json_struct.as_object().unwrap() {
             if !file_keys.contains(&key.as_str()) {
                 let val = match val {
-                    &Value::String(ref val) => val.to_string(),
+                    Value::String(val) => val.to_string(),
                     other => other.to_string(),
                 };
 


### PR DESCRIPTION
#95 CI fails due to new lints. I fixed them and some minor improvements I saw nearby. Works exactly the same as before, just a bit more performance due to one less clone :innocent: 