### PR TITLE
fix: clippy::too_long_first_doc_paragraph

### DIFF
--- a/src/api_traits.rs
+++ b/src/api_traits.rs
@@ -22,12 +22,14 @@ pub struct MethodResponse<T> {
     pub description: Option<String>,
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
-/// \[…\] an unsuccessful request, `ok` equals false and the error is explained in the `description`.
+/// Error on an unsuccessful request.
+///
+/// `ok` equals false and the error is explained in the `description`.
 /// An Integer `error_code` field is also returned, but its contents are subject to change in the future.
 /// Some errors may also have an optional field `parameters` of the type `ResponseParameters`, which can help to automatically handle the error.
 ///
 /// See <https://core.telegram.org/bots/api#making-requests>
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ErrorResponse {
     /// Always false
     pub ok: bool,


### PR DESCRIPTION
It's not yet on stable but errors the nightly clippy CI runs.
https://rust-lang.github.io/rust-clippy/master/index.html#/too_long_first_doc_paragraph