### PR TITLE
refactor: improve module structure

### DIFF
--- a/examples/async_custom_client.rs
+++ b/examples/async_custom_client.rs
@@ -1,5 +1,4 @@
-use frankenstein::AsyncApi;
-use frankenstein::AsyncTelegramApi;
+use frankenstein::{AsyncApi, AsyncTelegramApi};
 use std::time::Duration;
 
 static TOKEN: &str = "API_TOKEN";

--- a/examples/async_file_upload.rs
+++ b/examples/async_file_upload.rs
@@ -1,6 +1,5 @@
-use frankenstein::api_params::SendPhotoParams;
-use frankenstein::AsyncApi;
-use frankenstein::AsyncTelegramApi;
+use frankenstein::parameters::SendPhotoParams;
+use frankenstein::{AsyncApi, AsyncTelegramApi};
 
 static TOKEN: &str = "TOKEN";
 static CHAT_ID: i64 = 1;

--- a/examples/async_get_me.rs
+++ b/examples/async_get_me.rs
@@ -1,5 +1,4 @@
-use frankenstein::AsyncApi;
-use frankenstein::AsyncTelegramApi;
+use frankenstein::{AsyncApi, AsyncTelegramApi};
 
 static TOKEN: &str = "API_TOKEN";
 

--- a/examples/async_reply_to_message_updates.rs
+++ b/examples/async_reply_to_message_updates.rs
@@ -1,9 +1,6 @@
-use frankenstein::AsyncTelegramApi;
-use frankenstein::GetUpdatesParams;
-use frankenstein::Message;
-use frankenstein::ReplyParameters;
-use frankenstein::SendMessageParams;
-use frankenstein::{AsyncApi, UpdateContent};
+use frankenstein::objects::{Message, UpdateContent};
+use frankenstein::parameters::{GetUpdatesParams, ReplyParameters, SendMessageParams};
+use frankenstein::{AsyncApi, AsyncTelegramApi};
 
 static TOKEN: &str = "API_TOKEN";
 

--- a/examples/custom_client.rs
+++ b/examples/custom_client.rs
@@ -1,5 +1,4 @@
-use frankenstein::Api;
-use frankenstein::TelegramApi;
+use frankenstein::{Api, TelegramApi};
 use std::time::Duration;
 
 static TOKEN: &str = "API_TOKEN";

--- a/examples/get_me.rs
+++ b/examples/get_me.rs
@@ -1,5 +1,4 @@
-use frankenstein::Api;
-use frankenstein::TelegramApi;
+use frankenstein::{Api, TelegramApi};
 
 static TOKEN: &str = "API_TOKEN";
 

--- a/examples/inline_keyboard.rs
+++ b/examples/inline_keyboard.rs
@@ -1,9 +1,6 @@
-use frankenstein::Api;
-use frankenstein::InlineKeyboardButton;
-use frankenstein::InlineKeyboardMarkup;
-use frankenstein::ReplyMarkup;
-use frankenstein::SendMessageParams;
-use frankenstein::TelegramApi;
+use frankenstein::objects::{InlineKeyboardButton, InlineKeyboardMarkup};
+use frankenstein::parameters::{ReplyMarkup, SendMessageParams};
+use frankenstein::{Api, TelegramApi};
 
 // replace with your token
 static TOKEN: &str = "TOKEN";

--- a/examples/reply_keyboard.rs
+++ b/examples/reply_keyboard.rs
@@ -1,9 +1,6 @@
-use frankenstein::Api;
-use frankenstein::KeyboardButton;
-use frankenstein::ReplyKeyboardMarkup;
-use frankenstein::ReplyMarkup;
-use frankenstein::SendMessageParams;
-use frankenstein::TelegramApi;
+use frankenstein::objects::{KeyboardButton, ReplyKeyboardMarkup};
+use frankenstein::parameters::{ReplyMarkup, SendMessageParams};
+use frankenstein::{Api, TelegramApi};
 
 // replace with your token
 static TOKEN: &str = "TOKEN";

--- a/examples/reply_to_message_updates.rs
+++ b/examples/reply_to_message_updates.rs
@@ -1,8 +1,6 @@
-use frankenstein::GetUpdatesParams;
-use frankenstein::ReplyParameters;
-use frankenstein::SendMessageParams;
-use frankenstein::TelegramApi;
-use frankenstein::{Api, UpdateContent};
+use frankenstein::objects::UpdateContent;
+use frankenstein::parameters::{GetUpdatesParams, ReplyParameters, SendMessageParams};
+use frankenstein::{Api, TelegramApi};
 
 static TOKEN: &str = "API_TOKEN";
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -1,34 +1,9 @@
-use crate::api_traits::ErrorResponse;
-use serde::{Deserialize, Serialize};
-
-#[cfg(feature = "async-http-client")]
-pub mod async_telegram_api_impl;
 #[cfg(feature = "async-http-client")]
 pub use async_telegram_api_impl::*;
-
-#[cfg(feature = "http-client")]
-pub mod telegram_api_impl;
 #[cfg(feature = "http-client")]
 pub use telegram_api_impl::*;
 
