### PR TITLE
Renamed "banned" user status to "kicked"

### DIFF
--- a/src/objects.rs
+++ b/src/objects.rs
@@ -39,6 +39,7 @@ pub enum ChatMember {
     Member(ChatMemberMember),
     Restricted(ChatMemberRestricted),
     Left(ChatMemberLeft),
+    #[serde(rename = "kicked")]
     Banned(ChatMemberBanned),
 }
 


### PR DESCRIPTION
Re-applied an old bug fix: #78 
Without this, get_updates fails to parse the response if it contains a "kicked" user. This makes the program unable to read any updates.