### PR TITLE
ci(rust): split clippy, features and test

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -4,12 +4,10 @@ on:
   push:
   pull_request:
     types: [reopened, opened]
+  workflow_dispatch:
   schedule:
     # Check if it works with current dependencies
     - cron: "32 2 * * 3" # weekly on Wednesday 2:32 UTC
-
-env:
-  RUSTFLAGS: --deny warnings
 
 jobs:
   rustfmt:
@@ -23,63 +21,98 @@ jobs:
       - uses: actions/checkout@v4
       - run: cargo fmt --check --verbose
 
-  test:
-    name: Test ${{ matrix.toolchain }} ${{ matrix.os }} ${{ matrix.features }}
-    runs-on: ${{ matrix.os }}
+  clippy:
+    name: Clippy ${{ matrix.toolchain }}
+    runs-on: ubuntu-latest
     continue-on-error: ${{ (matrix.toolchain == 'beta') || (matrix.toolchain == 'nightly') }}
     strategy:
       fail-fast: false
       matrix:
         toolchain:
           - stable
-        os:
-          - ubuntu-latest
-          - macos-latest
-          - windows-latest
-        clippyargs:
-          - -D clippy::pedantic
-        features:
-          - --no-default-features
-          - "" # default features
-          - --all-features
-        include:
-          # Check future versions and maybe get some glances on soon to be lints
-          - toolchain: beta
-            os: ubuntu-latest
-            features: --all-features
-            clippyargs: -D clippy::pedantic
-          - toolchain: nightly
-            os: ubuntu-latest
-            features: --all-features
-            clippyargs: -D clippy::pedantic
+          - beta
+          - nightly
+    env:
+      RUSTFLAGS: --deny warnings
     steps:
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.toolchain }}
           components: clippy
+      - uses: actions/checkout@v4
+      - run: cargo fetch
+      - run: cargo clippy --offline --all-features --all-targets -- -D clippy::pedantic
+      - run: cargo doc --offline --all-features --no-deps
+
+  features:
+    name: Features ${{ matrix.toolchain }} ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        toolchain:
+          - stable
+          - beta
+        os:
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
+    env:
+      RUSTFLAGS: --allow unknown-lints --deny warnings
+    steps:
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ matrix.toolchain }}
+
+      - name: Install cargo-hack
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-hack
 
       - uses: actions/checkout@v4
+      - run: cargo fetch
 
-      - name: Fetch dependencies
-        run: cargo fetch --verbose
+      - name: Check all targets
+        run: cargo hack --keep-going --feature-powerset check --all-targets --offline
 
-      - name: Check clippy
-        run: cargo clippy --verbose --all-targets ${{ matrix.features }} -- ${{ matrix.clippyargs }}
+      - name: Check without dev dependencies
+        run: cargo hack --keep-going --feature-powerset --no-dev-deps check --offline
 
-      - name: Check docs
-        run: cargo doc --verbose --no-deps ${{ matrix.features }}
-
-      - name: Build
-        run: cargo build --verbose --all-targets ${{ matrix.features }}
-
-      - name: Run tests
-        run: cargo test --verbose ${{ matrix.features }}
+  test:
+    name: Test ${{ matrix.toolchain }} ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.toolchain == 'nightly' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        toolchain:
+          - stable
+          - beta
+          - nightly
+        os:
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
+    env:
+      RUSTFLAGS: --allow unknown-lints --deny warnings
+    steps:
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ matrix.toolchain }}
+      - uses: actions/checkout@v4
+      - run: cargo fetch
+      - run: cargo build --offline --all-features --all-targets
+      - run: cargo test --offline --all-features
 
   release:
     name: Release ${{ matrix.triple }}
     runs-on: ${{ matrix.os }}
-    needs: test
+    needs:
+      - features
+      - test
     strategy:
       fail-fast: false
       matrix:
@@ -104,6 +137,8 @@ jobs:
             os: windows-latest
           - triple: aarch64-pc-windows-msvc
             os: windows-latest
+    env:
+      RUSTFLAGS: --allow unknown-lints --deny warnings
     steps:
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@master
@@ -118,9 +153,7 @@ jobs:
           tool: cross
 
       - uses: actions/checkout@v4
-
-      - name: Fetch dependencies
-        run: cargo fetch --verbose
+      - run: cargo fetch
 
       - name: Build
-        run: ${{ runner.os == 'Linux' && 'cross' || 'cargo' }} build --release --verbose --target ${{ matrix.triple }}
+        run: ${{ runner.os == 'Linux' && 'cross' || 'cargo' }} build --release --offline --all-features --target ${{ matrix.triple }}


### PR DESCRIPTION
Split up the Rust CI into multiple jobs running in parallel. This results in faster results as clips / test are no longer in sequence. Also, the feature set is not automatically tested via cargo-hack instead of some predefined list.