### PR TITLE
refactor(json)!: generalize encoding/decoding

### DIFF
--- a/examples/async_reply_to_message_updates.rs
+++ b/examples/async_reply_to_message_updates.rs
@@ -42,14 +42,12 @@ async fn process_message(message: Message, api: AsyncApi) {
     let reply_parameters = ReplyParameters::builder()
         .message_id(message.message_id)
         .build();
-
     let send_message_params = SendMessageParams::builder()
         .chat_id(message.chat.id)
         .text("hello")
         .reply_parameters(reply_parameters)
         .build();
-
-    if let Err(err) = api.send_message(&send_message_params).await {
-        println!("Failed to send message: {err:?}");
+    if let Err(error) = api.send_message(&send_message_params).await {
+        println!("Failed to send message: {error:?}");
     }
 }

--- a/examples/reply_to_message_updates.rs
+++ b/examples/reply_to_message_updates.rs
@@ -23,15 +23,13 @@ fn main() {
                         let reply_parameters = ReplyParameters::builder()
                             .message_id(message.message_id)
                             .build();
-
                         let send_message_params = SendMessageParams::builder()
                             .chat_id(message.chat.id)
                             .text("hello")
                             .reply_parameters(reply_parameters)
                             .build();
-
-                        if let Err(err) = api.send_message(&send_message_params) {
-                            println!("Failed to send message: {err:?}");
+                        if let Err(error) = api.send_message(&send_message_params) {
+                            println!("Failed to send message: {error:?}");
                         }
                     }
                     update_params.offset = Some(i64::from(update.update_id) + 1);

--- a/src/api.rs
+++ b/src/api.rs
@@ -14,6 +14,7 @@ pub use telegram_api_impl::*;
 pub static BASE_API_URL: &str = "https://api.telegram.org/bot";
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, thiserror::Error)]
+#[non_exhaustive]
 #[serde(untagged)]
 pub enum Error {
     #[error("Http Error {code}: {message}")]

--- a/src/api/async_telegram_api_impl.rs
+++ b/src/api/async_telegram_api_impl.rs
@@ -30,13 +30,6 @@ impl AsyncApi {
         Self::builder().api_url(api_url).build()
     }
 
-    pub fn encode_params<Params>(params: &Params) -> Result<String, Error>
-    where
-        Params: serde::ser::Serialize + std::fmt::Debug,
-    {
-        serde_json::to_string(params).map_err(|err| Error::Encode(format!("{err:?} : {params:?}")))
-    }
-
     pub async fn decode_response<Output>(response: reqwest::Response) -> Result<Output, Error>
     where
         Output: serde::de::DeserializeOwned,
@@ -45,17 +38,13 @@ impl AsyncApi {
         match response.text().await {
             Ok(message) => {
                 if status_code == 200 {
-                    Ok(Self::parse_json(&message)?)
+                    Ok(crate::json::decode(&message)?)
                 } else {
-                    Err(Error::Api(Self::parse_json(&message)?))
+                    Err(Error::Api(crate::json::decode(&message)?))
                 }
             }
             Err(error) => Err(Error::Decode(format!("{error:?}"))),
         }
-    }
-
-    fn parse_json<Output: serde::de::DeserializeOwned>(body: &str) -> Result<Output, Error> {
-        serde_json::from_str(body).map_err(|error| Error::Decode(format!("{error:?} : {body:?}")))
     }
 }
 