-pub static BASE_API_URL: &str = "https://api.telegram.org/bot";
-
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, thiserror::Error)]
-#[serde(untagged)]
-pub enum Error {
-    #[error("{0}")]
-    Http(HttpError),
-    #[error("Api Error {0:?}")]
-    Api(ErrorResponse),
-    #[error("Decode Error {0}")]
-    Decode(String),
-    #[error("Encode Error {0}")]
-    Encode(String),
-}
-
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, thiserror::Error)]
-#[error("Http Error {code}: {message}")]
-pub struct HttpError {
-    pub code: u16,
-    pub message: String,
-}
+#[cfg(feature = "async-http-client")]
+mod async_telegram_api_impl;
+#[cfg(feature = "http-client")]
+mod telegram_api_impl;

--- a/src/api_traits.rs
+++ b/src/api_traits.rs
@@ -1,48 +1,9 @@
-use crate::objects::{Message, ResponseParameters};
-use serde::{Deserialize, Serialize};
-
 #[cfg(feature = "async-telegram-trait")]
-pub mod async_telegram_api;
-
+mod async_telegram_api;
 #[cfg(feature = "telegram-trait")]
-pub mod telegram_api;
+mod telegram_api;
 
 #[cfg(feature = "async-telegram-trait")]
 pub use async_telegram_api::*;
-
 #[cfg(feature = "telegram-trait")]
 pub use telegram_api::*;
-
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
-pub struct MethodResponse<T> {
-    /// Always true
-    pub ok: bool,
-    pub result: T,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub description: Option<String>,
-}
-
-/// Error on an unsuccessful request.
-///
-/// `ok` equals false and the error is explained in the `description`.
-/// An Integer `error_code` field is also returned, but its contents are subject to change in the future.
-/// Some errors may also have an optional field `parameters` of the type `ResponseParameters`, which can help to automatically handle the error.
-///
-/// See <https://core.telegram.org/bots/api#making-requests>
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
-pub struct ErrorResponse {
-    /// Always false
-    pub ok: bool,
-    pub description: String,
-    /// Contents are subject to change in the future
-    pub error_code: u64,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub parameters: Option<ResponseParameters>,
-}
-
-#[derive(Debug, Serialize, Deserialize, PartialEq)]
-#[serde(untagged)]
-pub enum EditMessageResponse {
-    Message(MethodResponse<Message>),
-    Bool(MethodResponse<bool>),
-}

