### PR TITLE
refactor: improve generic argument naming

### DIFF
--- a/src/api/async_telegram_api_impl.rs
+++ b/src/api/async_telegram_api_impl.rs
@@ -1,7 +1,6 @@
 use super::Error;
 use super::HttpError;
 use crate::api_traits::AsyncTelegramApi;
-use crate::api_traits::ErrorResponse;
 use async_trait::async_trait;
 use reqwest::multipart;
 use serde_json::Value;
@@ -28,48 +27,36 @@ impl AsyncApi {
     }
 
     /// Create a new `AsyncApi`. You can use [`AsyncApi::builder`] for more options.
-    pub fn new_url<T: Into<String>>(api_url: T) -> Self {
+    pub fn new_url<S: Into<String>>(api_url: S) -> Self {
         Self::builder().api_url(api_url).build()
     }
 
-    pub fn encode_params<T: serde::ser::Serialize + std::fmt::Debug>(
-        params: &T,
-    ) -> Result<String, Error> {
+    pub fn encode_params<Params>(params: &Params) -> Result<String, Error>
+    where
+        Params: serde::ser::Serialize + std::fmt::Debug,
+    {
         serde_json::to_string(params).map_err(|e| Error::Encode(format!("{e:?} : {params:?}")))
     }
 
-    pub async fn decode_response<T: serde::de::DeserializeOwned>(
-        response: reqwest::Response,
-    ) -> Result<T, Error> {
+    pub async fn decode_response<Output>(response: reqwest::Response) -> Result<Output, Error>
+    where
+        Output: serde::de::DeserializeOwned,
+    {
         let status_code = response.status().as_u16();
         match response.text().await {
             Ok(message) => {
                 if status_code == 200 {
-                    let success_response: T = Self::parse_json(&message)?;
-                    return Ok(success_response);
+                    Ok(Self::parse_json(&message)?)
+                } else {
+                    Err(Error::Api(Self::parse_json(&message)?))
                 }
-
-                let error_response: ErrorResponse = Self::parse_json(&message)?;
-                Err(Error::Api(error_response))
             }
-            Err(e) => {
-                let err = Error::Decode(format!("Failed to decode response: {e:?}"));
-                Err(err)
-            }
+            Err(e) => Err(Error::Decode(format!("Failed to decode response: {e:?}"))),
         }
     }
 
-    fn parse_json<T: serde::de::DeserializeOwned>(body: &str) -> Result<T, Error> {
-        let json_result: Result<T, serde_json::Error> = serde_json::from_str(body);
-
-        match json_result {
-            Ok(result) => Ok(result),
-
-            Err(e) => {
-                let err = Error::Decode(format!("{e:?} : {body:?}"));
-                Err(err)
-            }
-        }
+    fn parse_json<Output: serde::de::DeserializeOwned>(body: &str) -> Result<Output, Error> {
+        serde_json::from_str(body).map_err(|e| Error::Decode(format!("{e:?} : {body:?}")))
     }
 }
 
@@ -97,14 +84,15 @@ impl From<std::io::Error> for Error {
 impl AsyncTelegramApi for AsyncApi {
     type Error = Error;
 
-    async fn request<
-        T1: serde::ser::Serialize + std::fmt::Debug + std::marker::Send,
-        T2: serde::de::DeserializeOwned,
-    >(
+    async fn request<Params, Output>(
         &self,
         method: &str,
-        params: Option<T1>,
-    ) -> Result<T2, Self::Error> {
+        params: Option<Params>,
+    ) -> Result<Output, Self::Error>
+    where
+        Params: serde::ser::Serialize + std::fmt::Debug + std::marker::Send,
+        Output: serde::de::DeserializeOwned,
+    {
         let url = format!("{}/{method}", self.api_url);
 
         let mut prepared_request = self
@@ -121,20 +109,19 @@ impl AsyncTelegramApi for AsyncApi {
         };
 
         let response = prepared_request.send().await?;
-        let parsed_response: T2 = Self::decode_response(response).await?;
-
-        Ok(parsed_response)
+        Self::decode_response(response).await
     }
 
-    async fn request_with_form_data<
-        T1: serde::ser::Serialize + std::fmt::Debug + std::marker::Send,
-        T2: serde::de::DeserializeOwned,
-    >(
+    async fn request_with_form_data<Params, Output>(
         &self,
         method: &str,
-        params: T1,
+        params: Params,
         files: Vec<(&str, PathBuf)>,
-    ) -> Result<T2, Self::Error> {
+    ) -> Result<Output, Self::Error>
+    where
+        Params: serde::ser::Serialize + std::fmt::Debug + std::marker::Send,
+        Output: serde::de::DeserializeOwned,
+    {
         let json_string = Self::encode_params(&params)?;
         let json_struct: Value = serde_json::from_str(&json_string).unwrap();
         let file_keys: Vec<&str> = files.iter().map(|(key, _)| *key).collect();
@@ -171,9 +158,7 @@ impl AsyncTelegramApi for AsyncApi {
         let url = format!("{}/{method}", self.api_url);
 
         let response = self.client.post(url).multipart(form).send().await?;
-        let parsed_response: T2 = Self::decode_response(response).await?;
-
-        Ok(parsed_response)
+        Self::decode_response(response).await
     }
 }
 

--- a/src/api/async_telegram_api_impl.rs
+++ b/src/api/async_telegram_api_impl.rs
@@ -83,20 +83,14 @@ impl AsyncTelegramApi for AsyncApi {
         Output: serde::de::DeserializeOwned,
     {
         let url = format!("{}/{method}", self.api_url);
-
         let mut prepared_request = self
             .client
             .post(url)
             .header("Content-Type", "application/json");
-
-        prepared_request = if let Some(data) = params {
-            let json_string = Self::encode_params(&data)?;
-
-            prepared_request.body(json_string)
-        } else {
-            prepared_request
+        if let Some(params) = params {
+            let json_string = Self::encode_params(&params)?;
+            prepared_request = prepared_request.body(json_string);
         };
-
         let response = prepared_request.send().await?;
         Self::decode_response(response).await
     }

--- a/src/api/telegram_api_impl.rs
+++ b/src/api/telegram_api_impl.rs
@@ -80,7 +80,6 @@ impl TelegramApi for Api {
             .request_agent
             .post(&url)
             .set("Content-Type", "application/json");
-
         let response = match params {
             None => prepared_request.call()?,
             Some(data) => {
@@ -88,7 +87,6 @@ impl TelegramApi for Api {
                 prepared_request.send_string(&json)?
             }
         };
-
         Self::decode_response(response)
     }
 
@@ -143,7 +141,6 @@ impl TelegramApi for Api {
                 &format!("multipart/form-data; boundary={}", form_data.boundary()),
             )
             .send(form_data)?;
-
         Self::decode_response(response)
     }
 }

--- a/src/api/telegram_api_impl.rs
+++ b/src/api/telegram_api_impl.rs
@@ -24,33 +24,25 @@ impl Api {
     }
 
     /// Create a new `Api`. You can use [`Api::builder`] for more options.
-    pub fn new_url<T: Into<String>>(api_url: T) -> Self {
+    pub fn new_url<S: Into<String>>(api_url: S) -> Self {
         Self::builder().api_url(api_url).build()
     }
 
-    pub fn encode_params<T: serde::ser::Serialize + std::fmt::Debug>(
-        params: &T,
-    ) -> Result<String, Error> {
+    pub fn encode_params<Params>(params: &Params) -> Result<String, Error>
+    where
+        Params: serde::ser::Serialize + std::fmt::Debug,
+    {
         serde_json::to_string(params).map_err(|e| Error::Encode(format!("{e:?} : {params:?}")))
     }
 
-    pub fn decode_response<T: serde::de::DeserializeOwned>(response: Response) -> Result<T, Error> {
+    pub fn decode_response<Output>(response: Response) -> Result<Output, Error>
+    where
+        Output: serde::de::DeserializeOwned,
+    {
         match response.into_string() {
-            Ok(message) => {
-                let json_result: Result<T, serde_json::Error> = serde_json::from_str(&message);
-
-                match json_result {
-                    Ok(result) => Ok(result),
-                    Err(e) => {
-                        let err = Error::Decode(format!("{e:?} : {message:?}"));
-                        Err(err)
-                    }
-                }
-            }
-            Err(e) => {
-                let err = Error::Decode(format!("Failed to decode response: {e:?}"));
-                Err(err)
-            }
+            Ok(message) => serde_json::from_str(&message)
+                .map_err(|error| Error::Decode(format!("{error:?} : {message:?}"))),
+            Err(e) => Err(Error::Decode(format!("Failed to decode response: {e:?}"))),
         }
     }
 }
@@ -79,11 +71,11 @@ impl From<ureq::Error> for Error {
 impl TelegramApi for Api {
     type Error = Error;
 
-    fn request<T1: serde::ser::Serialize + std::fmt::Debug, T2: serde::de::DeserializeOwned>(
-        &self,
-        method: &str,
-        params: Option<T1>,
-    ) -> Result<T2, Error> {
+    fn request<Params, Output>(&self, method: &str, params: Option<Params>) -> Result<Output, Error>
+    where
+        Params: serde::ser::Serialize + std::fmt::Debug,
+        Output: serde::de::DeserializeOwned,
+    {
         let url = format!("{}/{method}", self.api_url);
         let prepared_request = self
             .request_agent
@@ -98,20 +90,19 @@ impl TelegramApi for Api {
             }
         };
 
-        let parsed_response: T2 = Self::decode_response(response)?;
-
-        Ok(parsed_response)
+        Self::decode_response(response)
     }
 
-    fn request_with_form_data<
-        T1: serde::ser::Serialize + std::fmt::Debug,
-        T2: serde::de::DeserializeOwned,
-    >(
+    fn request_with_form_data<Params, Output>(
         &self,
         method: &str,
-        params: T1,
+        params: Params,
         files: Vec<(&str, PathBuf)>,
-    ) -> Result<T2, Error> {
+    ) -> Result<Output, Error>
+    where
+        Params: serde::ser::Serialize + std::fmt::Debug,
+        Output: serde::de::DeserializeOwned,
+    {
         let json_string = Self::encode_params(&params)?;
         let json_struct: Value = serde_json::from_str(&json_string).unwrap();
         let file_keys: Vec<&str> = files.iter().map(|(key, _)| *key).collect();
@@ -154,9 +145,7 @@ impl TelegramApi for Api {
             )
             .send(form_data)?;
 
-        let parsed_response: T2 = Self::decode_response(response)?;
-
-        Ok(parsed_response)
+        Self::decode_response(response)
     }
 }
 

--- a/src/api_traits/async_telegram_api.rs
+++ b/src/api_traits/async_telegram_api.rs
@@ -361,7 +361,7 @@ pub trait AsyncTelegramApi {
         let mut new_params = params.clone();
         new_params.media = new_medias;
 
-        let files_with_str_names: Vec<(&str, PathBuf)> = files
+        let files_with_str_names = files
             .iter()
             .map(|(key, path)| (key.as_str(), path.clone()))
             .collect();
@@ -1069,7 +1069,7 @@ pub trait AsyncTelegramApi {
         let mut new_params = params.clone();
         new_params.media = new_media;
 
-        let files_with_str_names: Vec<(&str, PathBuf)> = files
+        let files_with_str_names = files
             .iter()
             .map(|(key, path)| (key.as_str(), path.clone()))
             .collect();
@@ -1170,7 +1170,7 @@ pub trait AsyncTelegramApi {
         let mut new_params = params.clone();
         new_params.stickers = new_stickers;
 
-        let files_with_str_names: Vec<(&str, PathBuf)> = files
+        let files_with_str_names = files
             .iter()
             .map(|(key, path)| (key.as_str(), path.clone()))
             .collect();
@@ -1387,33 +1387,33 @@ pub trait AsyncTelegramApi {
             .await
     }
 
-    async fn request_without_body<T: serde::de::DeserializeOwned>(
-        &self,
-        method: &str,
-    ) -> Result<T, Self::Error> {
+    async fn request_without_body<Output>(&self, method: &str) -> Result<Output, Self::Error>
+    where
+        Output: serde::de::DeserializeOwned,
+    {
         let params: Option<()> = None;
-
         self.request(method, params).await
     }
 
-    async fn request<
-        T1: serde::ser::Serialize + std::fmt::Debug + std::marker::Send,
-        T2: serde::de::DeserializeOwned,
-    >(
+    async fn request<Params, Output>(
         &self,
         method: &str,
-        params: Option<T1>,
-    ) -> Result<T2, Self::Error>;
+        params: Option<Params>,
+    ) -> Result<Output, Self::Error>
+    where
+        Params: serde::ser::Serialize + std::fmt::Debug + std::marker::Send,
+        Output: serde::de::DeserializeOwned;
 
-    async fn request_with_possible_form_data<
-        T1: serde::ser::Serialize + std::fmt::Debug + std::marker::Send,
-        T2: serde::de::DeserializeOwned,
-    >(
+    async fn request_with_possible_form_data<Params, Output>(
         &self,
         method_name: &str,
-        params: T1,
+        params: Params,
         files: Vec<(&str, PathBuf)>,
-    ) -> Result<T2, Self::Error> {
+    ) -> Result<Output, Self::Error>
+    where
+        Params: serde::ser::Serialize + std::fmt::Debug + std::marker::Send,
+        Output: serde::de::DeserializeOwned,
+    {
         if files.is_empty() {
             self.request(method_name, Some(params)).await
         } else {
@@ -1422,13 +1422,13 @@ pub trait AsyncTelegramApi {
         }
     }
 
-    async fn request_with_form_data<
-        T1: serde::ser::Serialize + std::fmt::Debug + std::marker::Send,
-        T2: serde::de::DeserializeOwned,
-    >(
+    async fn request_with_form_data<Params, Output>(
         &self,
         method: &str,
-        params: T1,
+        params: Params,
         files: Vec<(&str, PathBuf)>,
-    ) -> Result<T2, Self::Error>;
+    ) -> Result<Output, Self::Error>
+    where
+        Params: serde::ser::Serialize + std::fmt::Debug + std::marker::Send,
+        Output: serde::de::DeserializeOwned;
 }

--- a/src/api_traits/telegram_api.rs
+++ b/src/api_traits/telegram_api.rs
@@ -348,7 +348,7 @@ pub trait TelegramApi {
         let mut new_params = params.clone();
         new_params.media = new_medias;
 
-        let files_with_str_names: Vec<(&str, PathBuf)> = files
+        let files_with_str_names = files
             .iter()
             .map(|(key, path)| (key.as_str(), path.clone()))
             .collect();
@@ -1019,7 +1019,7 @@ pub trait TelegramApi {
         let mut new_params = params.clone();
         new_params.media = new_media;
 
-        let files_with_str_names: Vec<(&str, PathBuf)> = files
+        let files_with_str_names = files
             .iter()
             .map(|(key, path)| (key.as_str(), path.clone()))
             .collect();
@@ -1114,7 +1114,7 @@ pub trait TelegramApi {
         let mut new_params = params.clone();
         new_params.stickers = new_stickers;
 
-        let files_with_str_names: Vec<(&str, PathBuf)> = files
+        let files_with_str_names = files
             .iter()
             .map(|(key, path)| (key.as_str(), path.clone()))
             .collect();
@@ -1322,24 +1322,24 @@ pub trait TelegramApi {
         self.request("unpinAllGeneralForumTopicMessages", Some(params))
     }
 
-    fn request_without_body<T: serde::de::DeserializeOwned>(
-        &self,
-        method: &str,
-    ) -> Result<T, Self::Error> {
+    fn request_without_body<Output>(&self, method: &str) -> Result<Output, Self::Error>
+    where
+        Output: serde::de::DeserializeOwned,
+    {
         let params: Option<()> = None;
-
         self.request(method, params)
     }
 
-    fn request_with_possible_form_data<
-        T1: serde::ser::Serialize + std::fmt::Debug,
-        T2: serde::de::DeserializeOwned,
-    >(
+    fn request_with_possible_form_data<Params, Output>(
         &self,
         method_name: &str,
-        params: &T1,
+        params: &Params,
         files: Vec<(&str, PathBuf)>,
-    ) -> Result<T2, Self::Error> {
+    ) -> Result<Output, Self::Error>
+    where
+        Params: serde::ser::Serialize + std::fmt::Debug,
+        Output: serde::de::DeserializeOwned,
+    {
         if files.is_empty() {
             self.request(method_name, Some(params))
         } else {
@@ -1347,19 +1347,22 @@ pub trait TelegramApi {
         }
     }
 
-    fn request_with_form_data<
-        T1: serde::ser::Serialize + std::fmt::Debug,
-        T2: serde::de::DeserializeOwned,
-    >(
+    fn request_with_form_data<Params, Output>(
         &self,
         method: &str,
-        params: T1,
+        params: Params,
         files: Vec<(&str, PathBuf)>,
-    ) -> Result<T2, Self::Error>;
+    ) -> Result<Output, Self::Error>
+    where
+        Params: serde::ser::Serialize + std::fmt::Debug,
+        Output: serde::de::DeserializeOwned;
 
-    fn request<T1: serde::ser::Serialize + std::fmt::Debug, T2: serde::de::DeserializeOwned>(
+    fn request<Params, Output>(
         &self,
         method: &str,
-        params: Option<T1>,
-    ) -> Result<T2, Self::Error>;
+        params: Option<Params>,
+    ) -> Result<Output, Self::Error>
+    where
+        Params: serde::ser::Serialize + std::fmt::Debug,
+        Output: serde::de::DeserializeOwned;
 }


### PR DESCRIPTION
Generic names like T1 or T2 are quite useless to understand what their purpose / goal is. This is renaming them to something more speaking.

Also simplify some code in relation to generics and allow Rust to assume a bunch of them by itself.