@@ -88,7 +77,7 @@ impl AsyncTelegramApi for AsyncApi {
             .post(url)
             .header("Content-Type", "application/json");
         if let Some(params) = params {
-            let json_string = Self::encode_params(&params)?;
+            let json_string = crate::json::encode(&params)?;
             prepared_request = prepared_request.body(json_string);
         };
         let response = prepared_request.send().await?;
@@ -105,7 +94,7 @@ impl AsyncTelegramApi for AsyncApi {
         Params: serde::ser::Serialize + std::fmt::Debug + std::marker::Send,
         Output: serde::de::DeserializeOwned,
     {
-        let json_string = Self::encode_params(&params)?;
+        let json_string = crate::json::encode(&params)?;
         let json_struct: Value = serde_json::from_str(&json_string).unwrap();
         let file_keys: Vec<&str> = files.iter().map(|(key, _)| *key).collect();
         let files_with_paths: Vec<(String, &str, String)> = files

--- a/src/api/async_telegram_api_impl.rs
+++ b/src/api/async_telegram_api_impl.rs
@@ -34,7 +34,7 @@ impl AsyncApi {
     where
         Params: serde::ser::Serialize + std::fmt::Debug,
     {
-        serde_json::to_string(params).map_err(|e| Error::Encode(format!("{e:?} : {params:?}")))
+        serde_json::to_string(params).map_err(|err| Error::Encode(format!("{err:?} : {params:?}")))
     }
 
     pub async fn decode_response<Output>(response: reqwest::Response) -> Result<Output, Error>
@@ -50,12 +50,12 @@ impl AsyncApi {
                     Err(Error::Api(Self::parse_json(&message)?))
                 }
             }
-            Err(e) => Err(Error::Decode(format!("Failed to decode response: {e:?}"))),
+            Err(error) => Err(Error::Decode(format!("{error:?}"))),
         }
     }
 
     fn parse_json<Output: serde::de::DeserializeOwned>(body: &str) -> Result<Output, Error> {
-        serde_json::from_str(body).map_err(|e| Error::Decode(format!("{e:?} : {body:?}")))
+        serde_json::from_str(body).map_err(|error| Error::Decode(format!("{error:?} : {body:?}")))
     }
 }
 
