### PR TITLE
Bot API 7.6

### DIFF
--- a/src/api_params.rs
+++ b/src/api_params.rs
@@ -876,6 +876,47 @@ pub struct SendVideoNoteParams {
     pub reply_markup: Option<ReplyMarkup>,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
+pub struct SendPaidMediaParams {
+    pub chat_id: ChatId,
+
+    pub star_count: u32,
+
+    pub media: Vec<InputPaidMedia>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[builder(setter(into, strip_option), default)]
+    pub caption: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[builder(setter(into, strip_option), default)]
+    pub parse_mode: Option<ParseMode>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[builder(setter(into, strip_option), default)]
+    pub caption_entities: Option<Vec<MessageEntity>>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[builder(setter(into, strip_option), default)]
+    pub show_caption_above_media: Option<bool>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[builder(setter(into, strip_option), default)]
+    pub disable_notification: Option<bool>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[builder(setter(into, strip_option), default)]
+    pub protect_content: Option<bool>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[builder(setter(into, strip_option), default)]
+    pub reply_parameters: Option<ReplyParameters>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[builder(setter(into, strip_option), default)]
+    pub reply_markup: Option<ReplyMarkup>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
 pub struct SendMediaGroupParams {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -2794,45 +2835,6 @@ pub struct GetChatMenuButtonParams {
 pub struct UnpinAllGeneralForumTopicMessagesParams {
     #[builder(setter(into))]
     pub chat_id: ChatId,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-pub struct SendPaidMediaParams {
-    pub chat_id: ChatId,
-    pub star_count: i32,
-    pub media: Vec<InputPaidMedia>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(into, strip_option), default)]
-    pub caption: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(into, strip_option), default)]
-    pub parse_mode: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(into, strip_option), default)]
-    pub caption_entities: Option<Vec<MessageEntity>>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(into, strip_option), default)]
-    pub show_caption_above_media: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(into, strip_option), default)]
-    pub disable_notification: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(into, strip_option), default)]
-    pub protect_content: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(into, strip_option), default)]
-    pub reply_parameters: Option<ReplyParameters>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(into, strip_option), default)]
-    pub reply_markup: Option<ReplyMarkup>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]

