### PR TITLE
refactor: clippy::must_use_candidate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,8 +23,9 @@ async-telegram-trait = ["async-trait"]
 [lints.rust]
 unsafe_code = "forbid"
 [lints.clippy]
-pedantic = "warn"
+pedantic = { level = "warn", priority = -1 }
 derive_partial_eq_without_eq = "warn"
+must_use_candidate = "warn"
 
 [[example]]
 name = "get_me"

--- a/src/api/async_telegram_api_impl.rs
+++ b/src/api/async_telegram_api_impl.rs
@@ -11,6 +11,7 @@ use tokio::fs::File;
 use typed_builder::TypedBuilder;
 
 #[derive(Debug, Clone, TypedBuilder)]
+#[must_use = "API needs to be used in order to be useful"]
 pub struct AsyncApi {
     #[builder(setter(into))]
     pub api_url: String,

--- a/src/api/telegram_api_impl.rs
+++ b/src/api/telegram_api_impl.rs
@@ -9,6 +9,7 @@ use typed_builder::TypedBuilder;
 use ureq::Response;
 
 #[derive(Debug, Clone, TypedBuilder)]
+#[must_use = "API needs to be used in order to be useful"]
 pub struct Api {
     #[builder(setter(into))]
     pub api_url: String,
@@ -20,7 +21,6 @@ impl Api {
     /// Create a new `Api`. You can use `Api::builder()` for more options.
     pub fn new(api_key: &str) -> Self {
         let api_url = format!("{}{api_key}", super::BASE_API_URL);
-
         Self::builder().api_url(api_url).build()
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,6 @@
 // TODO: remove and fix (or allow explicitly on the specific problem)
 #![allow(
     clippy::missing_errors_doc,
-    clippy::must_use_candidate,
     clippy::single_match_else,
     clippy::struct_excessive_bools,
     clippy::unreadable_literal,

--- a/src/parse_mode.rs
+++ b/src/parse_mode.rs
@@ -29,6 +29,7 @@ impl FromStr for ParseMode {
 }
 
 impl ParseMode {
+    #[must_use]
     pub const fn to_str(self) -> &'static str {
         match self {
             Self::Html => "HTML",


### PR DESCRIPTION
Adding must_use is considered a breaking change.
While it is, I think it can be considered a bug when it isn't used before so I would be fine not releasing it as major version and consider it as a bug fix release.

Will create a conflict with #190, so I'll do this as a draft for now.