### PR TITLE
fix: `message_id` is optional in `ExternalReplyInfo`

### DIFF
--- a/src/objects.rs
+++ b/src/objects.rs
@@ -1012,7 +1012,7 @@ pub struct ExternalReplyInfo {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(setter(into, strip_option), default)]
-    pub chain: Option<Chat>,
+    pub chat: Option<Chat>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(setter(into, strip_option), default)]

--- a/src/objects.rs
+++ b/src/objects.rs
@@ -1014,7 +1014,9 @@ pub struct ExternalReplyInfo {
     #[builder(setter(into, strip_option), default)]
     pub chain: Option<Chat>,
 
-    pub message_id: i32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[builder(setter(into, strip_option), default)]
+    pub message_id: Option<i32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(setter(into, strip_option), default)]


### PR DESCRIPTION
fixes https://github.com/ayrat555/frankenstein/issues/164#issuecomment-2078813442