--- a/src/api_params.rs
+++ b/src/api_params.rs
@@ -7,10 +7,10 @@ use crate::objects::{
     InlineQueryResultCachedVoice, InlineQueryResultContact, InlineQueryResultDocument,
     InlineQueryResultGame, InlineQueryResultGif, InlineQueryResultLocation,
     InlineQueryResultMpeg4Gif, InlineQueryResultPhoto, InlineQueryResultVenue,
-    InlineQueryResultVideo, InlineQueryResultVoice, InputPollOption, InputSticker, LabeledPrice,
-    LinkPreviewOptions, MaskPosition, MenuButton, MessageEntity, PassportElementErrorDataField,
-    PassportElementErrorFile, PassportElementErrorFiles, PassportElementErrorFrontSide,
-    PassportElementErrorReverseSide, PassportElementErrorSelfie,
+    InlineQueryResultVideo, InlineQueryResultVoice, InputPaidMedia, InputPollOption, InputSticker,
+    LabeledPrice, LinkPreviewOptions, MaskPosition, MenuButton, MessageEntity,
+    PassportElementErrorDataField, PassportElementErrorFile, PassportElementErrorFiles,
+    PassportElementErrorFrontSide, PassportElementErrorReverseSide, PassportElementErrorSelfie,
     PassportElementErrorTranslationFile, PassportElementErrorTranslationFiles,
     PassportElementErrorUnspecified, PollType, ReactionType, ReplyKeyboardMarkup,
     ReplyKeyboardRemove, ShippingOption, StickerFormat, StickerType, WebAppInfo,
@@ -2794,6 +2794,45 @@ pub struct GetChatMenuButtonParams {
 pub struct UnpinAllGeneralForumTopicMessagesParams {
     #[builder(setter(into))]
     pub chat_id: ChatId,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
+pub struct SendPaidMediaParams {
+    pub chat_id: ChatId,
+    pub star_count: i32,
+    pub media: Vec<InputPaidMedia>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[builder(setter(into, strip_option), default)]
+    pub caption: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[builder(setter(into, strip_option), default)]
+    pub parse_mode: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[builder(setter(into, strip_option), default)]
+    pub caption_entities: Option<Vec<MessageEntity>>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[builder(setter(into, strip_option), default)]
+    pub show_caption_above_media: Option<bool>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[builder(setter(into, strip_option), default)]
+    pub disable_notification: Option<bool>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[builder(setter(into, strip_option), default)]
+    pub protect_content: Option<bool>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[builder(setter(into, strip_option), default)]
+    pub reply_parameters: Option<ReplyParameters>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[builder(setter(into, strip_option), default)]
+    pub reply_markup: Option<ReplyMarkup>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]

--- a/src/api_traits/async_telegram_api.rs
+++ b/src/api_traits/async_telegram_api.rs
@@ -459,6 +459,13 @@ pub trait AsyncTelegramApi {
             .await
     }
 
+    async fn send_paid_media(
+        &self,
+        params: SendPaidMediaParams,
+    ) -> Result<MethodResponse<Message>, Self::Error> {
+        self.request("sendPaidMedia", Some(params)).await
+    }
+
     async fn send_location(
         &self,
         params: &SendLocationParams,
@@ -1360,13 +1367,6 @@ pub trait AsyncTelegramApi {
     ) -> Result<MethodResponse<bool>, Self::Error> {
         self.request("unpinAllGeneralForumTopicMessages", Some(params))
             .await
-    }
-
-    async fn send_paid_media(
-        &self,
-        params: SendPaidMediaParams,
-    ) -> Result<MethodResponse<Message>, Self::Error> {
-        self.request("sendPaidMedia", Some(params)).await
     }
 
     async fn request_without_body<T: serde::de::DeserializeOwned>(

--- a/src/api_traits/async_telegram_api.rs
+++ b/src/api_traits/async_telegram_api.rs
@@ -81,6 +81,7 @@ use crate::api_params::SendInvoiceParams;
 use crate::api_params::SendLocationParams;
 use crate::api_params::SendMediaGroupParams;
 use crate::api_params::SendMessageParams;
+use crate::api_params::SendPaidMediaParams;
 use crate::api_params::SendPhotoParams;
 use crate::api_params::SendPollParams;
 use crate::api_params::SendStickerParams;
@@ -1359,6 +1360,13 @@ pub trait AsyncTelegramApi {
     ) -> Result<MethodResponse<bool>, Self::Error> {
         self.request("unpinAllGeneralForumTopicMessages", Some(params))
             .await
+    }
+
+    async fn send_paid_media(
+        &self,
+        params: SendPaidMediaParams,
+    ) -> Result<MethodResponse<Message>, Self::Error> {
+        self.request("sendPaidMedia", Some(params)).await
     }
 
     async fn request_without_body<T: serde::de::DeserializeOwned>(

--- a/src/api_traits/telegram_api.rs
+++ b/src/api_traits/telegram_api.rs
@@ -434,6 +434,13 @@ pub trait TelegramApi {
         self.request_with_possible_form_data(method_name, params, files)
     }
 
+    fn send_paid_media(
+        &self,
+        params: SendPaidMediaParams,
+    ) -> Result<MethodResponse<Message>, Self::Error> {
+        self.request("sendPaidMedia", Some(params))
+    }
+
     fn send_location(
         &self,
         params: &SendLocationParams,
@@ -1297,13 +1304,6 @@ pub trait TelegramApi {
         params: UnpinAllGeneralForumTopicMessagesParams,
     ) -> Result<MethodResponse<bool>, Self::Error> {
         self.request("unpinAllGeneralForumTopicMessages", Some(params))
-    }
-
-    fn send_paid_media(
-        &self,
-        params: SendPaidMediaParams,
-    ) -> Result<MethodResponse<Message>, Self::Error> {
-        self.request("sendPaidMedia", Some(params))
     }
 
     fn request_without_body<T: serde::de::DeserializeOwned>(

--- a/src/api_traits/telegram_api.rs
+++ b/src/api_traits/telegram_api.rs
@@ -80,6 +80,7 @@ use crate::api_params::SendInvoiceParams;
 use crate::api_params::SendLocationParams;
 use crate::api_params::SendMediaGroupParams;
 use crate::api_params::SendMessageParams;
+use crate::api_params::SendPaidMediaParams;
 use crate::api_params::SendPhotoParams;
 use crate::api_params::SendPollParams;
 use crate::api_params::SendStickerParams;
@@ -1296,6 +1297,13 @@ pub trait TelegramApi {
         params: UnpinAllGeneralForumTopicMessagesParams,
     ) -> Result<MethodResponse<bool>, Self::Error> {
         self.request("unpinAllGeneralForumTopicMessages", Some(params))
+    }
+
+    fn send_paid_media(
+        &self,
+        params: SendPaidMediaParams,
+    ) -> Result<MethodResponse<Message>, Self::Error> {
+        self.request("sendPaidMedia", Some(params))
     }
 
     fn request_without_body<T: serde::de::DeserializeOwned>(

--- a/src/objects.rs
+++ b/src/objects.rs
@@ -642,6 +642,10 @@ pub struct ChatFullInfo {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(setter(into, strip_option), default)]
+    pub can_send_paid_media: Option<bool>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[builder(setter(into, strip_option), default)]
     pub slow_mode_delay: Option<u16>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -801,6 +805,10 @@ pub struct Message {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(setter(into, strip_option), default)]
     pub document: Option<Box<Document>>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[builder(setter(into, strip_option), default)]
+    pub paid_media: Option<Box<PaidMediaInfo>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(setter(into, strip_option), default)]
@@ -1095,6 +1103,10 @@ pub struct ExternalReplyInfo {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(setter(into, strip_option), default)]
     pub document: Option<Document>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[builder(setter(into, strip_option), default)]
+    pub paid_media: Option<PaidMediaInfo>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(setter(into, strip_option), default)]
@@ -3510,6 +3522,84 @@ pub struct Invoice {
     pub total_amount: u32,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
+pub struct PaidMediaInfo {
+    pub start_count: u32,
+
+    pub paid_media: Vec<PaidMedia>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum PaidMedia {
+    Preview(PaidMediaPreview),
+    Photo(PaidMediaPhoto),
+    Video(PaidMediaVideo),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
+pub struct PaidMediaPreview {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[builder(setter(into, strip_option), default)]
+    pub width: Option<u32>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[builder(setter(into, strip_option), default)]
+    pub height: Option<u32>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[builder(setter(into, strip_option), default)]
+    pub duration: Option<u32>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct PaidMediaPhoto {
+    pub photo: Vec<PhotoSize>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct PaidMediaVideo {
+    pub video: Video,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum InputPaidMedia {
+    Photo(InputPaidMediaPhoto),
+    Video(InputPaidMediaVideo),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
+pub struct InputPaidMediaPhoto {
+    #[builder(setter(into))]
+    pub media: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
+pub struct InputPaidMediaVideo {
+    #[builder(setter(into))]
+    pub media: String,
+
+    #[builder(setter(into))]
+    pub thumbnail: String,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[builder(setter(into, strip_option), default)]
+    pub width: Option<u32>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[builder(setter(into, strip_option), default)]
+    pub height: Option<u32>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[builder(setter(into, strip_option), default)]
+    pub duration: Option<u32>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[builder(setter(into, strip_option), default)]
+    pub supports_streaming: Option<bool>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
 pub struct ShippingAddress {
     #[builder(setter(into))]
@@ -4170,73 +4260,6 @@ pub struct StarTransaction {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
 pub struct StarTransactions {
     pub transactions: Vec<StarTransaction>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-#[serde(tag = "type", rename_all = "snake_case")]
-pub enum PaidMedia {
-    Preview(PaidMediaPreview),
-    Photo(PaidMediaPhoto),
-    Video(PaidMediaVideo),
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-pub struct PaidMediaPreview {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(into, strip_option), default)]
-    pub width: Option<i32>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(into, strip_option), default)]
-    pub height: Option<i32>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(into, strip_option), default)]
-    pub duration: Option<i32>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub struct PaidMediaPhoto {
-    pub photo: Vec<PhotoSize>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub struct PaidMediaVideo {
-    pub video: Video,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-#[serde(tag = "type", rename_all = "snake_case")]
-pub enum InputPaidMedia {
-    Photo(InputPaidMediaPhoto),
-    Video(InputPaidMediaVideo),
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub struct InputPaidMediaPhoto {
-    pub media: String,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
-pub struct InputPaidMediaVideo {
-    pub media: String,
-    pub thumbnail: FileUpload,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(into, strip_option), default)]
-    pub width: Option<i32>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(into, strip_option), default)]
-    pub height: Option<i32>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(into, strip_option), default)]
-    pub duration: Option<i32>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(setter(into, strip_option), default)]
-    pub supports_streaming: Option<bool>,
 }
 
 #[cfg(test)]

--- a/src/objects.rs
+++ b/src/objects.rs
@@ -3,7 +3,7 @@ use super::api_params::FileUpload;
 use serde::{Deserialize, Serialize};
 use typed_builder::TypedBuilder as Builder;
 
-use crate::ParseMode;
+use crate::{InputFile, ParseMode};
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -4170,6 +4170,73 @@ pub struct StarTransaction {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
 pub struct StarTransactions {
     pub transactions: Vec<StarTransaction>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum PaidMedia {
+    Preview(PaidMediaPreview),
+    Photo(PaidMediaPhoto),
+    Video(PaidMediaVideo),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
+pub struct PaidMediaPreview {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[builder(setter(into, strip_option), default)]
+    pub width: Option<i32>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[builder(setter(into, strip_option), default)]
+    pub height: Option<i32>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[builder(setter(into, strip_option), default)]
+    pub duration: Option<i32>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct PaidMediaPhoto {
+    pub photo: Vec<PhotoSize>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct PaidMediaVideo {
+    pub video: Video,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum InputPaidMedia {
+    Photo(InputPaidMediaPhoto),
+    Video(InputPaidMediaVideo),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct InputPaidMediaPhoto {
+    pub media: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
+pub struct InputPaidMediaVideo {
+    pub media: String,
+    pub thumbnail: FileUpload,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[builder(setter(into, strip_option), default)]
+    pub width: Option<i32>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[builder(setter(into, strip_option), default)]
+    pub height: Option<i32>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[builder(setter(into, strip_option), default)]
+    pub duration: Option<i32>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[builder(setter(into, strip_option), default)]
+    pub supports_streaming: Option<bool>,
 }
 
 #[cfg(test)]

--- a/src/objects.rs
+++ b/src/objects.rs
@@ -3,7 +3,7 @@ use super::api_params::FileUpload;
 use serde::{Deserialize, Serialize};
 use typed_builder::TypedBuilder as Builder;
 
-use crate::{InputFile, ParseMode};
+use crate::ParseMode;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]


### PR DESCRIPTION
https://core.telegram.org/bots/api#july-1-2024

- [X] Added the classes [PaidMedia](https://core.telegram.org/bots/api#paidmedia), [PaidMediaInfo](https://core.telegram.org/bots/api#paidmediainfo), [PaidMediaPreview](https://core.telegram.org/bots/api#paidmediapreview), [PaidMediaPhoto](https://core.telegram.org/bots/api#paidmediaphoto) and [PaidMediaVideo](https://core.telegram.org/bots/api#paidmediavideo), containing information about paid media.
- [x] Added the method [sendPaidMedia](https://core.telegram.org/bots/api#sendpaidmedia) and 
- [X] Added the classes [InputPaidMedia](https://core.telegram.org/bots/api#inputpaidmedia), [InputPaidMediaPhoto](https://core.telegram.org/bots/api#inputpaidmediaphoto) and [InputPaidMediaVideo](https://core.telegram.org/bots/api#inputpaidmediavideo), to support sending paid media.
- [ ] Documented that the methods [copyMessage](https://core.telegram.org/bots/api#copymessage) and [copyMessages](https://core.telegram.org/bots/api#copymessages) cannot be used to copy paid media.
- [ ] Added the field can_send_paid_media to the class [ChatFullInfo](https://core.telegram.org/bots/api#chatfullinfo).
- [ ] Added the field paid_media to the classes [Message](https://core.telegram.org/bots/api#message) and [ExternalReplyInfo](https://core.telegram.org/bots/api#externalreplyinfo).
- [x] Added the class [TransactionPartnerTelegramAds](https://core.telegram.org/bots/api#transactionpartnertelegramads), containing information about Telegram Star transactions involving the Telegram Ads Platform.
- [ ] Added the field invoice_payload to the class [TransactionPartnerUser](https://core.telegram.org/bots/api#transactionpartneruser), containing the bot-specified invoice payload.
- [ ] Changed the default opening mode for [Direct Link Mini Apps](https://core.telegram.org/bots/webapps#direct-link-mini-apps).
- [ ] Added support for launching Web Apps via t.me link in the class [MenuButtonWebApp](https://core.telegram.org/bots/api#menubuttonwebapp).
- [ ] Added the field section_separator_color to the class [ThemeParams](https://core.telegram.org/bots/webapps#themeparams).