@@ -134,7 +134,7 @@ impl AsyncTelegramApi for AsyncApi {
         for (parameter_name, file_path, file_name) in files_with_paths {
             let file = File::open(file_path)
                 .await
-                .map_err(|err| Error::Encode(err.to_string()))?;
+                .map_err(|error| Error::Encode(error.to_string()))?;
             let part = multipart::Part::stream(file).file_name(file_name);
             form = form.part(parameter_name, part);
         }

--- a/src/api/telegram_api_impl.rs
+++ b/src/api/telegram_api_impl.rs
@@ -31,7 +31,7 @@ impl Api {
     where
         Params: serde::ser::Serialize + std::fmt::Debug,
     {
-        serde_json::to_string(params).map_err(|e| Error::Encode(format!("{e:?} : {params:?}")))
+        serde_json::to_string(params).map_err(|err| Error::Encode(format!("{err:?} : {params:?}")))
     }
 
     pub fn decode_response<Output>(response: Response) -> Result<Output, Error>
@@ -41,7 +41,7 @@ impl Api {
         match response.into_string() {
             Ok(message) => serde_json::from_str(&message)
                 .map_err(|error| Error::Decode(format!("{error:?} : {message:?}"))),
-            Err(e) => Err(Error::Decode(format!("Failed to decode response: {e:?}"))),
+            Err(error) => Err(Error::Decode(format!("{error:?}"))),
         }
     }
 }

--- a/src/api/telegram_api_impl.rs
+++ b/src/api/telegram_api_impl.rs
@@ -32,8 +32,7 @@ impl Api {
         Output: serde::de::DeserializeOwned,
     {
         match response.into_string() {
-            Ok(message) => serde_json::from_str(&message)
-                .map_err(|error| Error::Decode(format!("{error:?} : {message:?}"))),
+            Ok(message) => crate::json::decode(&message),
             Err(error) => Err(Error::Decode(format!("{error:?}"))),
         }
     }

--- a/src/api/telegram_api_impl.rs
+++ b/src/api/telegram_api_impl.rs
@@ -27,13 +27,6 @@ impl Api {
         Self::builder().api_url(api_url).build()
     }
 
-    pub fn encode_params<Params>(params: &Params) -> Result<String, Error>
-    where
-        Params: serde::ser::Serialize + std::fmt::Debug,
-    {
-        serde_json::to_string(params).map_err(|err| Error::Encode(format!("{err:?} : {params:?}")))
-    }
-
     pub fn decode_response<Output>(response: Response) -> Result<Output, Error>
     where
         Output: serde::de::DeserializeOwned,
@@ -83,7 +76,7 @@ impl TelegramApi for Api {
         let response = match params {
             None => prepared_request.call()?,
             Some(data) => {
-                let json = Self::encode_params(&data)?;
+                let json = crate::json::encode(&data)?;
                 prepared_request.send_string(&json)?
             }
         };
@@ -100,7 +93,7 @@ impl TelegramApi for Api {
         Params: serde::ser::Serialize + std::fmt::Debug,
         Output: serde::de::DeserializeOwned,
     {
-        let json_string = Self::encode_params(&params)?;
+        let json_string = crate::json::encode(&params)?;
         let json_struct: Value = serde_json::from_str(&json_string).unwrap();
         let file_keys: Vec<&str> = files.iter().map(|(key, _)| *key).collect();
         let files_with_names: Vec<(&str, Option<&str>, PathBuf)> = files

--- a/src/json.rs
+++ b/src/json.rs
@@ -1,5 +1,6 @@
 use crate::Error;
 
+/// Shortcut for [`serde_json::from_str`] with [`crate::Error`].
 pub fn decode<T>(string: &str) -> Result<T, Error>
 where
     T: serde::de::DeserializeOwned,
@@ -7,6 +8,7 @@ where
     serde_json::from_str(string).map_err(|error| Error::Decode(format!("{error:?} : {string:?}")))
 }
 
+/// Shortcut for [`serde_json::to_string`] with [`crate::Error`].
 pub fn encode<T>(value: &T) -> Result<String, Error>
 where
     T: serde::ser::Serialize + std::fmt::Debug,

--- a/src/json.rs
+++ b/src/json.rs
@@ -1,0 +1,15 @@
+use crate::Error;
+
+pub fn decode<T>(string: &str) -> Result<T, Error>
+where
+    T: serde::de::DeserializeOwned,
+{
+    serde_json::from_str(string).map_err(|error| Error::Decode(format!("{error:?} : {string:?}")))
+}
+
+pub fn encode<T>(value: &T) -> Result<String, Error>
+where
+    T: serde::ser::Serialize + std::fmt::Debug,
+{
+    serde_json::to_string(value).map_err(|error| Error::Encode(format!("{error:?} : {value:?}")))
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,15 +1,3 @@
-#[cfg(any(feature = "http-client", feature = "async-http-client"))]
-pub mod api;
-
-#[cfg(any(feature = "telegram-trait", feature = "async-telegram-trait"))]
-pub mod api_traits;
-
-#[cfg(any(feature = "http-client", feature = "async-http-client"))]
-pub use api::*;
-
-#[cfg(any(feature = "telegram-trait", feature = "async-telegram-trait"))]
-pub use api_traits::*;
-
 #[doc(hidden)]
 #[cfg(feature = "async-http-client")]
 pub use reqwest;
@@ -18,10 +6,15 @@ pub use reqwest;
 #[cfg(feature = "http-client")]
 pub use ureq;
 
+pub mod api;
 pub mod api_params;
+pub mod api_traits;
+mod json;
 pub mod objects;
 mod parse_mode;
 
+pub use api::*;
 pub use api_params::*;
+pub use api_traits::*;
 pub use objects::*;
 pub use parse_mode::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@ pub use ureq;
 pub mod api;
 pub mod api_params;
 pub mod api_traits;
+#[cfg(feature = "serde_json")]
 mod json;
 pub mod objects;
 mod parse_mode;


### PR DESCRIPTION
BREAKING CHANGE: `(Async)Api::encode_params` is gone

Its was likely meant for internal use only anyway