### PR TITLE
docs(examples): simplify update offset logic

### DIFF
--- a/examples/async_reply_to_message_updates.rs
+++ b/examples/async_reply_to_message_updates.rs
@@ -11,8 +11,7 @@ static TOKEN: &str = "API_TOKEN";
 async fn main() {
     let api = AsyncApi::new(TOKEN);
 
-    let update_params_builder = GetUpdatesParams::builder();
-    let mut update_params = update_params_builder.clone().build();
+    let mut update_params = GetUpdatesParams::builder().build();
 
     loop {
         let result = api.get_updates(&update_params).await;
@@ -29,10 +28,7 @@ async fn main() {
                             process_message(message, api_clone).await;
                         });
                     }
-                    update_params = update_params_builder
-                        .clone()
-                        .offset(update.update_id + 1)
-                        .build();
+                    update_params.offset = Some(i64::from(update.update_id) + 1);
                 }
             }
             Err(error) => {

--- a/examples/reply_to_message_updates.rs
+++ b/examples/reply_to_message_updates.rs
@@ -9,8 +9,7 @@ static TOKEN: &str = "API_TOKEN";
 fn main() {
     let api = Api::new(TOKEN);
 
-    let update_params_builder = GetUpdatesParams::builder();
-    let mut update_params = update_params_builder.clone().build();
+    let mut update_params = GetUpdatesParams::builder().build();
 
     loop {
         let result = api.get_updates(&update_params);
@@ -35,10 +34,7 @@ fn main() {
                             println!("Failed to send message: {err:?}");
                         }
                     }
-                    update_params = update_params_builder
-                        .clone()
-                        .offset(update.update_id + 1)
-                        .build();
+                    update_params.offset = Some(i64::from(update.update_id) + 1);
                 }
             }
             Err(error) => {


### PR DESCRIPTION
As noticed on https://github.com/ayrat555/frankenstein/pull/196#discussion_r1740170364 this simplifies the examples to be closer to the actual intended logic of updating the offset on the existing `update_params`.