### PR TITLE
refactor(api): reuse new_url

### DIFF
--- a/src/api/async_telegram_api_impl.rs
+++ b/src/api/async_telegram_api_impl.rs
@@ -22,13 +22,12 @@ pub struct AsyncApi {
 }
 
 impl AsyncApi {
-    /// Create a new `AsyncApi`. You can use `AsyncApi::builder()` for more options.
+    /// Create a new `AsyncApi`. You can use [`AsyncApi::new_url`] or [`AsyncApi::builder`] for more options.
     pub fn new(api_key: &str) -> Self {
-        let api_url = format!("{}{api_key}", super::BASE_API_URL);
-        Self::builder().api_url(api_url).build()
+        Self::new_url(format!("{}{api_key}", super::BASE_API_URL))
     }
 
-    /// Create a new `AsyncApi`. You can use `AsyncApi::builder()` for more options.
+    /// Create a new `AsyncApi`. You can use [`AsyncApi::builder`] for more options.
     pub fn new_url<T: Into<String>>(api_url: T) -> Self {
         Self::builder().api_url(api_url).build()
     }

--- a/src/api/telegram_api_impl.rs
+++ b/src/api/telegram_api_impl.rs
@@ -18,13 +18,12 @@ pub struct Api {
 }
 
 impl Api {
-    /// Create a new `Api`. You can use `Api::builder()` for more options.
+    /// Create a new `Api`. You can use [`Api::new_url`] or [`Api::builder`] for more options.
     pub fn new(api_key: &str) -> Self {
-        let api_url = format!("{}{api_key}", super::BASE_API_URL);
-        Self::builder().api_url(api_url).build()
+        Self::new_url(format!("{}{api_key}", super::BASE_API_URL))
     }
 
-    /// Create a new `Api`. You can use `Api::builder()` for more options.
+    /// Create a new `Api`. You can use [`Api::builder`] for more options.
     pub fn new_url<T: Into<String>>(api_url: T) -> Self {
         Self::builder().api_url(api_url).build()
     }


### PR DESCRIPTION
As the `(Async)Api::new` is basically a shortcut for the `new_url` it's a bit more obvious to reuse the `new_url` method more explicitly.

Also improves the linking to the actual methods in the doc comments. (Which also allows it to check that the given method actually exists which is neat on refactorings.)