### PR TITLE
refactor!: merge Error and HttpError

### DIFF
--- a/examples/api_trait_implementation.rs
+++ b/examples/api_trait_implementation.rs
@@ -14,14 +14,8 @@ pub struct Api {
 
 #[derive(Debug)]
 pub enum Error {
-    HttpError(HttpError),
-    ApiError(ErrorResponse),
-}
-
-#[derive(Debug)]
-pub struct HttpError {
-    pub code: u16,
-    pub message: String,
+    Http { code: u16, message: String },
+    Api(ErrorResponse),
 }
 
 impl Api {
@@ -40,24 +34,14 @@ impl Api {
 impl From<isahc::http::Error> for Error {
     fn from(error: isahc::http::Error) -> Self {
         let message = format!("{error:?}");
-        let error = HttpError { code: 500, message };
-        Self::HttpError(error)
-    }
-}
-
-impl From<std::io::Error> for Error {
-    fn from(error: std::io::Error) -> Self {
-        let message = format!("{error:?}");
-        let error = HttpError { code: 500, message };
-        Self::HttpError(error)
+        Self::Http { code: 500, message }
     }
 }
 
 impl From<isahc::Error> for Error {
     fn from(error: isahc::Error) -> Self {
         let message = format!("{error:?}");
-        let error = HttpError { code: 500, message };
-        Self::HttpError(error)
+        Self::Http { code: 500, message }
     }
 }
 
@@ -81,21 +65,18 @@ impl TelegramApi for Api {
             }
         };
 
-        let text = response.text()?;
+        let text = response.text().map_err(|error| Error::Http {
+            code: 500,
+            message: format!("{error:?}"),
+        })?;
 
-        let parsed_result: Result<T2, serde_json::Error> = serde_json::from_str(&text);
-
-        parsed_result.map_err(|_| {
-            let parsed_error: Result<ErrorResponse, serde_json::Error> =
-                serde_json::from_str(&text);
-
-            match parsed_error {
-                Ok(result) => Error::ApiError(result),
-                Err(error) => {
-                    let message = format!("{error:?}");
-                    let error = HttpError { code: 500, message };
-                    Error::HttpError(error)
-                }
+        serde_json::from_str(&text).map_err(|_| {
+            match serde_json::from_str::<ErrorResponse>(&text) {
+                Ok(result) => Error::Api(result),
+                Err(error) => Error::Http {
+                    code: 500,
+                    message: format!("{error:?}"),
+                },
             }
         })
     }
@@ -108,12 +89,8 @@ impl TelegramApi for Api {
         _params: T1,
         _files: Vec<(&str, PathBuf)>,
     ) -> Result<T2, Error> {
-        let error = HttpError {
-            code: 500,
-            message: "isahc doesn't support form data requests".to_string(),
-        };
-
-        Err(Error::HttpError(error))
+        let message = "isahc doesn't support form data requests".to_string();
+        Err(Error::Http { code: 500, message })
     }
 }
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -16,19 +16,12 @@ pub static BASE_API_URL: &str = "https://api.telegram.org/bot";
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, thiserror::Error)]
 #[serde(untagged)]
 pub enum Error {
-    #[error("{0}")]
-    Http(HttpError),
+    #[error("Http Error {code}: {message}")]
+    Http { code: u16, message: String },
     #[error("Api Error {0:?}")]
     Api(ErrorResponse),
     #[error("Decode Error {0}")]
     Decode(String),
     #[error("Encode Error {0}")]
     Encode(String),
-}
-
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, thiserror::Error)]
-#[error("Http Error {code}: {message}")]
-pub struct HttpError {
-    pub code: u16,
-    pub message: String,
 }

--- a/src/api/async_telegram_api_impl.rs
+++ b/src/api/async_telegram_api_impl.rs
@@ -1,5 +1,4 @@
 use super::Error;
-use super::HttpError;
 use crate::api_traits::AsyncTelegramApi;
 use crate::api_traits::ErrorResponse;
 use async_trait::async_trait;
@@ -79,17 +78,7 @@ impl From<reqwest::Error> for Error {
         let code = error
             .status()
             .map_or(500, |status_code| status_code.as_u16());
-
-        let error = HttpError { code, message };
-        Self::Http(error)
-    }
-}
-
-impl From<std::io::Error> for Error {
-    fn from(error: std::io::Error) -> Self {
-        let message = error.to_string();
-
-        Self::Encode(message)
+        Self::Http { code, message }
     }
 }
 
@@ -162,8 +151,9 @@ impl AsyncTelegramApi for AsyncApi {
         }
 
         for (parameter_name, file_path, file_name) in files_with_paths {
-            let file = File::open(file_path).await?;
-
+            let file = File::open(file_path)
+                .await
+                .map_err(|err| Error::Encode(err.to_string()))?;
             let part = multipart::Part::stream(file).file_name(file_name);
             form = form.part(parameter_name, part);
         }

--- a/src/api/telegram_api_impl.rs
+++ b/src/api/telegram_api_impl.rs
@@ -1,5 +1,4 @@
 use super::Error;
-use super::HttpError;
 use crate::api_traits::TelegramApi;
 use multipart::client::lazy::Multipart;
 use serde_json::Value;
@@ -61,17 +60,17 @@ impl From<ureq::Error> for Error {
             ureq::Error::Status(code, response) => match response.into_string() {
                 Ok(message) => match serde_json::from_str(&message) {
                     Ok(json_result) => Self::Api(json_result),
-                    Err(_) => Self::Http(HttpError { code, message }),
+                    Err(_) => Self::Http { code, message },
                 },
-                Err(_) => Self::Http(HttpError {
+                Err(_) => Self::Http {
                     code,
                     message: "Failed to decode response".to_string(),
-                }),
+                },
             },
-            ureq::Error::Transport(transport_error) => Self::Http(HttpError {
+            ureq::Error::Transport(transport_error) => Self::Http {
                 message: format!("{transport_error:?}"),
                 code: 500,
-            }),
+            },
         }
     }
 }


### PR DESCRIPTION
Also, `From<std::io::Error> for Error` is removed as it could result in accidental wrong error kinds when the `?` operator is used.

BREAKING CHANGE: `Error::Http` changed and `HttpError` struct is gone.