### PR TITLE
Ability to attach files formed from bytes

### DIFF
--- a/examples/api_trait_implementation.rs
+++ b/examples/api_trait_implementation.rs
@@ -1,8 +1,8 @@
 use frankenstein::ErrorResponse;
+use frankenstein::FileUploadForm;
 use frankenstein::SendMessageParams;
 use frankenstein::TelegramApi;
 use isahc::{prelude::*, Request};
-use std::path::PathBuf;
 
 static TOKEN: &str = "TOKEN";
 static BASE_API_URL: &str = "https://api.telegram.org/bot";
@@ -106,7 +106,7 @@ impl TelegramApi for Api {
         &self,
         _method: &str,
         _params: T1,
-        _files: Vec<(&str, PathBuf)>,
+        _files: Vec<FileUploadForm>,
     ) -> Result<T2, Error> {
         let error = HttpError {
             code: 500,

--- a/src/api/async_telegram_api_impl.rs
+++ b/src/api/async_telegram_api_impl.rs
@@ -1,11 +1,12 @@
 use super::Error;
 use super::HttpError;
+use crate::api_params::FileUpload;
+use crate::api_params::FileUploadForm;
 use crate::api_traits::AsyncTelegramApi;
 use crate::api_traits::ErrorResponse;
 use async_trait::async_trait;
 use reqwest::multipart;
 use serde_json::Value;
-use std::path::PathBuf;
 use std::time::Duration;
 use tokio::fs::File;
 use typed_builder::TypedBuilder;
@@ -133,21 +134,11 @@ impl AsyncTelegramApi for AsyncApi {
         &self,
         method: &str,
         params: T1,
-        files: Vec<(&str, PathBuf)>,
+        files: Vec<FileUploadForm>,
     ) -> Result<T2, Self::Error> {
         let json_string = Self::encode_params(&params)?;
         let json_struct: Value = serde_json::from_str(&json_string).unwrap();
-        let file_keys: Vec<&str> = files.iter().map(|(key, _)| *key).collect();
-        let files_with_paths: Vec<(String, &str, String)> = files
-            .iter()
-            .map(|(key, path)| {
-                (
-                    (*key).to_string(),
-                    path.to_str().unwrap(),
-                    path.file_name().unwrap().to_str().unwrap().to_string(),
-                )
-            })
-            .collect();
+        let file_keys: Vec<&str> = files.iter().map(|(key, _)| key.as_str()).collect();
 
         let mut form = multipart::Form::new();
         for (key, val) in json_struct.as_object().unwrap() {
@@ -161,11 +152,25 @@ impl AsyncTelegramApi for AsyncApi {
             }
         }
 
-        for (parameter_name, file_path, file_name) in files_with_paths {
-            let file = File::open(file_path).await?;
+        for (parameter_name, file) in files {
+            match file {
+                FileUpload::InputFile(input_file) => {
+                    let file_path = input_file.path;
+                    let file = File::open(&file_path).await?;
+                    let file_name = file_path.file_name().unwrap().to_str().unwrap().to_string();
 
-            let part = multipart::Part::stream(file).file_name(file_name);
-            form = form.part(parameter_name, part);
+                    let part = multipart::Part::stream(file).file_name(file_name);
+                    form = form.part(parameter_name, part);
+                }
+                FileUpload::InputBuf(input_buf) => {
+                    let buf = input_buf.data.clone();
+                    let file_name = input_buf.file_name.clone();
+
+                    let part = multipart::Part::stream(buf).file_name(file_name);
+                    form = form.part(parameter_name, part);
+                }
+                FileUpload::String(_) => continue,
+            }
         }
 
         let url = format!("{}/{method}", self.api_url);

--- a/src/api/telegram_api_impl.rs
+++ b/src/api/telegram_api_impl.rs
@@ -142,7 +142,7 @@ impl TelegramApi for Api {
             }
         }
 
-        for (parameter_name, file) in files.iter() {
+        for (parameter_name, file) in &files {
             match file {
                 FileUpload::InputFile(input_file) => {
                     let file = std::fs::File::open(&input_file.path).unwrap();

--- a/src/api/telegram_api_impl.rs
+++ b/src/api/telegram_api_impl.rs
@@ -1,10 +1,11 @@
 use super::Error;
 use super::HttpError;
+use crate::api_params::FileUpload;
+use crate::api_params::FileUploadForm;
 use crate::api_traits::ErrorResponse;
 use crate::api_traits::TelegramApi;
 use multipart::client::lazy::Multipart;
 use serde_json::Value;
-use std::path::PathBuf;
 use std::time::Duration;
 use typed_builder::TypedBuilder;
 use ureq::Response;
@@ -123,15 +124,11 @@ impl TelegramApi for Api {
         &self,
         method: &str,
         params: T1,
-        files: Vec<(&str, PathBuf)>,
+        files: Vec<FileUploadForm>,
     ) -> Result<T2, Error> {
         let json_string = Self::encode_params(&params)?;
         let json_struct: Value = serde_json::from_str(&json_string).unwrap();
-        let file_keys: Vec<&str> = files.iter().map(|(key, _)| *key).collect();
-        let files_with_names: Vec<(&str, Option<&str>, PathBuf)> = files
-            .iter()
-            .map(|(key, path)| (*key, path.file_name().unwrap().to_str(), path.clone()))
-            .collect();
+        let file_keys: Vec<&str> = files.iter().map(|(key, _)| key.as_str()).collect();
 
         let mut form = Multipart::new();
         for (key, val) in json_struct.as_object().unwrap() {
@@ -145,15 +142,26 @@ impl TelegramApi for Api {
             }
         }
 
-        for (parameter_name, file_name, file_path) in files_with_names {
-            let file = std::fs::File::open(&file_path).unwrap();
-            let file_extension = file_path
-                .extension()
-                .and_then(std::ffi::OsStr::to_str)
-                .unwrap_or("");
-            let mime = mime_guess::from_ext(file_extension).first_or_octet_stream();
+        for (parameter_name, file) in files.iter() {
+            match file {
+                FileUpload::InputFile(input_file) => {
+                    let file = std::fs::File::open(&input_file.path).unwrap();
+                    let file_name = input_file.path.file_name().unwrap().to_str();
+                    let file_extension =
+                        input_file.path.extension().unwrap().to_str().unwrap_or("");
+                    let mime = mime_guess::from_ext(file_extension).first_or_octet_stream();
 
-            form.add_stream(parameter_name, file, file_name, Some(mime));
+                    form.add_stream(parameter_name, file, file_name, Some(mime));
+                }
+                FileUpload::InputBuf(input_buf) => {
+                    let file = std::io::Cursor::<Vec<u8>>::new(input_buf.data.clone());
+                    let file_extension = input_buf.file_name.rsplit_once('.').unwrap_or(("", "")).1;
+                    let mime = mime_guess::from_ext(file_extension).first_or_octet_stream();
+
+                    form.add_stream(parameter_name, file, Some(&input_buf.file_name), Some(mime));
+                }
+                FileUpload::String(_) => continue,
+            }
         }
 
         let url = format!("{}/{method}", self.api_url);

--- a/src/api_params.rs
+++ b/src/api_params.rs
@@ -25,7 +25,16 @@ use typed_builder::TypedBuilder as Builder;
 #[serde(untagged)]
 pub enum FileUpload {
     InputFile(InputFile),
+    InputBuf(InputBuf),
     String(String),
+}
+
+pub type FileUploadForm = (String, FileUpload);
+
+impl FileUpload {
+    pub fn to_form(&self, key: &str) -> FileUploadForm {
+        (key.to_string(), self.clone())
+    }
 }
 
 impl From<PathBuf> for FileUpload {
@@ -36,9 +45,33 @@ impl From<PathBuf> for FileUpload {
     }
 }
 
+impl From<(String, Vec<u8>)> for FileUpload {
+    fn from((file_name, data): (String, Vec<u8>)) -> Self {
+        Self::InputBuf(InputBuf { file_name, data })
+    }
+}
+
 impl From<InputFile> for FileUpload {
     fn from(file: InputFile) -> Self {
         Self::InputFile(file)
+    }
+}
+
+impl From<&InputFile> for FileUpload {
+    fn from(file: &InputFile) -> Self {
+        Self::InputFile(file.clone())
+    }
+}
+
+impl From<InputBuf> for FileUpload {
+    fn from(input: InputBuf) -> Self {
+        Self::InputBuf(input)
+    }
+}
+
+impl From<&InputBuf> for FileUpload {
+    fn from(input: &InputBuf) -> Self {
+        Self::InputBuf(input.clone())
     }
 }
 
@@ -218,6 +251,12 @@ pub struct BotCommandScopeChatMember {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
 pub struct InputFile {
     pub path: PathBuf,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+pub struct InputBuf {
+    pub file_name: String,
+    pub data: Vec<u8>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]

--- a/src/api_params.rs
+++ b/src/api_params.rs
@@ -32,8 +32,12 @@ pub enum FileUpload {
 pub type FileUploadForm = (String, FileUpload);
 
 impl FileUpload {
-    pub fn to_form(&self, key: &str) -> FileUploadForm {
+    pub fn to_form_with_key(&self, key: &str) -> FileUploadForm {
         (key.to_string(), self.clone())
+    }
+
+    pub fn is_input(&self) -> bool {
+        matches!(self, FileUpload::InputFile(_) | FileUpload::InputBuf(_))
     }
 }
 

--- a/src/api_traits/async_telegram_api.rs
+++ b/src/api_traits/async_telegram_api.rs
@@ -37,6 +37,7 @@ use crate::api_params::EditMessageReplyMarkupParams;
 use crate::api_params::EditMessageTextParams;
 use crate::api_params::ExportChatInviteLinkParams;
 use crate::api_params::FileUpload;
+use crate::api_params::FileUploadForm;
 use crate::api_params::ForwardMessageParams;
 use crate::api_params::ForwardMessagesParams;
 use crate::api_params::GetBusinessConnectionParams;
@@ -129,7 +130,6 @@ use crate::objects::ChatAdministratorRights;
 use crate::objects::ChatFullInfo;
 use crate::objects::ChatInviteLink;
 use crate::objects::ChatMember;
-use crate::objects::File as FileObject;
 use crate::objects::ForumTopic;
 use crate::objects::GameHighScore;
 use crate::objects::InputSticker;
@@ -148,7 +148,6 @@ use crate::objects::WebhookInfo;
 use crate::Sticker;
 use crate::UnpinAllGeneralForumTopicMessagesParams;
 use async_trait::async_trait;
-use std::path::PathBuf;
 
 #[async_trait]
 pub trait AsyncTelegramApi {
@@ -231,11 +230,9 @@ pub trait AsyncTelegramApi {
         params: &SendPhotoParams,
     ) -> Result<MethodResponse<Message>, Self::Error> {
         let method_name = "sendPhoto";
-        let mut files: Vec<(&str, PathBuf)> = vec![];
+        let mut files: Vec<FileUploadForm> = vec![];
 
-        if let FileUpload::InputFile(input_file) = &params.photo {
-            files.push(("photo", input_file.path.clone()));
-        }
+        files.push(params.photo.to_form("photo"));
 
         self.request_with_possible_form_data(method_name, params, files)
             .await
@@ -246,14 +243,12 @@ pub trait AsyncTelegramApi {
         params: &SendAudioParams,
     ) -> Result<MethodResponse<Message>, Self::Error> {
         let method_name = "sendAudio";
-        let mut files: Vec<(&str, PathBuf)> = vec![];
+        let mut files: Vec<FileUploadForm> = vec![];
 
-        if let FileUpload::InputFile(input_file) = &params.audio {
-            files.push(("audio", input_file.path.clone()));
-        }
+        files.push(params.audio.to_form("audio"));
 
-        if let Some(FileUpload::InputFile(input_file)) = &params.thumbnail {
-            files.push(("thumbnail", input_file.path.clone()));
+        if let Some(thumbnail) = &params.thumbnail {
+            files.push(thumbnail.to_form("thumbnail"));
         }
 
         self.request_with_possible_form_data(method_name, params, files)
@@ -265,7 +260,7 @@ pub trait AsyncTelegramApi {
         params: &SendMediaGroupParams,
     ) -> Result<MethodResponse<Vec<Message>>, Self::Error> {
         let method_name = "sendMediaGroup";
-        let mut files: Vec<(String, PathBuf)> = vec![];
+        let mut files: Vec<FileUploadForm> = vec![];
         let mut new_medias: Vec<Media> = vec![];
         let mut file_idx = 0;
 
@@ -274,24 +269,22 @@ pub trait AsyncTelegramApi {
                 Media::Audio(audio) => {
                     let mut new_audio = audio.clone();
 
-                    if let FileUpload::InputFile(input_file) = &audio.media {
-                        let name = format!("file{file_idx}");
-                        let attach_name = format!("attach://{name}");
-                        file_idx += 1;
+                    let name = format!("file{file_idx}");
+                    let attach_name = format!("attach://{name}");
+                    file_idx += 1;
 
-                        new_audio.media = FileUpload::String(attach_name);
+                    new_audio.media = FileUpload::String(attach_name);
 
-                        files.push((name, input_file.path.clone()));
-                    };
+                    files.push((name, audio.media.clone()));
 
-                    if let Some(FileUpload::InputFile(input_file)) = &audio.thumbnail {
+                    if let Some(thumbnail) = &audio.thumbnail {
                         let name = format!("file{file_idx}");
                         let attach_name = format!("attach://{name}");
                         file_idx += 1;
 
                         new_audio.thumbnail = Some(FileUpload::String(attach_name));
 
-                        files.push((name, input_file.path.clone()));
+                        files.push(thumbnail.to_form(&name));
                     };
 
                     new_medias.push(Media::Audio(new_audio));
@@ -300,30 +293,26 @@ pub trait AsyncTelegramApi {
                 Media::Document(document) => {
                     let mut new_document = document.clone();
 
-                    if let FileUpload::InputFile(input_file) = &document.media {
-                        let name = format!("file{file_idx}");
-                        let attach_name = format!("attach://{name}");
-                        file_idx += 1;
+                    let name = format!("file{file_idx}");
+                    let attach_name = format!("attach://{name}");
+                    file_idx += 1;
 
-                        new_document.media = FileUpload::String(attach_name);
+                    new_document.media = FileUpload::String(attach_name);
 
-                        files.push((name, input_file.path.clone()));
-                    };
+                    files.push((name, document.media.clone()));
 
                     new_medias.push(Media::Document(new_document));
                 }
                 Media::Photo(photo) => {
                     let mut new_photo = photo.clone();
 
-                    if let FileUpload::InputFile(input_file) = &photo.media {
-                        let name = format!("file{file_idx}");
-                        let attach_name = format!("attach://{name}");
-                        file_idx += 1;
+                    let name = format!("file{file_idx}");
+                    let attach_name = format!("attach://{name}");
+                    file_idx += 1;
 
-                        new_photo.media = FileUpload::String(attach_name);
+                    new_photo.media = FileUpload::String(attach_name);
 
-                        files.push((name, input_file.path.clone()));
-                    };
+                    files.push((name, photo.media.clone()));
 
                     new_medias.push(Media::Photo(new_photo));
                 }
@@ -331,24 +320,22 @@ pub trait AsyncTelegramApi {
                 Media::Video(video) => {
                     let mut new_video = video.clone();
 
-                    if let FileUpload::InputFile(input_file) = &video.media {
-                        let name = format!("file{file_idx}");
-                        let attach_name = format!("attach://{name}");
-                        file_idx += 1;
+                    let name = format!("file{file_idx}");
+                    let attach_name = format!("attach://{name}");
+                    file_idx += 1;
 
-                        new_video.media = FileUpload::String(attach_name);
+                    new_video.media = FileUpload::String(attach_name);
 
-                        files.push((name, input_file.path.clone()));
-                    };
+                    files.push((name, video.media.clone()));
 
-                    if let Some(FileUpload::InputFile(input_file)) = &video.thumbnail {
+                    if let Some(thumbnail) = &video.thumbnail {
                         let name = format!("file{file_idx}");
                         let attach_name = format!("attach://{name}");
                         file_idx += 1;
 
                         new_video.thumbnail = Some(FileUpload::String(attach_name));
 
-                        files.push((name, input_file.path.clone()));
+                        files.push(thumbnail.to_form(&name));
                     };
 
                     new_medias.push(Media::Video(new_video));
@@ -359,12 +346,7 @@ pub trait AsyncTelegramApi {
         let mut new_params = params.clone();
         new_params.media = new_medias;
 
-        let files_with_str_names: Vec<(&str, PathBuf)> = files
-            .iter()
-            .map(|(key, path)| (key.as_str(), path.clone()))
-            .collect();
-
-        self.request_with_possible_form_data(method_name, &new_params, files_with_str_names)
+        self.request_with_possible_form_data(method_name, &new_params, files)
             .await
     }
 
@@ -373,14 +355,12 @@ pub trait AsyncTelegramApi {
         params: &SendDocumentParams,
     ) -> Result<MethodResponse<Message>, Self::Error> {
         let method_name = "sendDocument";
-        let mut files: Vec<(&str, PathBuf)> = vec![];
+        let mut files: Vec<FileUploadForm> = vec![];
 
-        if let FileUpload::InputFile(input_file) = &params.document {
-            files.push(("document", input_file.path.clone()));
-        }
+        files.push(params.document.to_form("document"));
 
-        if let Some(FileUpload::InputFile(input_file)) = &params.thumbnail {
-            files.push(("thumbnail", input_file.path.clone()));
+        if let Some(thumbnail) = &params.thumbnail {
+            files.push(thumbnail.to_form("thumbnail"));
         }
 
         self.request_with_possible_form_data(method_name, params, files)
@@ -392,14 +372,12 @@ pub trait AsyncTelegramApi {
         params: &SendVideoParams,
     ) -> Result<MethodResponse<Message>, Self::Error> {
         let method_name = "sendVideo";
-        let mut files: Vec<(&str, PathBuf)> = vec![];
+        let mut files: Vec<FileUploadForm> = vec![];
 
-        if let FileUpload::InputFile(input_file) = &params.video {
-            files.push(("video", input_file.path.clone()));
-        }
+        files.push(params.video.to_form("video"));
 
-        if let Some(FileUpload::InputFile(input_file)) = &params.thumbnail {
-            files.push(("thumbnail", input_file.path.clone()));
+        if let Some(thumbnail) = &params.thumbnail {
+            files.push(thumbnail.to_form("thumbnail"));
         }
 
         self.request_with_possible_form_data(method_name, params, files)
@@ -411,14 +389,12 @@ pub trait AsyncTelegramApi {
         params: &SendAnimationParams,
     ) -> Result<MethodResponse<Message>, Self::Error> {
         let method_name = "sendAnimation";
-        let mut files: Vec<(&str, PathBuf)> = vec![];
+        let mut files: Vec<FileUploadForm> = vec![];
 
-        if let FileUpload::InputFile(input_file) = &params.animation {
-            files.push(("animation", input_file.path.clone()));
-        }
+        files.push(params.animation.to_form("animation"));
 
-        if let Some(FileUpload::InputFile(input_file)) = &params.thumbnail {
-            files.push(("thumbnail", input_file.path.clone()));
+        if let Some(thumbnail) = &params.thumbnail {
+            files.push(thumbnail.to_form("thumbnail"));
         }
 
         self.request_with_possible_form_data(method_name, params, files)
@@ -430,11 +406,9 @@ pub trait AsyncTelegramApi {
         params: &SendVoiceParams,
     ) -> Result<MethodResponse<Message>, Self::Error> {
         let method_name = "sendVoice";
-        let mut files: Vec<(&str, PathBuf)> = vec![];
+        let mut files: Vec<FileUploadForm> = vec![];
 
-        if let FileUpload::InputFile(input_file) = &params.voice {
-            files.push(("voice", input_file.path.clone()));
-        }
+        files.push(params.voice.to_form("voice"));
 
         self.request_with_possible_form_data(method_name, params, files)
             .await
@@ -445,14 +419,12 @@ pub trait AsyncTelegramApi {
         params: &SendVideoNoteParams,
     ) -> Result<MethodResponse<Message>, Self::Error> {
         let method_name = "sendVideoNote";
-        let mut files: Vec<(&str, PathBuf)> = vec![];
+        let mut files: Vec<FileUploadForm> = vec![];
 
-        if let FileUpload::InputFile(input_file) = &params.video_note {
-            files.push(("video_note", input_file.path.clone()));
-        }
+        files.push(params.video_note.to_form("video_note"));
 
-        if let Some(FileUpload::InputFile(input_file)) = &params.thumbnail {
-            files.push(("thumbnail", input_file.path.clone()));
+        if let Some(thumbnail) = &params.thumbnail {
+            files.push(thumbnail.to_form("thumbnail"));
         }
 
         self.request_with_possible_form_data(method_name, params, files)
@@ -539,7 +511,7 @@ pub trait AsyncTelegramApi {
     async fn get_file(
         &self,
         params: &GetFileParams,
-    ) -> Result<MethodResponse<FileObject>, Self::Error> {
+    ) -> Result<MethodResponse<FileUpload>, Self::Error> {
         self.request("getFile", Some(params)).await
     }
 
@@ -646,9 +618,9 @@ pub trait AsyncTelegramApi {
         &self,
         params: &SetChatPhotoParams,
     ) -> Result<MethodResponse<bool>, Self::Error> {
-        let photo = &params.photo;
+        let photo = FileUpload::from(&params.photo);
 
-        self.request_with_form_data("setChatPhoto", params, vec![("photo", photo.path.clone())])
+        self.request_with_form_data("setChatPhoto", params, vec![photo.to_form("photo")])
             .await
     }
 
@@ -937,28 +909,26 @@ pub trait AsyncTelegramApi {
         params: &EditMessageMediaParams,
     ) -> Result<EditMessageResponse, Self::Error> {
         let method_name = "editMessageMedia";
-        let mut files: Vec<(String, PathBuf)> = vec![];
+        let mut files: Vec<FileUploadForm> = vec![];
 
         let new_media = match &params.media {
             InputMedia::Animation(animation) => {
                 let mut new_animation = animation.clone();
 
-                if let FileUpload::InputFile(input_file) = &animation.media {
-                    let name = "animation".to_string();
-                    let attach_name = format!("attach://{name}");
+                let name = "animation".to_string();
+                let attach_name = format!("attach://{name}");
 
-                    new_animation.media = FileUpload::String(attach_name);
+                new_animation.media = FileUpload::String(attach_name);
 
-                    files.push((name, input_file.path.clone()));
-                };
+                files.push((name, animation.media.clone()));
 
-                if let Some(FileUpload::InputFile(input_file)) = &animation.thumbnail {
+                if let Some(thumbnail) = &animation.thumbnail {
                     let name = "animation_thumb".to_string();
                     let attach_name = format!("attach://{name}");
 
                     new_animation.thumbnail = Some(FileUpload::String(attach_name));
 
-                    files.push((name, input_file.path.clone()));
+                    files.push(thumbnail.to_form(&name));
                 };
 
                 InputMedia::Animation(new_animation)
@@ -966,22 +936,20 @@ pub trait AsyncTelegramApi {
             InputMedia::Document(document) => {
                 let mut new_document = document.clone();
 
-                if let FileUpload::InputFile(input_file) = &document.media {
-                    let name = "document".to_string();
-                    let attach_name = format!("attach://{name}");
+                let name = "document".to_string();
+                let attach_name = format!("attach://{name}");
 
-                    new_document.media = FileUpload::String(attach_name);
+                new_document.media = FileUpload::String(attach_name);
 
-                    files.push((name, input_file.path.clone()));
-                };
+                files.push((name, document.media.clone()));
 
-                if let Some(FileUpload::InputFile(input_file)) = &document.thumbnail {
+                if let Some(thumbnail) = &document.thumbnail {
                     let name = "document_thumb".to_string();
                     let attach_name = format!("attach://{name}");
 
                     new_document.thumbnail = Some(FileUpload::String(attach_name));
 
-                    files.push((name, input_file.path.clone()));
+                    files.push(thumbnail.to_form(&name));
                 };
 
                 InputMedia::Document(new_document)
@@ -989,22 +957,20 @@ pub trait AsyncTelegramApi {
             InputMedia::Audio(audio) => {
                 let mut new_audio = audio.clone();
 
-                if let FileUpload::InputFile(input_file) = &audio.media {
-                    let name = "audio".to_string();
-                    let attach_name = format!("attach://{name}");
+                let name = "audio".to_string();
+                let attach_name = format!("attach://{name}");
 
-                    new_audio.media = FileUpload::String(attach_name);
+                new_audio.media = FileUpload::String(attach_name);
 
-                    files.push((name, input_file.path.clone()));
-                };
+                files.push((name, audio.media.clone()));
 
-                if let Some(FileUpload::InputFile(input_file)) = &audio.thumbnail {
+                if let Some(thumbnail) = &audio.thumbnail {
                     let name = "audio_thumb".to_string();
                     let attach_name = format!("attach://{name}");
 
                     new_audio.thumbnail = Some(FileUpload::String(attach_name));
 
-                    files.push((name, input_file.path.clone()));
+                    files.push(thumbnail.to_form(&name));
                 };
 
                 InputMedia::Audio(new_audio)
@@ -1012,36 +978,32 @@ pub trait AsyncTelegramApi {
             InputMedia::Photo(photo) => {
                 let mut new_photo = photo.clone();
 
-                if let FileUpload::InputFile(input_file) = &photo.media {
-                    let name = "photo".to_string();
-                    let attach_name = format!("attach://{name}");
+                let name = "photo".to_string();
+                let attach_name = format!("attach://{name}");
 
-                    new_photo.media = FileUpload::String(attach_name);
+                new_photo.media = FileUpload::String(attach_name);
 
-                    files.push((name, input_file.path.clone()));
-                };
+                files.push((name, photo.media.clone()));
 
                 InputMedia::Photo(new_photo)
             }
             InputMedia::Video(video) => {
                 let mut new_video = video.clone();
 
-                if let FileUpload::InputFile(input_file) = &video.media {
-                    let name = "video".to_string();
-                    let attach_name = format!("attach://{name}");
+                let name = "video".to_string();
+                let attach_name = format!("attach://{name}");
 
-                    new_video.media = FileUpload::String(attach_name);
+                new_video.media = FileUpload::String(attach_name);
 
-                    files.push((name, input_file.path.clone()));
-                };
+                files.push((name, video.media.clone()));
 
-                if let Some(FileUpload::InputFile(input_file)) = &video.thumbnail {
+                if let Some(thumbnail) = &video.thumbnail {
                     let name = "video_thumb".to_string();
                     let attach_name = format!("attach://{name}");
 
                     new_video.thumbnail = Some(FileUpload::String(attach_name));
 
-                    files.push((name, input_file.path.clone()));
+                    files.push(thumbnail.to_form(&name));
                 };
 
                 InputMedia::Video(new_video)
@@ -1051,12 +1013,7 @@ pub trait AsyncTelegramApi {
         let mut new_params = params.clone();
         new_params.media = new_media;
 
-        let files_with_str_names: Vec<(&str, PathBuf)> = files
-            .iter()
-            .map(|(key, path)| (key.as_str(), path.clone()))
-            .collect();
-
-        self.request_with_possible_form_data(method_name, &new_params, files_with_str_names)
+        self.request_with_possible_form_data(method_name, &new_params, files)
             .await
     }
 
@@ -1093,11 +1050,9 @@ pub trait AsyncTelegramApi {
         params: &SendStickerParams,
     ) -> Result<MethodResponse<Message>, Self::Error> {
         let method_name = "sendSticker";
-        let mut files: Vec<(&str, PathBuf)> = vec![];
+        let mut files: Vec<FileUploadForm> = vec![];
 
-        if let FileUpload::InputFile(input_file) = &params.sticker {
-            files.push(("sticker", input_file.path.clone()));
-        }
+        files.push(params.sticker.to_form("sticker"));
 
         self.request_with_possible_form_data(method_name, params, files)
             .await
@@ -1113,13 +1068,13 @@ pub trait AsyncTelegramApi {
     async fn upload_sticker_file(
         &self,
         params: &UploadStickerFileParams,
-    ) -> Result<MethodResponse<FileObject>, Self::Error> {
-        let sticker = &params.sticker;
+    ) -> Result<MethodResponse<FileUpload>, Self::Error> {
+        let sticker = FileUpload::from(&params.sticker);
 
         self.request_with_form_data(
             "uploadStickerFile",
             params,
-            vec![("sticker", sticker.path.clone())],
+            vec![sticker.to_form("sticker")],
         )
         .await
     }
@@ -1130,21 +1085,17 @@ pub trait AsyncTelegramApi {
     ) -> Result<MethodResponse<bool>, Self::Error> {
         let method_name = "createNewStickerSet";
         let mut new_stickers: Vec<InputSticker> = vec![];
-        let mut files: Vec<(String, PathBuf)> = vec![];
-        let mut file_idx = 0;
+        let mut files: Vec<FileUploadForm> = vec![];
 
-        for sticker in &params.stickers {
+        for (file_idx, sticker) in params.stickers.iter().enumerate() {
             let mut new_sticker = sticker.clone();
 
-            if let FileUpload::InputFile(input_file) = &sticker.sticker {
-                let name = format!("file{file_idx}");
-                let attach_name = format!("attach://{name}");
-                file_idx += 1;
+            let name = format!("file{file_idx}");
+            let attach_name = format!("attach://{name}");
 
-                new_sticker.sticker = FileUpload::String(attach_name);
+            new_sticker.sticker = FileUpload::String(attach_name);
 
-                files.push((name, input_file.path.clone()));
-            };
+            files.push((name, sticker.sticker.clone()));
 
             new_stickers.push(new_sticker);
         }
@@ -1152,12 +1103,7 @@ pub trait AsyncTelegramApi {
         let mut new_params = params.clone();
         new_params.stickers = new_stickers;
 
-        let files_with_str_names: Vec<(&str, PathBuf)> = files
-            .iter()
-            .map(|(key, path)| (key.as_str(), path.clone()))
-            .collect();
-
-        self.request_with_possible_form_data(method_name, &new_params, files_with_str_names)
+        self.request_with_possible_form_data(method_name, &new_params, files)
             .await
     }
 
@@ -1167,16 +1113,15 @@ pub trait AsyncTelegramApi {
     ) -> Result<MethodResponse<Vec<Sticker>>, Self::Error> {
         self.request("getCustomEmojiStickers", Some(params)).await
     }
+
     async fn add_sticker_to_set(
         &self,
         params: &AddStickerToSetParams,
     ) -> Result<MethodResponse<bool>, Self::Error> {
         let method_name = "addStickerToSet";
-        let mut files: Vec<(&str, PathBuf)> = vec![];
+        let mut files: Vec<FileUploadForm> = vec![];
 
-        if let FileUpload::InputFile(input_file) = &params.sticker.sticker {
-            files.push(("sticker", input_file.path.clone()));
-        }
+        files.push(params.sticker.sticker.to_form("sticker"));
 
         self.request_with_possible_form_data(method_name, params, files)
             .await
@@ -1236,10 +1181,10 @@ pub trait AsyncTelegramApi {
         params: &SetStickerSetThumbnailParams,
     ) -> Result<MethodResponse<bool>, Self::Error> {
         let method_name = "setStickerSetThumbnail";
-        let mut files: Vec<(&str, PathBuf)> = vec![];
+        let mut files: Vec<FileUploadForm> = vec![];
 
-        if let Some(FileUpload::InputFile(input_file)) = &params.thumbnail {
-            files.push(("thumbnail", input_file.path.clone()));
+        if let Some(thumbnail) = &params.thumbnail {
+            files.push(thumbnail.to_form("thumbnail"));
         }
 
         self.request_with_possible_form_data(method_name, params, files)
@@ -1394,7 +1339,7 @@ pub trait AsyncTelegramApi {
         &self,
         method_name: &str,
         params: T1,
-        files: Vec<(&str, PathBuf)>,
+        files: Vec<FileUploadForm>,
     ) -> Result<T2, Self::Error> {
         if files.is_empty() {
             self.request(method_name, Some(params)).await
@@ -1411,6 +1356,6 @@ pub trait AsyncTelegramApi {
         &self,
         method: &str,
         params: T1,
-        files: Vec<(&str, PathBuf)>,
+        files: Vec<FileUploadForm>,
     ) -> Result<T2, Self::Error>;
 }

--- a/src/api_traits/async_telegram_api.rs
+++ b/src/api_traits/async_telegram_api.rs
@@ -130,6 +130,7 @@ use crate::objects::ChatAdministratorRights;
 use crate::objects::ChatFullInfo;
 use crate::objects::ChatInviteLink;
 use crate::objects::ChatMember;
+use crate::objects::File as FileObject;
 use crate::objects::ForumTopic;
 use crate::objects::GameHighScore;
 use crate::objects::InputSticker;
@@ -232,7 +233,9 @@ pub trait AsyncTelegramApi {
         let method_name = "sendPhoto";
         let mut files: Vec<FileUploadForm> = vec![];
 
-        files.push(params.photo.to_form("photo"));
+        if params.photo.is_input() {
+            files.push(params.photo.to_form_with_key("photo"));
+        }
 
         self.request_with_possible_form_data(method_name, params, files)
             .await
@@ -245,10 +248,14 @@ pub trait AsyncTelegramApi {
         let method_name = "sendAudio";
         let mut files: Vec<FileUploadForm> = vec![];
 
-        files.push(params.audio.to_form("audio"));
+        if params.audio.is_input() {
+            files.push(params.audio.to_form_with_key("audio"));
+        }
 
         if let Some(thumbnail) = &params.thumbnail {
-            files.push(thumbnail.to_form("thumbnail"));
+            if thumbnail.is_input() {
+                files.push(thumbnail.to_form_with_key("thumbnail"));
+            }
         }
 
         self.request_with_possible_form_data(method_name, params, files)
@@ -269,23 +276,24 @@ pub trait AsyncTelegramApi {
                 Media::Audio(audio) => {
                     let mut new_audio = audio.clone();
 
-                    let name = format!("file{file_idx}");
-                    let attach_name = format!("attach://{name}");
-                    file_idx += 1;
-
-                    new_audio.media = FileUpload::String(attach_name);
-
-                    files.push((name, audio.media.clone()));
-
-                    if let Some(thumbnail) = &audio.thumbnail {
+                    if audio.media.is_input() {
                         let name = format!("file{file_idx}");
-                        let attach_name = format!("attach://{name}");
                         file_idx += 1;
 
-                        new_audio.thumbnail = Some(FileUpload::String(attach_name));
+                        new_audio.media = FileUpload::String(format!("attach://{name}"));
+                        files.push(audio.media.to_form_with_key(&name));
+                    }
 
-                        files.push(thumbnail.to_form(&name));
-                    };
+                    if let Some(thumbnail) = &audio.thumbnail {
+                        if thumbnail.is_input() {
+                            let name = format!("file{file_idx}");
+                            file_idx += 1;
+
+                            new_audio.thumbnail =
+                                Some(FileUpload::String(format!("attach://{name}")));
+                            files.push(thumbnail.to_form_with_key(&name));
+                        }
+                    }
 
                     new_medias.push(Media::Audio(new_audio));
                 }
@@ -293,26 +301,27 @@ pub trait AsyncTelegramApi {
                 Media::Document(document) => {
                     let mut new_document = document.clone();
 
-                    let name = format!("file{file_idx}");
-                    let attach_name = format!("attach://{name}");
-                    file_idx += 1;
+                    if document.media.is_input() {
+                        let name = format!("file{file_idx}");
+                        file_idx += 1;
 
-                    new_document.media = FileUpload::String(attach_name);
-
-                    files.push((name, document.media.clone()));
+                        new_document.media = FileUpload::String(format!("attach://{name}"));
+                        files.push(document.media.to_form_with_key(&name));
+                    }
 
                     new_medias.push(Media::Document(new_document));
                 }
+
                 Media::Photo(photo) => {
                     let mut new_photo = photo.clone();
 
-                    let name = format!("file{file_idx}");
-                    let attach_name = format!("attach://{name}");
-                    file_idx += 1;
+                    if photo.media.is_input() {
+                        let name = format!("file{file_idx}");
+                        file_idx += 1;
 
-                    new_photo.media = FileUpload::String(attach_name);
-
-                    files.push((name, photo.media.clone()));
+                        new_photo.media = FileUpload::String(format!("attach://{name}"));
+                        files.push(photo.media.to_form_with_key(&name));
+                    }
 
                     new_medias.push(Media::Photo(new_photo));
                 }
@@ -320,23 +329,24 @@ pub trait AsyncTelegramApi {
                 Media::Video(video) => {
                     let mut new_video = video.clone();
 
-                    let name = format!("file{file_idx}");
-                    let attach_name = format!("attach://{name}");
-                    file_idx += 1;
-
-                    new_video.media = FileUpload::String(attach_name);
-
-                    files.push((name, video.media.clone()));
-
-                    if let Some(thumbnail) = &video.thumbnail {
+                    if video.media.is_input() {
                         let name = format!("file{file_idx}");
-                        let attach_name = format!("attach://{name}");
                         file_idx += 1;
 
-                        new_video.thumbnail = Some(FileUpload::String(attach_name));
+                        new_video.media = FileUpload::String(format!("attach://{name}"));
+                        files.push(video.media.to_form_with_key(&name));
+                    }
 
-                        files.push(thumbnail.to_form(&name));
-                    };
+                    if let Some(thumbnail) = &video.thumbnail {
+                        if thumbnail.is_input() {
+                            let name = format!("file{file_idx}");
+                            file_idx += 1;
+
+                            new_video.thumbnail =
+                                Some(FileUpload::String(format!("attach://{name}")));
+                            files.push(thumbnail.to_form_with_key(&name));
+                        }
+                    }
 
                     new_medias.push(Media::Video(new_video));
                 }
@@ -357,10 +367,14 @@ pub trait AsyncTelegramApi {
         let method_name = "sendDocument";
         let mut files: Vec<FileUploadForm> = vec![];
 
-        files.push(params.document.to_form("document"));
+        if params.document.is_input() {
+            files.push(params.document.to_form_with_key("document"));
+        }
 
         if let Some(thumbnail) = &params.thumbnail {
-            files.push(thumbnail.to_form("thumbnail"));
+            if thumbnail.is_input() {
+                files.push(thumbnail.to_form_with_key("thumbnail"));
+            }
         }
 
         self.request_with_possible_form_data(method_name, params, files)
@@ -374,10 +388,14 @@ pub trait AsyncTelegramApi {
         let method_name = "sendVideo";
         let mut files: Vec<FileUploadForm> = vec![];
 
-        files.push(params.video.to_form("video"));
+        if params.video.is_input() {
+            files.push(params.video.to_form_with_key("video"));
+        }
 
         if let Some(thumbnail) = &params.thumbnail {
-            files.push(thumbnail.to_form("thumbnail"));
+            if thumbnail.is_input() {
+                files.push(thumbnail.to_form_with_key("thumbnail"));
+            }
         }
 
         self.request_with_possible_form_data(method_name, params, files)
@@ -391,10 +409,14 @@ pub trait AsyncTelegramApi {
         let method_name = "sendAnimation";
         let mut files: Vec<FileUploadForm> = vec![];
 
-        files.push(params.animation.to_form("animation"));
+        if params.animation.is_input() {
+            files.push(params.animation.to_form_with_key("animation"));
+        }
 
         if let Some(thumbnail) = &params.thumbnail {
-            files.push(thumbnail.to_form("thumbnail"));
+            if thumbnail.is_input() {
+                files.push(thumbnail.to_form_with_key("thumbnail"));
+            }
         }
 
         self.request_with_possible_form_data(method_name, params, files)
@@ -408,7 +430,9 @@ pub trait AsyncTelegramApi {
         let method_name = "sendVoice";
         let mut files: Vec<FileUploadForm> = vec![];
 
-        files.push(params.voice.to_form("voice"));
+        if params.voice.is_input() {
+            files.push(params.voice.to_form_with_key("voice"));
+        }
 
         self.request_with_possible_form_data(method_name, params, files)
             .await
@@ -421,10 +445,14 @@ pub trait AsyncTelegramApi {
         let method_name = "sendVideoNote";
         let mut files: Vec<FileUploadForm> = vec![];
 
-        files.push(params.video_note.to_form("video_note"));
+        if params.video_note.is_input() {
+            files.push(params.video_note.to_form_with_key("video_note"));
+        }
 
         if let Some(thumbnail) = &params.thumbnail {
-            files.push(thumbnail.to_form("thumbnail"));
+            if thumbnail.is_input() {
+                files.push(thumbnail.to_form_with_key("thumbnail"));
+            }
         }
 
         self.request_with_possible_form_data(method_name, params, files)
@@ -511,7 +539,7 @@ pub trait AsyncTelegramApi {
     async fn get_file(
         &self,
         params: &GetFileParams,
-    ) -> Result<MethodResponse<FileUpload>, Self::Error> {
+    ) -> Result<MethodResponse<FileObject>, Self::Error> {
         self.request("getFile", Some(params)).await
     }
 
@@ -620,8 +648,12 @@ pub trait AsyncTelegramApi {
     ) -> Result<MethodResponse<bool>, Self::Error> {
         let photo = FileUpload::from(&params.photo);
 
-        self.request_with_form_data("setChatPhoto", params, vec![photo.to_form("photo")])
-            .await
+        self.request_with_form_data(
+            "setChatPhoto",
+            params,
+            vec![photo.to_form_with_key("photo")],
+        )
+        .await
     }
 
     async fn delete_chat_photo(
@@ -915,20 +947,19 @@ pub trait AsyncTelegramApi {
             InputMedia::Animation(animation) => {
                 let mut new_animation = animation.clone();
 
-                let name = "animation".to_string();
-                let attach_name = format!("attach://{name}");
-
-                new_animation.media = FileUpload::String(attach_name);
-
-                files.push((name, animation.media.clone()));
+                if animation.media.is_input() {
+                    let name = "animation";
+                    new_animation.media = FileUpload::String(format!("attach://{name}"));
+                    files.push(animation.media.to_form_with_key(name));
+                }
 
                 if let Some(thumbnail) = &animation.thumbnail {
-                    let name = "animation_thumb".to_string();
-                    let attach_name = format!("attach://{name}");
-
-                    new_animation.thumbnail = Some(FileUpload::String(attach_name));
-
-                    files.push(thumbnail.to_form(&name));
+                    if thumbnail.is_input() {
+                        let name = "animation_thumb";
+                        new_animation.thumbnail =
+                            Some(FileUpload::String(format!("attach://{name}")));
+                        files.push(thumbnail.to_form_with_key(name));
+                    }
                 };
 
                 InputMedia::Animation(new_animation)
@@ -936,20 +967,19 @@ pub trait AsyncTelegramApi {
             InputMedia::Document(document) => {
                 let mut new_document = document.clone();
 
-                let name = "document".to_string();
-                let attach_name = format!("attach://{name}");
-
-                new_document.media = FileUpload::String(attach_name);
-
-                files.push((name, document.media.clone()));
+                if document.media.is_input() {
+                    let name = "document";
+                    new_document.media = FileUpload::String(format!("attach://{name}"));
+                    files.push(document.media.to_form_with_key(name));
+                }
 
                 if let Some(thumbnail) = &document.thumbnail {
-                    let name = "document_thumb".to_string();
-                    let attach_name = format!("attach://{name}");
-
-                    new_document.thumbnail = Some(FileUpload::String(attach_name));
-
-                    files.push(thumbnail.to_form(&name));
+                    if thumbnail.is_input() {
+                        let name = "document_thumb";
+                        new_document.thumbnail =
+                            Some(FileUpload::String(format!("attach://{name}")));
+                        files.push(thumbnail.to_form_with_key(name));
+                    }
                 };
 
                 InputMedia::Document(new_document)
@@ -957,20 +987,18 @@ pub trait AsyncTelegramApi {
             InputMedia::Audio(audio) => {
                 let mut new_audio = audio.clone();
 
-                let name = "audio".to_string();
-                let attach_name = format!("attach://{name}");
-
-                new_audio.media = FileUpload::String(attach_name);
-
-                files.push((name, audio.media.clone()));
+                if audio.media.is_input() {
+                    let name = "audio";
+                    new_audio.media = FileUpload::String(format!("attach://{name}"));
+                    files.push(audio.media.to_form_with_key(name));
+                }
 
                 if let Some(thumbnail) = &audio.thumbnail {
-                    let name = "audio_thumb".to_string();
-                    let attach_name = format!("attach://{name}");
-
-                    new_audio.thumbnail = Some(FileUpload::String(attach_name));
-
-                    files.push(thumbnail.to_form(&name));
+                    if thumbnail.is_input() {
+                        let name = "audio_thumb";
+                        new_audio.thumbnail = Some(FileUpload::String(format!("attach://{name}")));
+                        files.push(thumbnail.to_form_with_key(name));
+                    }
                 };
 
                 InputMedia::Audio(new_audio)
@@ -978,32 +1006,29 @@ pub trait AsyncTelegramApi {
             InputMedia::Photo(photo) => {
                 let mut new_photo = photo.clone();
 
-                let name = "photo".to_string();
-                let attach_name = format!("attach://{name}");
-
-                new_photo.media = FileUpload::String(attach_name);
-
-                files.push((name, photo.media.clone()));
+                if photo.media.is_input() {
+                    let name = "photo";
+                    new_photo.media = FileUpload::String(format!("attach://{name}"));
+                    files.push(photo.media.to_form_with_key(name));
+                }
 
                 InputMedia::Photo(new_photo)
             }
             InputMedia::Video(video) => {
                 let mut new_video = video.clone();
 
-                let name = "video".to_string();
-                let attach_name = format!("attach://{name}");
-
-                new_video.media = FileUpload::String(attach_name);
-
-                files.push((name, video.media.clone()));
+                if video.media.is_input() {
+                    let name = "video";
+                    new_video.media = FileUpload::String(format!("attach://{name}"));
+                    files.push(video.media.to_form_with_key(name));
+                }
 
                 if let Some(thumbnail) = &video.thumbnail {
-                    let name = "video_thumb".to_string();
-                    let attach_name = format!("attach://{name}");
-
-                    new_video.thumbnail = Some(FileUpload::String(attach_name));
-
-                    files.push(thumbnail.to_form(&name));
+                    if thumbnail.is_input() {
+                        let name = "video_thumb";
+                        new_video.thumbnail = Some(FileUpload::String(format!("attach://{name}")));
+                        files.push(thumbnail.to_form_with_key(name));
+                    }
                 };
 
                 InputMedia::Video(new_video)
@@ -1052,7 +1077,9 @@ pub trait AsyncTelegramApi {
         let method_name = "sendSticker";
         let mut files: Vec<FileUploadForm> = vec![];
 
-        files.push(params.sticker.to_form("sticker"));
+        if params.sticker.is_input() {
+            files.push(params.sticker.to_form_with_key("sticker"));
+        }
 
         self.request_with_possible_form_data(method_name, params, files)
             .await
@@ -1074,7 +1101,7 @@ pub trait AsyncTelegramApi {
         self.request_with_form_data(
             "uploadStickerFile",
             params,
-            vec![sticker.to_form("sticker")],
+            vec![sticker.to_form_with_key("sticker")],
         )
         .await
     }
@@ -1086,16 +1113,19 @@ pub trait AsyncTelegramApi {
         let method_name = "createNewStickerSet";
         let mut new_stickers: Vec<InputSticker> = vec![];
         let mut files: Vec<FileUploadForm> = vec![];
+        let mut file_idx = 0;
 
-        for (file_idx, sticker) in params.stickers.iter().enumerate() {
+        for sticker in &params.stickers {
             let mut new_sticker = sticker.clone();
 
-            let name = format!("file{file_idx}");
-            let attach_name = format!("attach://{name}");
+            if sticker.sticker.is_input() {
+                let name = format!("file{file_idx}");
+                file_idx += 1;
 
-            new_sticker.sticker = FileUpload::String(attach_name);
+                new_sticker.sticker = FileUpload::String(format!("attach://{name}"));
 
-            files.push((name, sticker.sticker.clone()));
+                files.push(sticker.sticker.to_form_with_key(&name));
+            }
 
             new_stickers.push(new_sticker);
         }
@@ -1121,7 +1151,9 @@ pub trait AsyncTelegramApi {
         let method_name = "addStickerToSet";
         let mut files: Vec<FileUploadForm> = vec![];
 
-        files.push(params.sticker.sticker.to_form("sticker"));
+        if params.sticker.sticker.is_input() {
+            files.push(params.sticker.sticker.to_form_with_key("sticker"));
+        }
 
         self.request_with_possible_form_data(method_name, params, files)
             .await
@@ -1184,7 +1216,9 @@ pub trait AsyncTelegramApi {
         let mut files: Vec<FileUploadForm> = vec![];
 
         if let Some(thumbnail) = &params.thumbnail {
-            files.push(thumbnail.to_form("thumbnail"));
+            if thumbnail.is_input() {
+                files.push(thumbnail.to_form_with_key("thumbnail"));
+            }
         }
 
         self.request_with_possible_form_data(method_name, params, files)

--- a/src/api_traits/async_telegram_api.rs
+++ b/src/api_traits/async_telegram_api.rs
@@ -1095,7 +1095,7 @@ pub trait AsyncTelegramApi {
     async fn upload_sticker_file(
         &self,
         params: &UploadStickerFileParams,
-    ) -> Result<MethodResponse<FileUpload>, Self::Error> {
+    ) -> Result<MethodResponse<FileObject>, Self::Error> {
         let sticker = FileUpload::from(&params.sticker);
 
         self.request_with_form_data(

--- a/src/api_traits/telegram_api.rs
+++ b/src/api_traits/telegram_api.rs
@@ -1042,7 +1042,7 @@ pub trait TelegramApi {
     fn upload_sticker_file(
         &self,
         params: &UploadStickerFileParams,
-    ) -> Result<MethodResponse<FileUpload>, Self::Error> {
+    ) -> Result<MethodResponse<FileObject>, Self::Error> {
         let sticker = FileUpload::from(&params.sticker);
         self.request_with_form_data(
             "uploadStickerFile",


### PR DESCRIPTION
Example:
```
    let params = SendDocumentParams::builder()
        .chat_id(chat_id.to_string())
        .document(("Bytes".to_string(), bytes.to_vec()))
        .caption("Send bytes example")
        .build();

    frankenstein::AsyncApi::new(token).send_document(&params).await.unwrap();

```