--- a/src/api_traits/async_telegram_api.rs
+++ b/src/api_traits/async_telegram_api.rs
@@ -1,154 +1,50 @@
-use super::EditMessageResponse;
-use super::MethodResponse;
-use crate::api_params::AddStickerToSetParams;
-use crate::api_params::AnswerCallbackQueryParams;
-use crate::api_params::AnswerInlineQueryParams;
-use crate::api_params::AnswerPreCheckoutQueryParams;
-use crate::api_params::AnswerShippingQueryParams;
-use crate::api_params::AnswerWebAppQueryParams;
-use crate::api_params::ApproveChatJoinRequestParams;
-use crate::api_params::BanChatMemberParams;
-use crate::api_params::BanChatSenderChatParams;
-use crate::api_params::CloseForumTopicParams;
-use crate::api_params::CloseGeneralForumTopicParams;
-use crate::api_params::CopyMessageParams;
-use crate::api_params::CopyMessagesParams;
-use crate::api_params::CreateChatInviteLinkParams;
-use crate::api_params::CreateChatSubscriptionInviteLinkParams;
-use crate::api_params::CreateForumTopicParams;
-use crate::api_params::CreateInvoiceLinkParams;
-use crate::api_params::CreateNewStickerSetParams;
-use crate::api_params::DeclineChatJoinRequestParams;
-use crate::api_params::DeleteChatPhotoParams;
-use crate::api_params::DeleteChatStickerSetParams;
-use crate::api_params::DeleteForumTopicParams;
-use crate::api_params::DeleteMessageParams;
-use crate::api_params::DeleteMessagesParams;
-use crate::api_params::DeleteMyCommandsParams;
-use crate::api_params::DeleteStickerFromSetParams;
-use crate::api_params::DeleteStickerSetParams;
-use crate::api_params::DeleteWebhookParams;
-use crate::api_params::EditChatInviteLinkParams;
-use crate::api_params::EditChatSubscriptionInviteLinkParams;
-use crate::api_params::EditForumTopicParams;
-use crate::api_params::EditGeneralForumTopicParams;
-use crate::api_params::EditMessageCaptionParams;
-use crate::api_params::EditMessageLiveLocationParams;
-use crate::api_params::EditMessageMediaParams;
-use crate::api_params::EditMessageReplyMarkupParams;
-use crate::api_params::EditMessageTextParams;
-use crate::api_params::ExportChatInviteLinkParams;
-use crate::api_params::FileUpload;
-use crate::api_params::ForwardMessageParams;
-use crate::api_params::ForwardMessagesParams;
-use crate::api_params::GetBusinessConnectionParams;
-use crate::api_params::GetChatAdministratorsParams;
-use crate::api_params::GetChatMemberCountParams;
-use crate::api_params::GetChatMemberParams;
-use crate::api_params::GetChatMenuButtonParams;
-use crate::api_params::GetChatParams;
-use crate::api_params::GetCustomEmojiStickersParams;
-use crate::api_params::GetFileParams;
-use crate::api_params::GetGameHighScoresParams;
-use crate::api_params::GetMyCommandsParams;
-use crate::api_params::GetMyDefaultAdministratorRightsParams;
-use crate::api_params::GetMyDescriptionParams;
-use crate::api_params::GetMyNameParams;
-use crate::api_params::GetMyShortDescriptionParams;
-use crate::api_params::GetStarTransactionsParams;
-use crate::api_params::GetStickerSetParams;
-use crate::api_params::GetUpdatesParams;
-use crate::api_params::GetUserChatBoostsParams;
-use crate::api_params::GetUserProfilePhotosParams;
-use crate::api_params::HideGeneralForumTopicParams;
-use crate::api_params::InputMedia;
-use crate::api_params::LeaveChatParams;
-use crate::api_params::Media;
-use crate::api_params::PinChatMessageParams;
-use crate::api_params::PromoteChatMemberParams;
-use crate::api_params::RefundStarPaymentParams;
-use crate::api_params::ReopenForumTopicParams;
-use crate::api_params::ReopenGeneralForumTopicParams;
-use crate::api_params::ReplaceStickerInSetParams;
-use crate::api_params::RestrictChatMemberParams;
-use crate::api_params::RevokeChatInviteLinkParams;
-use crate::api_params::SendAnimationParams;
-use crate::api_params::SendAudioParams;
-use crate::api_params::SendChatActionParams;
-use crate::api_params::SendContactParams;
-use crate::api_params::SendDiceParams;
-use crate::api_params::SendDocumentParams;
-use crate::api_params::SendGameParams;
-use crate::api_params::SendInvoiceParams;
-use crate::api_params::SendLocationParams;
-use crate::api_params::SendMediaGroupParams;
-use crate::api_params::SendMessageParams;
-use crate::api_params::SendPaidMediaParams;
-use crate::api_params::SendPhotoParams;
-use crate::api_params::SendPollParams;
-use crate::api_params::SendStickerParams;
-use crate::api_params::SendVenueParams;
-use crate::api_params::SendVideoNoteParams;
-use crate::api_params::SendVideoParams;
-use crate::api_params::SendVoiceParams;
-use crate::api_params::SetChatAdministratorCustomTitleParams;
-use crate::api_params::SetChatDescriptionParams;
-use crate::api_params::SetChatMenuButtonParams;
-use crate::api_params::SetChatPermissionsParams;
-use crate::api_params::SetChatPhotoParams;
-use crate::api_params::SetChatStickerSetParams;
-use crate::api_params::SetChatTitleParams;
-use crate::api_params::SetCustomEmojiStickerSetThumbnailParams;
-use crate::api_params::SetGameScoreParams;
-use crate::api_params::SetMessageReactionParams;
-use crate::api_params::SetMyCommandsParams;
-use crate::api_params::SetMyDefaultAdministratorRightsParams;
-use crate::api_params::SetMyDescriptionParams;
-use crate::api_params::SetMyNameParams;
-use crate::api_params::SetMyShortDescriptionParams;
-use crate::api_params::SetStickerEmojiListParams;
-use crate::api_params::SetStickerKeywordsParams;
-use crate::api_params::SetStickerMaskPositionParams;
-use crate::api_params::SetStickerPositionInSetParams;
-use crate::api_params::SetStickerSetThumbnailParams;
-use crate::api_params::SetStickerSetTitleParams;
-use crate::api_params::SetWebhookParams;
-use crate::api_params::StopMessageLiveLocationParams;
-use crate::api_params::StopPollParams;
-use crate::api_params::UnbanChatMemberParams;
-use crate::api_params::UnbanChatSenderChatParams;
-use crate::api_params::UnhideGeneralForumTopicParams;
-use crate::api_params::UnpinAllChatMessagesParams;
-use crate::api_params::UnpinAllForumTopicMessagesParams;
-use crate::api_params::UnpinChatMessageParams;
-use crate::api_params::UploadStickerFileParams;
-use crate::objects::BotCommand;
-use crate::objects::BotDescription;
-use crate::objects::BotName;
-use crate::objects::BotShortDescription;
-use crate::objects::BusinessConnection;
-use crate::objects::ChatAdministratorRights;
-use crate::objects::ChatFullInfo;
-use crate::objects::ChatInviteLink;
-use crate::objects::ChatMember;
-use crate::objects::File as FileObject;
-use crate::objects::ForumTopic;
-use crate::objects::GameHighScore;
-use crate::objects::InputSticker;
-use crate::objects::MenuButton;
-use crate::objects::Message;
-use crate::objects::MessageId;
-use crate::objects::Poll;
-use crate::objects::SentWebAppMessage;
-use crate::objects::StarTransactions;
-use crate::objects::StickerSet;
-use crate::objects::Update;
-use crate::objects::User;
-use crate::objects::UserChatBoosts;
-use crate::objects::UserProfilePhotos;
-use crate::objects::WebhookInfo;
-use crate::Sticker;
-use crate::UnpinAllGeneralForumTopicMessagesParams;
+use crate::objects::{
+    BotCommand, BotDescription, BotName, BotShortDescription, BusinessConnection,
+    ChatAdministratorRights, ChatFullInfo, ChatInviteLink, ChatMember, File as FileObject,
+    ForumTopic, GameHighScore, InputSticker, MenuButton, Message, MessageId, Poll,
+    SentWebAppMessage, StarTransactions, Sticker, StickerSet, Update, User, UserChatBoosts,
+    UserProfilePhotos, WebhookInfo,
+};
+use crate::parameters::{
+    AddStickerToSetParams, AnswerCallbackQueryParams, AnswerInlineQueryParams,
+    AnswerPreCheckoutQueryParams, AnswerShippingQueryParams, AnswerWebAppQueryParams,
+    ApproveChatJoinRequestParams, BanChatMemberParams, BanChatSenderChatParams,
+    CloseForumTopicParams, CloseGeneralForumTopicParams, CopyMessageParams, CopyMessagesParams,
+    CreateChatInviteLinkParams, CreateChatSubscriptionInviteLinkParams, CreateForumTopicParams,
+    CreateInvoiceLinkParams, CreateNewStickerSetParams, DeclineChatJoinRequestParams,
+    DeleteChatPhotoParams, DeleteChatStickerSetParams, DeleteForumTopicParams, DeleteMessageParams,
+    DeleteMessagesParams, DeleteMyCommandsParams, DeleteStickerFromSetParams,
+    DeleteStickerSetParams, DeleteWebhookParams, EditChatInviteLinkParams,
+    EditChatSubscriptionInviteLinkParams, EditForumTopicParams, EditGeneralForumTopicParams,
+    EditMessageCaptionParams, EditMessageLiveLocationParams, EditMessageMediaParams,
+    EditMessageReplyMarkupParams, EditMessageTextParams, ExportChatInviteLinkParams, FileUpload,
+    ForwardMessageParams, ForwardMessagesParams, GetBusinessConnectionParams,
+    GetChatAdministratorsParams, GetChatMemberCountParams, GetChatMemberParams,
+    GetChatMenuButtonParams, GetChatParams, GetCustomEmojiStickersParams, GetFileParams,
+    GetGameHighScoresParams, GetMyCommandsParams, GetMyDefaultAdministratorRightsParams,
+    GetMyDescriptionParams, GetMyNameParams, GetMyShortDescriptionParams,
+    GetStarTransactionsParams, GetStickerSetParams, GetUpdatesParams, GetUserChatBoostsParams,
+    GetUserProfilePhotosParams, HideGeneralForumTopicParams, InputMedia, LeaveChatParams, Media,
+    PinChatMessageParams, PromoteChatMemberParams, RefundStarPaymentParams, ReopenForumTopicParams,
+    ReopenGeneralForumTopicParams, ReplaceStickerInSetParams, RestrictChatMemberParams,
+    RevokeChatInviteLinkParams, SendAnimationParams, SendAudioParams, SendChatActionParams,
+    SendContactParams, SendDiceParams, SendDocumentParams, SendGameParams, SendInvoiceParams,
+    SendLocationParams, SendMediaGroupParams, SendMessageParams, SendPaidMediaParams,
+    SendPhotoParams, SendPollParams, SendStickerParams, SendVenueParams, SendVideoNoteParams,
+    SendVideoParams, SendVoiceParams, SetChatAdministratorCustomTitleParams,
+    SetChatDescriptionParams, SetChatMenuButtonParams, SetChatPermissionsParams,
+    SetChatPhotoParams, SetChatStickerSetParams, SetChatTitleParams,
+    SetCustomEmojiStickerSetThumbnailParams, SetGameScoreParams, SetMessageReactionParams,
+    SetMyCommandsParams, SetMyDefaultAdministratorRightsParams, SetMyDescriptionParams,
+    SetMyNameParams, SetMyShortDescriptionParams, SetStickerEmojiListParams,
+    SetStickerKeywordsParams, SetStickerMaskPositionParams, SetStickerPositionInSetParams,
+    SetStickerSetThumbnailParams, SetStickerSetTitleParams, SetWebhookParams,
+    StopMessageLiveLocationParams, StopPollParams, UnbanChatMemberParams,
+    UnbanChatSenderChatParams, UnhideGeneralForumTopicParams, UnpinAllChatMessagesParams,
+    UnpinAllForumTopicMessagesParams, UnpinAllGeneralForumTopicMessagesParams,
+    UnpinChatMessageParams, UploadStickerFileParams,
+};
+use crate::response::{EditMessageResponse, MethodResponse};
 use async_trait::async_trait;
 use std::path::PathBuf;
 

