### PR TITLE
Remove "status" from ChatMemberRestricted

### DIFF
--- a/src/objects.rs
+++ b/src/objects.rs
@@ -250,9 +250,6 @@ pub struct ChatMemberMember {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
 pub struct ChatMemberRestricted {
-    #[builder(setter(into))]
-    pub status: String,
-
     pub user: User,
 
     pub is_member: bool,


### PR DESCRIPTION
Fixes decoding error that happens decoding an update that contains ChatMemberRestricted.
#164