### PR TITLE
docs: show the required feature on docs.rs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+
 #[doc(hidden)]
 #[cfg(feature = "async-http-client")]
 pub use reqwest;


### PR DESCRIPTION
see https://doc.rust-lang.org/rustdoc/unstable-features.html#doc_auto_cfg-automatically-generate-doccfg

While other projects seem to `--cfg docsrs` in the Cargo.toml this is likely not required (anymore?) as its documented as the way to [detect docs.rs](https://docs.rs/about/builds#detecting-docsrs)

Can be locally previewed:

```bash
RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc --all-features --no-deps --open
```