--- a/src/api_traits/telegram_api.rs
+++ b/src/api_traits/telegram_api.rs
@@ -1,154 +1,50 @@
-use super::EditMessageResponse;
-use super::MethodResponse;
-use crate::api_params::AddStickerToSetParams;
-use crate::api_params::AnswerCallbackQueryParams;
-use crate::api_params::AnswerInlineQueryParams;
-use crate::api_params::AnswerPreCheckoutQueryParams;
-use crate::api_params::AnswerShippingQueryParams;
-use crate::api_params::AnswerWebAppQueryParams;
-use crate::api_params::ApproveChatJoinRequestParams;
-use crate::api_params::BanChatMemberParams;
-use crate::api_params::BanChatSenderChatParams;
-use crate::api_params::CloseForumTopicParams;
-use crate::api_params::CloseGeneralForumTopicParams;
-use crate::api_params::CopyMessageParams;
-use crate::api_params::CopyMessagesParams;
-use crate::api_params::CreateChatInviteLinkParams;
-use crate::api_params::CreateChatSubscriptionInviteLinkParams;
-use crate::api_params::CreateForumTopicParams;
-use crate::api_params::CreateInvoiceLinkParams;
-use crate::api_params::CreateNewStickerSetParams;
-use crate::api_params::DeclineChatJoinRequestParams;
-use crate::api_params::DeleteChatPhotoParams;
-use crate::api_params::DeleteChatStickerSetParams;
-use crate::api_params::DeleteForumTopicParams;
-use crate::api_params::DeleteMessageParams;
-use crate::api_params::DeleteMessagesParams;
-use crate::api_params::DeleteMyCommandsParams;
-use crate::api_params::DeleteStickerFromSetParams;
-use crate::api_params::DeleteStickerSetParams;
-use crate::api_params::DeleteWebhookParams;
-use crate::api_params::EditChatInviteLinkParams;
-use crate::api_params::EditChatSubscriptionInviteLinkParams;
-use crate::api_params::EditForumTopicParams;
-use crate::api_params::EditGeneralForumTopicParams;
-use crate::api_params::EditMessageCaptionParams;
-use crate::api_params::EditMessageLiveLocationParams;
-use crate::api_params::EditMessageMediaParams;
-use crate::api_params::EditMessageReplyMarkupParams;
-use crate::api_params::EditMessageTextParams;
-use crate::api_params::ExportChatInviteLinkParams;
-use crate::api_params::FileUpload;
-use crate::api_params::ForwardMessageParams;
-use crate::api_params::ForwardMessagesParams;
-use crate::api_params::GetBusinessConnectionParams;
-use crate::api_params::GetChatAdministratorsParams;
-use crate::api_params::GetChatMemberCountParams;
-use crate::api_params::GetChatMemberParams;
-use crate::api_params::GetChatMenuButtonParams;
-use crate::api_params::GetChatParams;
-use crate::api_params::GetFileParams;
-use crate::api_params::GetGameHighScoresParams;
-use crate::api_params::GetMyCommandsParams;
-use crate::api_params::GetMyDefaultAdministratorRightsParams;
-use crate::api_params::GetMyDescriptionParams;
-use crate::api_params::GetMyNameParams;
-use crate::api_params::GetMyShortDescriptionParams;
-use crate::api_params::GetStarTransactionsParams;
-use crate::api_params::GetStickerSetParams;
-use crate::api_params::GetUpdatesParams;
-use crate::api_params::GetUserChatBoostsParams;
-use crate::api_params::GetUserProfilePhotosParams;
-use crate::api_params::HideGeneralForumTopicParams;
-use crate::api_params::InputMedia;
-use crate::api_params::LeaveChatParams;
-use crate::api_params::Media;
-use crate::api_params::PinChatMessageParams;
-use crate::api_params::PromoteChatMemberParams;
-use crate::api_params::RefundStarPaymentParams;
-use crate::api_params::ReopenForumTopicParams;
-use crate::api_params::ReopenGeneralForumTopicParams;
-use crate::api_params::ReplaceStickerInSetParams;
-use crate::api_params::RestrictChatMemberParams;
-use crate::api_params::RevokeChatInviteLinkParams;
-use crate::api_params::SendAnimationParams;
-use crate::api_params::SendAudioParams;
-use crate::api_params::SendChatActionParams;
-use crate::api_params::SendContactParams;
-use crate::api_params::SendDiceParams;
-use crate::api_params::SendDocumentParams;
-use crate::api_params::SendGameParams;
-use crate::api_params::SendInvoiceParams;
-use crate::api_params::SendLocationParams;
-use crate::api_params::SendMediaGroupParams;
-use crate::api_params::SendMessageParams;
-use crate::api_params::SendPaidMediaParams;
-use crate::api_params::SendPhotoParams;
-use crate::api_params::SendPollParams;
-use crate::api_params::SendStickerParams;
-use crate::api_params::SendVenueParams;
-use crate::api_params::SendVideoNoteParams;
-use crate::api_params::SendVideoParams;
-use crate::api_params::SendVoiceParams;
-use crate::api_params::SetChatAdministratorCustomTitleParams;
-use crate::api_params::SetChatDescriptionParams;
-use crate::api_params::SetChatMenuButtonParams;
-use crate::api_params::SetChatPermissionsParams;
-use crate::api_params::SetChatPhotoParams;
-use crate::api_params::SetChatStickerSetParams;
-use crate::api_params::SetChatTitleParams;
-use crate::api_params::SetCustomEmojiStickerSetThumbnailParams;
-use crate::api_params::SetGameScoreParams;
-use crate::api_params::SetMessageReactionParams;
-use crate::api_params::SetMyCommandsParams;
-use crate::api_params::SetMyDefaultAdministratorRightsParams;
-use crate::api_params::SetMyDescriptionParams;
-use crate::api_params::SetMyNameParams;
-use crate::api_params::SetMyShortDescriptionParams;
-use crate::api_params::SetStickerEmojiListParams;
-use crate::api_params::SetStickerKeywordsParams;
-use crate::api_params::SetStickerMaskPositionParams;
-use crate::api_params::SetStickerPositionInSetParams;
-use crate::api_params::SetStickerSetThumbnailParams;
-use crate::api_params::SetStickerSetTitleParams;
-use crate::api_params::SetWebhookParams;
-use crate::api_params::StopMessageLiveLocationParams;
-use crate::api_params::StopPollParams;
-use crate::api_params::UnbanChatMemberParams;
-use crate::api_params::UnbanChatSenderChatParams;
-use crate::api_params::UnhideGeneralForumTopicParams;
-use crate::api_params::UnpinAllChatMessagesParams;
-use crate::api_params::UnpinAllForumTopicMessagesParams;
-use crate::api_params::UnpinChatMessageParams;
-use crate::api_params::UploadStickerFileParams;
-use crate::objects::BotCommand;
-use crate::objects::BotDescription;
-use crate::objects::BotName;
-use crate::objects::BotShortDescription;
-use crate::objects::BusinessConnection;
-use crate::objects::ChatAdministratorRights;
-use crate::objects::ChatFullInfo;
-use crate::objects::ChatInviteLink;
-use crate::objects::ChatMember;
-use crate::objects::File as FileObject;
-use crate::objects::ForumTopic;
-use crate::objects::GameHighScore;
-use crate::objects::InputSticker;
-use crate::objects::MenuButton;
-use crate::objects::Message;
-use crate::objects::MessageId;
-use crate::objects::Poll;
-use crate::objects::SentWebAppMessage;
-use crate::objects::StarTransactions;
-use crate::objects::StickerSet;
-use crate::objects::Update;
-use crate::objects::User;
-use crate::objects::UserChatBoosts;
-use crate::objects::UserProfilePhotos;
-use crate::objects::WebhookInfo;
-use crate::GetCustomEmojiStickersParams;
-use crate::Sticker;
-use crate::UnpinAllGeneralForumTopicMessagesParams;
+use crate::objects::{
+    BotCommand, BotDescription, BotName, BotShortDescription, BusinessConnection,
+    ChatAdministratorRights, ChatFullInfo, ChatInviteLink, ChatMember, File as FileObject,
+    ForumTopic, GameHighScore, InputSticker, MenuButton, Message, MessageId, Poll,
+    SentWebAppMessage, StarTransactions, Sticker, StickerSet, Update, User, UserChatBoosts,
+    UserProfilePhotos, WebhookInfo,
+};
+use crate::parameters::{
+    AddStickerToSetParams, AnswerCallbackQueryParams, AnswerInlineQueryParams,
+    AnswerPreCheckoutQueryParams, AnswerShippingQueryParams, AnswerWebAppQueryParams,
+    ApproveChatJoinRequestParams, BanChatMemberParams, BanChatSenderChatParams,
+    CloseForumTopicParams, CloseGeneralForumTopicParams, CopyMessageParams, CopyMessagesParams,
+    CreateChatInviteLinkParams, CreateChatSubscriptionInviteLinkParams, CreateForumTopicParams,
+    CreateInvoiceLinkParams, CreateNewStickerSetParams, DeclineChatJoinRequestParams,
+    DeleteChatPhotoParams, DeleteChatStickerSetParams, DeleteForumTopicParams, DeleteMessageParams,
+    DeleteMessagesParams, DeleteMyCommandsParams, DeleteStickerFromSetParams,
+    DeleteStickerSetParams, DeleteWebhookParams, EditChatInviteLinkParams,
+    EditChatSubscriptionInviteLinkParams, EditForumTopicParams, EditGeneralForumTopicParams,
+    EditMessageCaptionParams, EditMessageLiveLocationParams, EditMessageMediaParams,
+    EditMessageReplyMarkupParams, EditMessageTextParams, ExportChatInviteLinkParams, FileUpload,
+    ForwardMessageParams, ForwardMessagesParams, GetBusinessConnectionParams,
+    GetChatAdministratorsParams, GetChatMemberCountParams, GetChatMemberParams,
+    GetChatMenuButtonParams, GetChatParams, GetCustomEmojiStickersParams, GetFileParams,
+    GetGameHighScoresParams, GetMyCommandsParams, GetMyDefaultAdministratorRightsParams,
+    GetMyDescriptionParams, GetMyNameParams, GetMyShortDescriptionParams,
+    GetStarTransactionsParams, GetStickerSetParams, GetUpdatesParams, GetUserChatBoostsParams,
+    GetUserProfilePhotosParams, HideGeneralForumTopicParams, InputMedia, LeaveChatParams, Media,
+    PinChatMessageParams, PromoteChatMemberParams, RefundStarPaymentParams, ReopenForumTopicParams,
+    ReopenGeneralForumTopicParams, ReplaceStickerInSetParams, RestrictChatMemberParams,
+    RevokeChatInviteLinkParams, SendAnimationParams, SendAudioParams, SendChatActionParams,
+    SendContactParams, SendDiceParams, SendDocumentParams, SendGameParams, SendInvoiceParams,
+    SendLocationParams, SendMediaGroupParams, SendMessageParams, SendPaidMediaParams,
+    SendPhotoParams, SendPollParams, SendStickerParams, SendVenueParams, SendVideoNoteParams,
+    SendVideoParams, SendVoiceParams, SetChatAdministratorCustomTitleParams,
+    SetChatDescriptionParams, SetChatMenuButtonParams, SetChatPermissionsParams,
+    SetChatPhotoParams, SetChatStickerSetParams, SetChatTitleParams,
+    SetCustomEmojiStickerSetThumbnailParams, SetGameScoreParams, SetMessageReactionParams,
+    SetMyCommandsParams, SetMyDefaultAdministratorRightsParams, SetMyDescriptionParams,
+    SetMyNameParams, SetMyShortDescriptionParams, SetStickerEmojiListParams,
+    SetStickerKeywordsParams, SetStickerMaskPositionParams, SetStickerPositionInSetParams,
+    SetStickerSetThumbnailParams, SetStickerSetTitleParams, SetWebhookParams,
+    StopMessageLiveLocationParams, StopPollParams, UnbanChatMemberParams,
+    UnbanChatSenderChatParams, UnhideGeneralForumTopicParams, UnpinAllChatMessagesParams,
+    UnpinAllForumTopicMessagesParams, UnpinAllGeneralForumTopicMessagesParams,
+    UnpinChatMessageParams, UploadStickerFileParams,
+};
+use crate::response::{EditMessageResponse, MethodResponse};
 use std::path::PathBuf;
 
 pub trait TelegramApi {

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,47 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, thiserror::Error)]
+#[serde(untagged)]
+pub enum Error {
+    #[error("Http Error {code}: {message}")]
+    Http { code: u16, message: String },
+    #[error("Api Error {0:?}")]
+    Api(crate::response::ErrorResponse),
+    #[error("Decode Error {0}")]
+    Decode(String),
+    #[error("Encode Error {0}")]
+    Encode(String),
+}
+
+#[cfg(feature = "reqwest")]
+impl From<reqwest::Error> for Error {
+    fn from(error: reqwest::Error) -> Self {
+        let message = error.to_string();
+        let code = error
+            .status()
+            .map_or(500, |status_code| status_code.as_u16());
+        Self::Http { code, message }
+    }
+}
+
+#[cfg(feature = "ureq")]
+impl From<ureq::Error> for Error {
+    fn from(error: ureq::Error) -> Self {
+        match error {
+            ureq::Error::Status(code, response) => match response.into_string() {
+                Ok(message) => match serde_json::from_str(&message) {
+                    Ok(json_result) => Self::Api(json_result),
+                    Err(_) => Self::Http { code, message },
+                },
+                Err(_) => Self::Http {
+                    code,
+                    message: "Failed to decode response".to_string(),
+                },
+            },
+            ureq::Error::Transport(transport_error) => Self::Http {
+                message: format!("{transport_error:?}"),
+                code: 500,
+            },
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,27 +1,24 @@
-#[cfg(any(feature = "http-client", feature = "async-http-client"))]
-pub mod api;
-
-#[cfg(any(feature = "telegram-trait", feature = "async-telegram-trait"))]
-pub mod api_traits;
-
-#[cfg(any(feature = "http-client", feature = "async-http-client"))]
-pub use api::*;
-
-#[cfg(any(feature = "telegram-trait", feature = "async-telegram-trait"))]
-pub use api_traits::*;
-
-#[doc(hidden)]
 #[cfg(feature = "async-http-client")]
 pub use reqwest;
-
-#[doc(hidden)]
 #[cfg(feature = "http-client")]
 pub use ureq;
 
-pub mod api_params;
+#[cfg(any(feature = "http-client", feature = "async-http-client"))]
+mod api;
+#[cfg(any(feature = "telegram-trait", feature = "async-telegram-trait"))]
+mod api_traits;
+mod error;
 pub mod objects;
+pub mod parameters;
 mod parse_mode;
+pub mod response;
 
-pub use api_params::*;
-pub use objects::*;
-pub use parse_mode::*;
+#[cfg(any(feature = "http-client", feature = "async-http-client"))]
+pub use api::*;
+#[cfg(any(feature = "telegram-trait", feature = "async-telegram-trait"))]
+pub use api_traits::*;
+pub use error::Error;
+pub use parse_mode::ParseMode;
+
+/// Default Bot API URL
+pub const BASE_API_URL: &str = "https://api.telegram.org/bot";

--- a/src/objects.rs
+++ b/src/objects.rs
@@ -1,9 +1,11 @@
+//! Objects returned or used with the Telegram API.
+
 #![allow(deprecated)]
-use super::api_params::FileUpload;
+
+use crate::parameters::FileUpload;
+use crate::ParseMode;
 use serde::{Deserialize, Serialize};
 use typed_builder::TypedBuilder as Builder;
-
-use crate::ParseMode;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]

--- a/src/parameters.rs
+++ b/src/parameters.rs
@@ -1,23 +1,26 @@
-#![allow(deprecated)]
+//! Parameters to Telegram API methods.
+
+#![allow(clippy::module_name_repetitions)]
+
 use crate::objects::{
-    BotCommand, ChatAdministratorRights, ChatPermissions, ForceReply, InlineKeyboardMarkup,
-    InlineQueryResultArticle, InlineQueryResultAudio, InlineQueryResultCachedAudio,
-    InlineQueryResultCachedDocument, InlineQueryResultCachedGif, InlineQueryResultCachedMpeg4Gif,
-    InlineQueryResultCachedPhoto, InlineQueryResultCachedSticker, InlineQueryResultCachedVideo,
-    InlineQueryResultCachedVoice, InlineQueryResultContact, InlineQueryResultDocument,
-    InlineQueryResultGame, InlineQueryResultGif, InlineQueryResultLocation,
-    InlineQueryResultMpeg4Gif, InlineQueryResultPhoto, InlineQueryResultVenue,
-    InlineQueryResultVideo, InlineQueryResultVoice, InputPaidMedia, InputPollOption, InputSticker,
-    LabeledPrice, LinkPreviewOptions, MaskPosition, MenuButton, MessageEntity,
-    PassportElementErrorDataField, PassportElementErrorFile, PassportElementErrorFiles,
-    PassportElementErrorFrontSide, PassportElementErrorReverseSide, PassportElementErrorSelfie,
-    PassportElementErrorTranslationFile, PassportElementErrorTranslationFiles,
-    PassportElementErrorUnspecified, PollType, ReactionType, ReplyKeyboardMarkup,
-    ReplyKeyboardRemove, ShippingOption, StickerFormat, StickerType, WebAppInfo,
+    AllowedUpdate, BotCommand, ChatAdministratorRights, ChatPermissions, ForceReply,
+    InlineKeyboardMarkup, InlineQueryResultArticle, InlineQueryResultAudio,
+    InlineQueryResultCachedAudio, InlineQueryResultCachedDocument, InlineQueryResultCachedGif,
+    InlineQueryResultCachedMpeg4Gif, InlineQueryResultCachedPhoto, InlineQueryResultCachedSticker,
+    InlineQueryResultCachedVideo, InlineQueryResultCachedVoice, InlineQueryResultContact,
+    InlineQueryResultDocument, InlineQueryResultGame, InlineQueryResultGif,
+    InlineQueryResultLocation, InlineQueryResultMpeg4Gif, InlineQueryResultPhoto,
+    InlineQueryResultVenue, InlineQueryResultVideo, InlineQueryResultVoice, InputPaidMedia,
+    InputPollOption, InputSticker, LabeledPrice, LinkPreviewOptions, MaskPosition, MenuButton,
+    MessageEntity, PassportElementErrorDataField, PassportElementErrorFile,
+    PassportElementErrorFiles, PassportElementErrorFrontSide, PassportElementErrorReverseSide,
+    PassportElementErrorSelfie, PassportElementErrorTranslationFile,
+    PassportElementErrorTranslationFiles, PassportElementErrorUnspecified, PollType, ReactionType,
+    ReplyKeyboardMarkup, ReplyKeyboardRemove, ShippingOption, StickerFormat, StickerType,
+    WebAppInfo,
 };
-use crate::{AllowedUpdate, ParseMode};
-use serde::Deserialize;
-use serde::Serialize;
+use crate::parse_mode::ParseMode;
+use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 use typed_builder::TypedBuilder as Builder;
 

--- a/src/parse_mode.rs
+++ b/src/parse_mode.rs
@@ -1,10 +1,12 @@
 #![allow(deprecated)]
 
+use serde::{Deserialize, Serialize};
 use std::fmt::Display;
 use std::str::FromStr;
 
-use serde::{Deserialize, Serialize};
-
+/// Text Formatting Options
+///
+/// See <https://core.telegram.org/bots/api#formatting-options>
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, Serialize, Deserialize)]
 pub enum ParseMode {
     #[serde(rename = "HTML")]
@@ -18,6 +20,7 @@ pub enum ParseMode {
 
 impl FromStr for ParseMode {
     type Err = ();
+
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
             "HTML" | "Html" | "html" => Ok(Self::Html),

--- a/src/response.rs
+++ b/src/response.rs
@@ -1,0 +1,41 @@
+//! Raw reponse objects returned by the Telegram API.
+//!
+//! Mainly useful when implementing the `TelegramApi` trait.
+
+#![allow(clippy::module_name_repetitions)]
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct MethodResponse<T> {
+    /// Always true
+    pub ok: bool,
+    pub result: T,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+}
+
+/// Error on an unsuccessful request.
+///
+/// `ok` equals false and the error is explained in the `description`.
+/// An Integer `error_code` field is also returned, but its contents are subject to change in the future.
+/// Some errors may also have an optional field `parameters` of the type `ResponseParameters`, which can help to automatically handle the error.
+///
+/// See <https://core.telegram.org/bots/api#making-requests>
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ErrorResponse {
+    /// Always false
+    pub ok: bool,
+    pub description: String,
+    /// Contents are subject to change in the future
+    pub error_code: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub parameters: Option<crate::objects::ResponseParameters>,
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[serde(untagged)]
+pub enum EditMessageResponse {
+    Message(MethodResponse<crate::objects::Message>),
+    Bool(MethodResponse<bool>),
+}


### PR DESCRIPTION
This also improves the documentation of the crate as there are no internal re-exports anymore and everything has a dedicated path.

BREAKING CHANGES:
- There should now be only a single path to import a specific object.
- HttpError is integrated into the Error enum variant