### PR TITLE
refactor!: simplify traits with macros

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,7 +76,7 @@ required-features = ["telegram-trait"]
 
 [dependencies]
 bon = "2.2.0"
-paste = "1"
+paste = "1.0.2"
 thiserror = "1"
 
 [dependencies.async-trait]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,8 +75,9 @@ name = "api_trait_implementation"
 required-features = ["telegram-trait"]
 
 [dependencies]
-thiserror = "1"
 bon = "2.2.0"
+paste = "1"
+thiserror = "1"
 
 [dependencies.async-trait]
 version = "0.1"

--- a/src/response.rs
+++ b/src/response.rs
@@ -36,7 +36,7 @@ pub struct ErrorResponse {
 
 #[derive(Debug, Serialize, Deserialize, PartialEq)]
 #[serde(untagged)]
-pub enum EditMessageResponse {
-    Message(MethodResponse<Message>),
-    Bool(MethodResponse<bool>),
+pub enum MessageOrBool {
+    Message(Message),
+    Bool(bool),
 }

--- a/src/trait_async.rs
+++ b/src/trait_async.rs
@@ -72,7 +72,8 @@ macro_rules! request_nb {
             async fn [<$name:snake>] (
                 &self,
             ) -> Result<MethodResponse<$return>, Self::Error> {
-                self.request_without_body(stringify!($name)).await
+                let params: Option<()> = None;
+                self.request(stringify!($name), params).await
             }
         }
     }
@@ -668,14 +669,6 @@ where
     request!(setChatMenuButton, bool);
     request!(getChatMenuButton, MenuButton);
     request!(unpinAllGeneralForumTopicMessages, bool);
-
-    async fn request_without_body<Output>(&self, method: &str) -> Result<Output, Self::Error>
-    where
-        Output: serde::de::DeserializeOwned,
-    {
-        let params: Option<()> = None;
-        self.request(method, params).await
-    }
 
     async fn request<Params, Output>(
         &self,

--- a/src/trait_async.rs
+++ b/src/trait_async.rs
@@ -462,7 +462,7 @@ pub trait AsyncTelegramApi {
 
     async fn send_paid_media(
         &self,
-        params: SendPaidMediaParams,
+        params: &SendPaidMediaParams,
     ) -> Result<MethodResponse<Message>, Self::Error> {
         self.request("sendPaidMedia", Some(params)).await
     }
@@ -811,35 +811,35 @@ pub trait AsyncTelegramApi {
 
     async fn edit_general_forum_topic(
         &self,
-        params: EditGeneralForumTopicParams,
+        params: &EditGeneralForumTopicParams,
     ) -> Result<MethodResponse<bool>, Self::Error> {
         self.request("editGeneralForumTopic", Some(params)).await
     }
 
     async fn close_general_forum_topic(
         &self,
-        params: CloseGeneralForumTopicParams,
+        params: &CloseGeneralForumTopicParams,
     ) -> Result<MethodResponse<bool>, Self::Error> {
         self.request("closeGeneralForumTopic", Some(params)).await
     }
 
     async fn reopen_general_forum_topic(
         &self,
-        params: ReopenGeneralForumTopicParams,
+        params: &ReopenGeneralForumTopicParams,
     ) -> Result<MethodResponse<bool>, Self::Error> {
         self.request("reopenGeneralForumTopic", Some(params)).await
     }
 
     async fn hide_general_forum_topic(
         &self,
-        params: HideGeneralForumTopicParams,
+        params: &HideGeneralForumTopicParams,
     ) -> Result<MethodResponse<bool>, Self::Error> {
         self.request("hideGeneralForumTopic", Some(params)).await
     }
 
     async fn unhide_general_forum_topic(
         &self,
-        params: UnhideGeneralForumTopicParams,
+        params: &UnhideGeneralForumTopicParams,
     ) -> Result<MethodResponse<bool>, Self::Error> {
         self.request("unhideGeneralForumTopic", Some(params)).await
     }
@@ -1308,7 +1308,7 @@ pub trait AsyncTelegramApi {
 
     async fn get_star_transactions(
         &self,
-        params: GetStarTransactionsParams,
+        params: &GetStarTransactionsParams,
     ) -> Result<MethodResponse<StarTransactions>, Self::Error> {
         self.request("getStarTransactions", Some(params)).await
     }
@@ -1366,21 +1366,21 @@ pub trait AsyncTelegramApi {
 
     async fn set_chat_menu_button(
         &self,
-        params: SetChatMenuButtonParams,
+        params: &SetChatMenuButtonParams,
     ) -> Result<MethodResponse<bool>, Self::Error> {
         self.request("setChatMenuButton", Some(params)).await
     }
 
     async fn get_chat_menu_button(
         &self,
-        params: GetChatMenuButtonParams,
+        params: &GetChatMenuButtonParams,
     ) -> Result<MethodResponse<MenuButton>, Self::Error> {
         self.request("getChatMenuButton", Some(params)).await
     }
 
     async fn unpin_all_general_forum_topic_messages(
         &self,
-        params: UnpinAllGeneralForumTopicMessagesParams,
+        params: &UnpinAllGeneralForumTopicMessagesParams,
     ) -> Result<MethodResponse<bool>, Self::Error> {
         self.request("unpinAllGeneralForumTopicMessages", Some(params))
             .await

--- a/src/trait_async.rs
+++ b/src/trait_async.rs
@@ -147,7 +147,7 @@ use crate::objects::User;
 use crate::objects::UserChatBoosts;
 use crate::objects::UserProfilePhotos;
 use crate::objects::WebhookInfo;
-use crate::response::{EditMessageResponse, MethodResponse};
+use crate::response::{MethodResponse, MessageOrBool};
 use async_trait::async_trait;
 use std::path::PathBuf;
 
@@ -477,14 +477,14 @@ pub trait AsyncTelegramApi {
     async fn edit_message_live_location(
         &self,
         params: &EditMessageLiveLocationParams,
-    ) -> Result<EditMessageResponse, Self::Error> {
+    ) -> Result<MethodResponse<MessageOrBool>, Self::Error> {
         self.request("editMessageLiveLocation", Some(params)).await
     }
 
     async fn stop_message_live_location(
         &self,
         params: &StopMessageLiveLocationParams,
-    ) -> Result<EditMessageResponse, Self::Error> {
+    ) -> Result<MethodResponse<MessageOrBool>, Self::Error> {
         self.request("stopMessageLiveLocation", Some(params)).await
     }
 
@@ -938,21 +938,21 @@ pub trait AsyncTelegramApi {
     async fn edit_message_text(
         &self,
         params: &EditMessageTextParams,
-    ) -> Result<EditMessageResponse, Self::Error> {
+    ) -> Result<MethodResponse<MessageOrBool>, Self::Error> {
         self.request("editMessageText", Some(params)).await
     }
 
     async fn edit_message_caption(
         &self,
         params: &EditMessageCaptionParams,
-    ) -> Result<EditMessageResponse, Self::Error> {
+    ) -> Result<MethodResponse<MessageOrBool>, Self::Error> {
         self.request("editMessageCaption", Some(params)).await
     }
 
     async fn edit_message_media(
         &self,
         params: &EditMessageMediaParams,
-    ) -> Result<EditMessageResponse, Self::Error> {
+    ) -> Result<MethodResponse<MessageOrBool>, Self::Error> {
         let method_name = "editMessageMedia";
         let mut files: Vec<(String, PathBuf)> = vec![];
 
@@ -1080,7 +1080,7 @@ pub trait AsyncTelegramApi {
     async fn edit_message_reply_markup(
         &self,
         params: &EditMessageReplyMarkupParams,
-    ) -> Result<EditMessageResponse, Self::Error> {
+    ) -> Result<MethodResponse<MessageOrBool>, Self::Error> {
         self.request("editMessageReplyMarkup", Some(params)).await
     }
 
@@ -1330,7 +1330,7 @@ pub trait AsyncTelegramApi {
     async fn set_game_score(
         &self,
         params: &SetGameScoreParams,
-    ) -> Result<EditMessageResponse, Self::Error> {
+    ) -> Result<MethodResponse<MessageOrBool>, Self::Error> {
         self.request("setGameScore", Some(params)).await
     }
 

--- a/src/trait_async.rs
+++ b/src/trait_async.rs
@@ -1,125 +1,20 @@
 use crate::api_params::AddStickerToSetParams;
-use crate::api_params::AnswerCallbackQueryParams;
-use crate::api_params::AnswerInlineQueryParams;
-use crate::api_params::AnswerPreCheckoutQueryParams;
-use crate::api_params::AnswerShippingQueryParams;
-use crate::api_params::AnswerWebAppQueryParams;
-use crate::api_params::ApproveChatJoinRequestParams;
-use crate::api_params::BanChatMemberParams;
-use crate::api_params::BanChatSenderChatParams;
-use crate::api_params::CloseForumTopicParams;
-use crate::api_params::CloseGeneralForumTopicParams;
-use crate::api_params::CopyMessageParams;
-use crate::api_params::CopyMessagesParams;
-use crate::api_params::CreateChatInviteLinkParams;
-use crate::api_params::CreateChatSubscriptionInviteLinkParams;
-use crate::api_params::CreateForumTopicParams;
-use crate::api_params::CreateInvoiceLinkParams;
 use crate::api_params::CreateNewStickerSetParams;
-use crate::api_params::DeclineChatJoinRequestParams;
-use crate::api_params::DeleteChatPhotoParams;
-use crate::api_params::DeleteChatStickerSetParams;
-use crate::api_params::DeleteForumTopicParams;
-use crate::api_params::DeleteMessageParams;
-use crate::api_params::DeleteMessagesParams;
-use crate::api_params::DeleteMyCommandsParams;
-use crate::api_params::DeleteStickerFromSetParams;
-use crate::api_params::DeleteStickerSetParams;
-use crate::api_params::DeleteWebhookParams;
-use crate::api_params::EditChatInviteLinkParams;
-use crate::api_params::EditChatSubscriptionInviteLinkParams;
-use crate::api_params::EditForumTopicParams;
-use crate::api_params::EditGeneralForumTopicParams;
-use crate::api_params::EditMessageCaptionParams;
-use crate::api_params::EditMessageLiveLocationParams;
 use crate::api_params::EditMessageMediaParams;
-use crate::api_params::EditMessageReplyMarkupParams;
-use crate::api_params::EditMessageTextParams;
-use crate::api_params::ExportChatInviteLinkParams;
 use crate::api_params::FileUpload;
-use crate::api_params::ForwardMessageParams;
-use crate::api_params::ForwardMessagesParams;
-use crate::api_params::GetBusinessConnectionParams;
-use crate::api_params::GetChatAdministratorsParams;
-use crate::api_params::GetChatMemberCountParams;
-use crate::api_params::GetChatMemberParams;
-use crate::api_params::GetChatMenuButtonParams;
-use crate::api_params::GetChatParams;
-use crate::api_params::GetCustomEmojiStickersParams;
-use crate::api_params::GetFileParams;
-use crate::api_params::GetGameHighScoresParams;
-use crate::api_params::GetMyCommandsParams;
-use crate::api_params::GetMyDefaultAdministratorRightsParams;
-use crate::api_params::GetMyDescriptionParams;
-use crate::api_params::GetMyNameParams;
-use crate::api_params::GetMyShortDescriptionParams;
-use crate::api_params::GetStarTransactionsParams;
-use crate::api_params::GetStickerSetParams;
-use crate::api_params::GetUpdatesParams;
-use crate::api_params::GetUserChatBoostsParams;
-use crate::api_params::GetUserProfilePhotosParams;
-use crate::api_params::HideGeneralForumTopicParams;
 use crate::api_params::InputMedia;
-use crate::api_params::LeaveChatParams;
 use crate::api_params::Media;
-use crate::api_params::PinChatMessageParams;
-use crate::api_params::PromoteChatMemberParams;
-use crate::api_params::RefundStarPaymentParams;
-use crate::api_params::ReopenForumTopicParams;
-use crate::api_params::ReopenGeneralForumTopicParams;
-use crate::api_params::ReplaceStickerInSetParams;
-use crate::api_params::RestrictChatMemberParams;
-use crate::api_params::RevokeChatInviteLinkParams;
 use crate::api_params::SendAnimationParams;
 use crate::api_params::SendAudioParams;
-use crate::api_params::SendChatActionParams;
-use crate::api_params::SendContactParams;
-use crate::api_params::SendDiceParams;
 use crate::api_params::SendDocumentParams;
-use crate::api_params::SendGameParams;
-use crate::api_params::SendInvoiceParams;
-use crate::api_params::SendLocationParams;
 use crate::api_params::SendMediaGroupParams;
-use crate::api_params::SendMessageParams;
-use crate::api_params::SendPaidMediaParams;
 use crate::api_params::SendPhotoParams;
-use crate::api_params::SendPollParams;
 use crate::api_params::SendStickerParams;
-use crate::api_params::SendVenueParams;
 use crate::api_params::SendVideoNoteParams;
 use crate::api_params::SendVideoParams;
 use crate::api_params::SendVoiceParams;
-use crate::api_params::SetChatAdministratorCustomTitleParams;
-use crate::api_params::SetChatDescriptionParams;
-use crate::api_params::SetChatMenuButtonParams;
-use crate::api_params::SetChatPermissionsParams;
 use crate::api_params::SetChatPhotoParams;
-use crate::api_params::SetChatStickerSetParams;
-use crate::api_params::SetChatTitleParams;
-use crate::api_params::SetCustomEmojiStickerSetThumbnailParams;
-use crate::api_params::SetGameScoreParams;
-use crate::api_params::SetMessageReactionParams;
-use crate::api_params::SetMyCommandsParams;
-use crate::api_params::SetMyDefaultAdministratorRightsParams;
-use crate::api_params::SetMyDescriptionParams;
-use crate::api_params::SetMyNameParams;
-use crate::api_params::SetMyShortDescriptionParams;
-use crate::api_params::SetStickerEmojiListParams;
-use crate::api_params::SetStickerKeywordsParams;
-use crate::api_params::SetStickerMaskPositionParams;
-use crate::api_params::SetStickerPositionInSetParams;
 use crate::api_params::SetStickerSetThumbnailParams;
-use crate::api_params::SetStickerSetTitleParams;
-use crate::api_params::SetWebhookParams;
-use crate::api_params::StopMessageLiveLocationParams;
-use crate::api_params::StopPollParams;
-use crate::api_params::UnbanChatMemberParams;
-use crate::api_params::UnbanChatSenderChatParams;
-use crate::api_params::UnhideGeneralForumTopicParams;
-use crate::api_params::UnpinAllChatMessagesParams;
-use crate::api_params::UnpinAllForumTopicMessagesParams;
-use crate::api_params::UnpinAllGeneralForumTopicMessagesParams;
-use crate::api_params::UnpinChatMessageParams;
 use crate::api_params::UploadStickerFileParams;
 use crate::objects::BotCommand;
 use crate::objects::BotDescription;
@@ -147,85 +42,61 @@ use crate::objects::User;
 use crate::objects::UserChatBoosts;
 use crate::objects::UserProfilePhotos;
 use crate::objects::WebhookInfo;
-use crate::response::{MethodResponse, MessageOrBool};
+use crate::response::{MessageOrBool, MethodResponse};
 use async_trait::async_trait;
 use std::path::PathBuf;
 
+macro_rules! request {
+    ($name:ident, $return:ty) => {
+        paste::paste! {
+            #[allow(async_fn_in_trait)]
+            #[doc = "Call the `" $name "` method.\n\nSee <https://core.telegram.org/bots/api#" $name:lower ">."]
+            #[inline(always)]
+            async fn [<$name:snake>] (
+                &self,
+                params: &crate::api_params::[<$name:camel Params>],
+            ) -> Result<MethodResponse<$return>, Self::Error> {
+                self.request(stringify!($name), Some(params)).await
+            }
+        }
+    }
+}
+
+/// request no body
+macro_rules! request_nb {
+    ($name:ident, $return:ty) => {
+        paste::paste! {
+            #[allow(async_fn_in_trait)]
+            #[doc = "Call the `" $name "` method.\n\nSee <https://core.telegram.org/bots/api#" $name:lower ">."]
+            #[inline(always)]
+            async fn [<$name:snake>] (
+                &self,
+            ) -> Result<MethodResponse<$return>, Self::Error> {
+                self.request_without_body(stringify!($name)).await
+            }
+        }
+    }
+}
+
 #[async_trait]
-pub trait AsyncTelegramApi {
+pub trait AsyncTelegramApi
+where
+    Self: Sync,
+{
     type Error;
 
-    async fn get_updates(
-        &self,
-        params: &GetUpdatesParams,
-    ) -> Result<MethodResponse<Vec<Update>>, Self::Error> {
-        self.request("getUpdates", Some(params)).await
-    }
-
-    async fn send_message(
-        &self,
-        params: &SendMessageParams,
-    ) -> Result<MethodResponse<Message>, Self::Error> {
-        self.request("sendMessage", Some(params)).await
-    }
-
-    async fn set_webhook(
-        &self,
-        params: &SetWebhookParams,
-    ) -> Result<MethodResponse<bool>, Self::Error> {
-        self.request("setWebhook", Some(params)).await
-    }
-
-    async fn delete_webhook(
-        &self,
-        params: &DeleteWebhookParams,
-    ) -> Result<MethodResponse<bool>, Self::Error> {
-        self.request("deleteWebhook", Some(params)).await
-    }
-
-    async fn get_webhook_info(&self) -> Result<MethodResponse<WebhookInfo>, Self::Error> {
-        self.request_without_body("getWebhookInfo").await
-    }
-
-    async fn get_me(&self) -> Result<MethodResponse<User>, Self::Error> {
-        self.request_without_body("getMe").await
-    }
-
-    async fn log_out(&self) -> Result<MethodResponse<bool>, Self::Error> {
-        self.request_without_body("logOut").await
-    }
-
-    async fn close(&self) -> Result<MethodResponse<bool>, Self::Error> {
-        self.request_without_body("close").await
-    }
-
-    async fn forward_message(
-        &self,
-        params: &ForwardMessageParams,
-    ) -> Result<MethodResponse<Message>, Self::Error> {
-        self.request("forwardMessage", Some(params)).await
-    }
-
-    async fn forward_messages(
-        &self,
-        params: &ForwardMessagesParams,
-    ) -> Result<MethodResponse<Vec<MessageId>>, Self::Error> {
-        self.request("forwardMessages", Some(params)).await
-    }
-
-    async fn copy_message(
-        &self,
-        params: &CopyMessageParams,
-    ) -> Result<MethodResponse<MessageId>, Self::Error> {
-        self.request("copyMessage", Some(params)).await
-    }
-
-    async fn copy_messages(
-        &self,
-        params: &CopyMessagesParams,
-    ) -> Result<MethodResponse<Vec<MessageId>>, Self::Error> {
-        self.request("copyMessages", Some(params)).await
-    }
+    request!(getUpdates, Vec<Update>);
+    request!(sendMessage, Message);
+    request!(setWebhook, bool);
+    request!(deleteWebhook, bool);
+    request_nb!(getWebhookInfo, WebhookInfo);
+    request_nb!(getMe, User);
+    request_nb!(logOut, bool);
+    request_nb!(close, bool);
+    request!(forwardMessage, Message);
+    request!(forwardMessages, Vec<MessageId>);
+    request!(copyMessage, MessageId);
+    request!(copyMessages, Vec<MessageId>);
 
     async fn send_photo(
         &self,
@@ -460,204 +331,34 @@ pub trait AsyncTelegramApi {
             .await
     }
 
-    async fn send_paid_media(
-        &self,
-        params: &SendPaidMediaParams,
-    ) -> Result<MethodResponse<Message>, Self::Error> {
-        self.request("sendPaidMedia", Some(params)).await
-    }
-
-    async fn send_location(
-        &self,
-        params: &SendLocationParams,
-    ) -> Result<MethodResponse<Message>, Self::Error> {
-        self.request("sendLocation", Some(params)).await
-    }
-
-    async fn edit_message_live_location(
-        &self,
-        params: &EditMessageLiveLocationParams,
-    ) -> Result<MethodResponse<MessageOrBool>, Self::Error> {
-        self.request("editMessageLiveLocation", Some(params)).await
-    }
-
-    async fn stop_message_live_location(
-        &self,
-        params: &StopMessageLiveLocationParams,
-    ) -> Result<MethodResponse<MessageOrBool>, Self::Error> {
-        self.request("stopMessageLiveLocation", Some(params)).await
-    }
-
-    async fn send_venue(
-        &self,
-        params: &SendVenueParams,
-    ) -> Result<MethodResponse<Message>, Self::Error> {
-        self.request("sendVenue", Some(params)).await
-    }
-
-    async fn send_contact(
-        &self,
-        params: &SendContactParams,
-    ) -> Result<MethodResponse<Message>, Self::Error> {
-        self.request("sendContact", Some(params)).await
-    }
-
-    async fn send_poll(
-        &self,
-        params: &SendPollParams,
-    ) -> Result<MethodResponse<Message>, Self::Error> {
-        self.request("sendPoll", Some(params)).await
-    }
-
-    async fn send_dice(
-        &self,
-        params: &SendDiceParams,
-    ) -> Result<MethodResponse<Message>, Self::Error> {
-        self.request("sendDice", Some(params)).await
-    }
-
-    async fn send_chat_action(
-        &self,
-        params: &SendChatActionParams,
-    ) -> Result<MethodResponse<bool>, Self::Error> {
-        self.request("sendChatAction", Some(params)).await
-    }
-
-    async fn set_message_reaction(
-        &self,
-        params: &SetMessageReactionParams,
-    ) -> Result<MethodResponse<bool>, Self::Error> {
-        self.request("setMessageReaction", Some(params)).await
-    }
-
-    async fn get_user_profile_photos(
-        &self,
-        params: &GetUserProfilePhotosParams,
-    ) -> Result<MethodResponse<UserProfilePhotos>, Self::Error> {
-        self.request("getUserProfilePhotos", Some(params)).await
-    }
-
-    async fn get_file(
-        &self,
-        params: &GetFileParams,
-    ) -> Result<MethodResponse<FileObject>, Self::Error> {
-        self.request("getFile", Some(params)).await
-    }
-
-    async fn ban_chat_member(
-        &self,
-        params: &BanChatMemberParams,
-    ) -> Result<MethodResponse<bool>, Self::Error> {
-        self.request("banChatMember", Some(params)).await
-    }
-
-    async fn unban_chat_member(
-        &self,
-        params: &UnbanChatMemberParams,
-    ) -> Result<MethodResponse<bool>, Self::Error> {
-        self.request("unbanChatMember", Some(params)).await
-    }
-
-    async fn restrict_chat_member(
-        &self,
-        params: &RestrictChatMemberParams,
-    ) -> Result<MethodResponse<bool>, Self::Error> {
-        self.request("restrictChatMember", Some(params)).await
-    }
-
-    async fn promote_chat_member(
-        &self,
-        params: &PromoteChatMemberParams,
-    ) -> Result<MethodResponse<bool>, Self::Error> {
-        self.request("promoteChatMember", Some(params)).await
-    }
-
-    async fn set_chat_administrator_custom_title(
-        &self,
-        params: &SetChatAdministratorCustomTitleParams,
-    ) -> Result<MethodResponse<bool>, Self::Error> {
-        self.request("setChatAdministratorCustomTitle", Some(params))
-            .await
-    }
-
-    async fn ban_chat_sender_chat(
-        &self,
-        params: &BanChatSenderChatParams,
-    ) -> Result<MethodResponse<bool>, Self::Error> {
-        self.request("banChatSenderChat", Some(params)).await
-    }
-
-    async fn unban_chat_sender_chat(
-        &self,
-        params: &UnbanChatSenderChatParams,
-    ) -> Result<MethodResponse<bool>, Self::Error> {
-        self.request("unbanChatSenderChat", Some(params)).await
-    }
-
-    async fn set_chat_permissions(
-        &self,
-        params: &SetChatPermissionsParams,
-    ) -> Result<MethodResponse<bool>, Self::Error> {
-        self.request("setChatPermissions", Some(params)).await
-    }
-
-    async fn export_chat_invite_link(
-        &self,
-        params: &ExportChatInviteLinkParams,
-    ) -> Result<MethodResponse<String>, Self::Error> {
-        self.request("exportChatInviteLink", Some(params)).await
-    }
-
-    async fn create_chat_invite_link(
-        &self,
-        params: &CreateChatInviteLinkParams,
-    ) -> Result<MethodResponse<ChatInviteLink>, Self::Error> {
-        self.request("createChatInviteLink", Some(params)).await
-    }
-
-    async fn edit_chat_invite_link(
-        &self,
-        params: &EditChatInviteLinkParams,
-    ) -> Result<MethodResponse<ChatInviteLink>, Self::Error> {
-        self.request("editChatInviteLink", Some(params)).await
-    }
-
-    async fn create_chat_subscription_invite_link(
-        &self,
-        params: &CreateChatSubscriptionInviteLinkParams,
-    ) -> Result<MethodResponse<ChatInviteLink>, Self::Error> {
-        self.request("createChatSubscriptionInviteLink", Some(params))
-            .await
-    }
-
-    async fn edit_chat_subscription_invite_link(
-        &self,
-        params: &EditChatSubscriptionInviteLinkParams,
-    ) -> Result<MethodResponse<ChatInviteLink>, Self::Error> {
-        self.request("editChatSubscriptionInviteLink", Some(params))
-            .await
-    }
-
-    async fn revoke_chat_invite_link(
-        &self,
-        params: &RevokeChatInviteLinkParams,
-    ) -> Result<MethodResponse<ChatInviteLink>, Self::Error> {
-        self.request("revokeChatInviteLink", Some(params)).await
-    }
-
-    async fn approve_chat_join_request(
-        &self,
-        params: &ApproveChatJoinRequestParams,
-    ) -> Result<MethodResponse<bool>, Self::Error> {
-        self.request("approveChatJoinRequest", Some(params)).await
-    }
-
-    async fn decline_chat_join_request(
-        &self,
-        params: &DeclineChatJoinRequestParams,
-    ) -> Result<MethodResponse<bool>, Self::Error> {
-        self.request("declineChatJoinRequest", Some(params)).await
-    }
+    request!(sendPaidMedia, Message);
+    request!(sendLocation, Message);
+    request!(editMessageLiveLocation, MessageOrBool);
+    request!(stopMessageLiveLocation, MessageOrBool);
+    request!(sendVenue, Message);
+    request!(sendContact, Message);
+    request!(sendPoll, Message);
+    request!(sendDice, Message);
+    request!(sendChatAction, bool);
+    request!(setMessageReaction, bool);
+    request!(getUserProfilePhotos, UserProfilePhotos);
+    request!(getFile, FileObject);
+    request!(banChatMember, bool);
+    request!(unbanChatMember, bool);
+    request!(restrictChatMember, bool);
+    request!(promoteChatMember, bool);
+    request!(setChatAdministratorCustomTitle, bool);
+    request!(banChatSenderChat, bool);
+    request!(unbanChatSenderChat, bool);
+    request!(setChatPermissions, bool);
+    request!(exportChatInviteLink, String);
+    request!(createChatInviteLink, ChatInviteLink);
+    request!(editChatInviteLink, ChatInviteLink);
+    request!(createChatSubscriptionInviteLink, ChatInviteLink);
+    request!(editChatSubscriptionInviteLink, ChatInviteLink);
+    request!(revokeChatInviteLink, ChatInviteLink);
+    request!(approveChatJoinRequest, bool);
+    request!(declineChatJoinRequest, bool);
 
     async fn set_chat_photo(
         &self,
@@ -669,285 +370,46 @@ pub trait AsyncTelegramApi {
             .await
     }
 
-    async fn delete_chat_photo(
-        &self,
-        params: &DeleteChatPhotoParams,
-    ) -> Result<MethodResponse<bool>, Self::Error> {
-        self.request("deleteChatPhoto", Some(params)).await
-    }
-
-    async fn set_chat_title(
-        &self,
-        params: &SetChatTitleParams,
-    ) -> Result<MethodResponse<bool>, Self::Error> {
-        self.request("setChatTitle", Some(params)).await
-    }
-
-    async fn set_chat_description(
-        &self,
-        params: &SetChatDescriptionParams,
-    ) -> Result<MethodResponse<bool>, Self::Error> {
-        self.request("setChatDescription", Some(params)).await
-    }
-
-    async fn pin_chat_message(
-        &self,
-        params: &PinChatMessageParams,
-    ) -> Result<MethodResponse<bool>, Self::Error> {
-        self.request("pinChatMessage", Some(params)).await
-    }
-
-    async fn unpin_chat_message(
-        &self,
-        params: &UnpinChatMessageParams,
-    ) -> Result<MethodResponse<bool>, Self::Error> {
-        self.request("unpinChatMessage", Some(params)).await
-    }
-
-    async fn unpin_all_chat_messages(
-        &self,
-        params: &UnpinAllChatMessagesParams,
-    ) -> Result<MethodResponse<bool>, Self::Error> {
-        self.request("unpinAllChatMessages", Some(params)).await
-    }
-
-    async fn leave_chat(
-        &self,
-        params: &LeaveChatParams,
-    ) -> Result<MethodResponse<bool>, Self::Error> {
-        self.request("leaveChat", Some(params)).await
-    }
-
-    async fn get_chat(
-        &self,
-        params: &GetChatParams,
-    ) -> Result<MethodResponse<ChatFullInfo>, Self::Error> {
-        self.request("getChat", Some(params)).await
-    }
-
-    async fn get_chat_administrators(
-        &self,
-        params: &GetChatAdministratorsParams,
-    ) -> Result<MethodResponse<Vec<ChatMember>>, Self::Error> {
-        self.request("getChatAdministrators", Some(params)).await
-    }
-
-    async fn get_chat_member_count(
-        &self,
-        params: &GetChatMemberCountParams,
-    ) -> Result<MethodResponse<u32>, Self::Error> {
-        self.request("getChatMemberCount", Some(params)).await
-    }
-
-    async fn get_chat_member(
-        &self,
-        params: &GetChatMemberParams,
-    ) -> Result<MethodResponse<ChatMember>, Self::Error> {
-        self.request("getChatMember", Some(params)).await
-    }
-
-    async fn set_chat_sticker_set(
-        &self,
-        params: &SetChatStickerSetParams,
-    ) -> Result<MethodResponse<bool>, Self::Error> {
-        self.request("setChatStickerSet", Some(params)).await
-    }
-
-    async fn delete_chat_sticker_set(
-        &self,
-        params: &DeleteChatStickerSetParams,
-    ) -> Result<MethodResponse<bool>, Self::Error> {
-        self.request("deleteChatStickerSet", Some(params)).await
-    }
-
-    async fn get_forum_topic_icon_stickers(
-        &self,
-    ) -> Result<MethodResponse<Vec<Sticker>>, Self::Error> {
-        self.request_without_body("getForumTopicIconStickers").await
-    }
-
-    async fn create_forum_topic(
-        &self,
-        params: &CreateForumTopicParams,
-    ) -> Result<MethodResponse<ForumTopic>, Self::Error> {
-        self.request("createForumTopic", Some(params)).await
-    }
-
-    async fn edit_forum_topic(
-        &self,
-        params: &EditForumTopicParams,
-    ) -> Result<MethodResponse<bool>, Self::Error> {
-        self.request("editForumTopic", Some(params)).await
-    }
-
-    async fn close_forum_topic(
-        &self,
-        params: &CloseForumTopicParams,
-    ) -> Result<MethodResponse<bool>, Self::Error> {
-        self.request("closeForumTopic", Some(params)).await
-    }
-
-    async fn reopen_forum_topic(
-        &self,
-        params: &ReopenForumTopicParams,
-    ) -> Result<MethodResponse<bool>, Self::Error> {
-        self.request("reopenForumTopic", Some(params)).await
-    }
-
-    async fn delete_forum_topic(
-        &self,
-        params: &DeleteForumTopicParams,
-    ) -> Result<MethodResponse<bool>, Self::Error> {
-        self.request("deleteForumTopic", Some(params)).await
-    }
-
-    async fn unpin_all_forum_topic_messages(
-        &self,
-        params: &UnpinAllForumTopicMessagesParams,
-    ) -> Result<MethodResponse<bool>, Self::Error> {
-        self.request("unpinAllForumTopicMessages", Some(params))
-            .await
-    }
-
-    async fn edit_general_forum_topic(
-        &self,
-        params: &EditGeneralForumTopicParams,
-    ) -> Result<MethodResponse<bool>, Self::Error> {
-        self.request("editGeneralForumTopic", Some(params)).await
-    }
-
-    async fn close_general_forum_topic(
-        &self,
-        params: &CloseGeneralForumTopicParams,
-    ) -> Result<MethodResponse<bool>, Self::Error> {
-        self.request("closeGeneralForumTopic", Some(params)).await
-    }
-
-    async fn reopen_general_forum_topic(
-        &self,
-        params: &ReopenGeneralForumTopicParams,
-    ) -> Result<MethodResponse<bool>, Self::Error> {
-        self.request("reopenGeneralForumTopic", Some(params)).await
-    }
-
-    async fn hide_general_forum_topic(
-        &self,
-        params: &HideGeneralForumTopicParams,
-    ) -> Result<MethodResponse<bool>, Self::Error> {
-        self.request("hideGeneralForumTopic", Some(params)).await
-    }
-
-    async fn unhide_general_forum_topic(
-        &self,
-        params: &UnhideGeneralForumTopicParams,
-    ) -> Result<MethodResponse<bool>, Self::Error> {
-        self.request("unhideGeneralForumTopic", Some(params)).await
-    }
-
-    async fn answer_callback_query(
-        &self,
-        params: &AnswerCallbackQueryParams,
-    ) -> Result<MethodResponse<bool>, Self::Error> {
-        self.request("answerCallbackQuery", Some(params)).await
-    }
-
-    async fn get_user_chat_boosts(
-        &self,
-        params: &GetUserChatBoostsParams,
-    ) -> Result<MethodResponse<UserChatBoosts>, Self::Error> {
-        self.request("getUserChatBoosts", Some(params)).await
-    }
-
-    async fn get_business_connection(
-        &self,
-        params: &GetBusinessConnectionParams,
-    ) -> Result<MethodResponse<BusinessConnection>, Self::Error> {
-        self.request("getBusinessConnection", Some(params)).await
-    }
-
-    async fn get_my_commands(
-        &self,
-        params: &GetMyCommandsParams,
-    ) -> Result<MethodResponse<Vec<BotCommand>>, Self::Error> {
-        self.request("getMyCommands", Some(params)).await
-    }
-
-    async fn set_my_commands(
-        &self,
-        params: &SetMyCommandsParams,
-    ) -> Result<MethodResponse<bool>, Self::Error> {
-        self.request("setMyCommands", Some(params)).await
-    }
-
-    async fn delete_my_commands(
-        &self,
-        params: &DeleteMyCommandsParams,
-    ) -> Result<MethodResponse<bool>, Self::Error> {
-        self.request("deleteMyCommands", Some(params)).await
-    }
-
-    async fn set_my_name(
-        &self,
-        params: &SetMyNameParams,
-    ) -> Result<MethodResponse<bool>, Self::Error> {
-        self.request("setMyName", Some(params)).await
-    }
-
-    async fn get_my_name(
-        &self,
-        params: &GetMyNameParams,
-    ) -> Result<MethodResponse<BotName>, Self::Error> {
-        self.request("getMyName", Some(params)).await
-    }
-
-    async fn set_my_description(
-        &self,
-        params: &SetMyDescriptionParams,
-    ) -> Result<MethodResponse<bool>, Self::Error> {
-        self.request("setMyDescription", Some(params)).await
-    }
-
-    async fn get_my_description(
-        &self,
-        params: &GetMyDescriptionParams,
-    ) -> Result<MethodResponse<BotDescription>, Self::Error> {
-        self.request("getMyDescription", Some(params)).await
-    }
-
-    async fn set_my_short_description(
-        &self,
-        params: &SetMyShortDescriptionParams,
-    ) -> Result<MethodResponse<bool>, Self::Error> {
-        self.request("setMyShortDescription", Some(params)).await
-    }
-
-    async fn get_my_short_description(
-        &self,
-        params: &GetMyShortDescriptionParams,
-    ) -> Result<MethodResponse<BotShortDescription>, Self::Error> {
-        self.request("getMyShortDescription", Some(params)).await
-    }
-
-    async fn answer_inline_query(
-        &self,
-        params: &AnswerInlineQueryParams,
-    ) -> Result<MethodResponse<bool>, Self::Error> {
-        self.request("answerInlineQuery", Some(params)).await
-    }
-
-    async fn edit_message_text(
-        &self,
-        params: &EditMessageTextParams,
-    ) -> Result<MethodResponse<MessageOrBool>, Self::Error> {
-        self.request("editMessageText", Some(params)).await
-    }
-
-    async fn edit_message_caption(
-        &self,
-        params: &EditMessageCaptionParams,
-    ) -> Result<MethodResponse<MessageOrBool>, Self::Error> {
-        self.request("editMessageCaption", Some(params)).await
-    }
+    request!(deleteChatPhoto, bool);
+    request!(setChatTitle, bool);
+    request!(setChatDescription, bool);
+    request!(pinChatMessage, bool);
+    request!(unpinChatMessage, bool);
+    request!(unpinAllChatMessages, bool);
+    request!(leaveChat, bool);
+    request!(getChat, ChatFullInfo);
+    request!(getChatAdministrators, Vec<ChatMember>);
+    request!(getChatMemberCount, u32);
+    request!(getChatMember, ChatMember);
+    request!(setChatStickerSet, bool);
+    request!(deleteChatStickerSet, bool);
+    request_nb!(getForumTopicIconStickers, Vec<Sticker>);
+    request!(createForumTopic, ForumTopic);
+    request!(editForumTopic, bool);
+    request!(closeForumTopic, bool);
+    request!(reopenForumTopic, bool);
+    request!(deleteForumTopic, bool);
+    request!(unpinAllForumTopicMessages, bool);
+    request!(editGeneralForumTopic, bool);
+    request!(closeGeneralForumTopic, bool);
+    request!(reopenGeneralForumTopic, bool);
+    request!(hideGeneralForumTopic, bool);
+    request!(unhideGeneralForumTopic, bool);
+    request!(answerCallbackQuery, bool);
+    request!(getUserChatBoosts, UserChatBoosts);
+    request!(getBusinessConnection, BusinessConnection);
+    request!(getMyCommands, Vec<BotCommand>);
+    request!(setMyCommands, bool);
+    request!(deleteMyCommands, bool);
+    request!(setMyName, bool);
+    request!(getMyName, BotName);
+    request!(setMyDescription, bool);
+    request!(getMyDescription, BotDescription);
+    request!(setMyShortDescription, bool);
+    request!(getMyShortDescription, BotShortDescription);
+    request!(answerInlineQuery, bool);
+    request!(editMessageText, MessageOrBool);
+    request!(editMessageCaption, MessageOrBool);
 
     async fn edit_message_media(
         &self,
@@ -1077,33 +539,10 @@ pub trait AsyncTelegramApi {
             .await
     }
 
-    async fn edit_message_reply_markup(
-        &self,
-        params: &EditMessageReplyMarkupParams,
-    ) -> Result<MethodResponse<MessageOrBool>, Self::Error> {
-        self.request("editMessageReplyMarkup", Some(params)).await
-    }
-
-    async fn stop_poll(
-        &self,
-        params: &StopPollParams,
-    ) -> Result<MethodResponse<Poll>, Self::Error> {
-        self.request("stopPoll", Some(params)).await
-    }
-
-    async fn delete_message(
-        &self,
-        params: &DeleteMessageParams,
-    ) -> Result<MethodResponse<bool>, Self::Error> {
-        self.request("deleteMessage", Some(params)).await
-    }
-
-    async fn delete_messages(
-        &self,
-        params: &DeleteMessagesParams,
-    ) -> Result<MethodResponse<bool>, Self::Error> {
-        self.request("deleteMessages", Some(params)).await
-    }
+    request!(editMessageReplyMarkup, MessageOrBool);
+    request!(stopPoll, Poll);
+    request!(deleteMessage, bool);
+    request!(deleteMessages, bool);
 
     async fn send_sticker(
         &self,
@@ -1120,12 +559,7 @@ pub trait AsyncTelegramApi {
             .await
     }
 
-    async fn get_sticker_set(
-        &self,
-        params: &GetStickerSetParams,
-    ) -> Result<MethodResponse<StickerSet>, Self::Error> {
-        self.request("getStickerSet", Some(params)).await
-    }
+    request!(getStickerSet, StickerSet);
 
     async fn upload_sticker_file(
         &self,
@@ -1178,12 +612,7 @@ pub trait AsyncTelegramApi {
             .await
     }
 
-    async fn get_custom_emoji_stickers(
-        &self,
-        params: &GetCustomEmojiStickersParams,
-    ) -> Result<MethodResponse<Vec<Sticker>>, Self::Error> {
-        self.request("getCustomEmojiStickers", Some(params)).await
-    }
+    request!(getCustomEmojiStickers, Vec<Sticker>);
     async fn add_sticker_to_set(
         &self,
         params: &AddStickerToSetParams,
@@ -1199,54 +628,13 @@ pub trait AsyncTelegramApi {
             .await
     }
 
-    async fn set_sticker_position_in_set(
-        &self,
-        params: &SetStickerPositionInSetParams,
-    ) -> Result<MethodResponse<bool>, Self::Error> {
-        self.request("setStickerPositionInSet", Some(params)).await
-    }
-
-    async fn replace_sticker_in_set(
-        &self,
-        params: &ReplaceStickerInSetParams,
-    ) -> Result<MethodResponse<bool>, Self::Error> {
-        self.request("replaceStickerInSet", Some(params)).await
-    }
-
-    async fn delete_sticker_from_set(
-        &self,
-        params: &DeleteStickerFromSetParams,
-    ) -> Result<MethodResponse<bool>, Self::Error> {
-        self.request("deleteStickerFromSet", Some(params)).await
-    }
-
-    async fn set_sticker_emoji_list(
-        &self,
-        params: &SetStickerEmojiListParams,
-    ) -> Result<MethodResponse<bool>, Self::Error> {
-        self.request("setStickerEmojiList", Some(params)).await
-    }
-
-    async fn set_sticker_keywords(
-        &self,
-        params: &SetStickerKeywordsParams,
-    ) -> Result<MethodResponse<bool>, Self::Error> {
-        self.request("setStickerKeywords", Some(params)).await
-    }
-
-    async fn set_sticker_mask_position(
-        &self,
-        params: &SetStickerMaskPositionParams,
-    ) -> Result<MethodResponse<bool>, Self::Error> {
-        self.request("setStickerMaskPosition", Some(params)).await
-    }
-
-    async fn set_sticker_set_title(
-        &self,
-        params: &SetStickerSetTitleParams,
-    ) -> Result<MethodResponse<bool>, Self::Error> {
-        self.request("setStickerSetTitle", Some(params)).await
-    }
+    request!(setStickerPositionInSet, bool);
+    request!(replaceStickerInSet, bool);
+    request!(deleteStickerFromSet, bool);
+    request!(setStickerEmojiList, bool);
+    request!(setStickerKeywords, bool);
+    request!(setStickerMaskPosition, bool);
+    request!(setStickerSetTitle, bool);
 
     async fn set_sticker_set_thumb(
         &self,
@@ -1263,128 +651,23 @@ pub trait AsyncTelegramApi {
             .await
     }
 
-    async fn set_custom_emoji_sticker_set_thumbnail(
-        &self,
-        params: &SetCustomEmojiStickerSetThumbnailParams,
-    ) -> Result<MethodResponse<bool>, Self::Error> {
-        self.request("setCustomEmojiStickerSetThumbnail", Some(params))
-            .await
-    }
-
-    async fn delete_sticker_set(
-        &self,
-        params: &DeleteStickerSetParams,
-    ) -> Result<MethodResponse<bool>, Self::Error> {
-        self.request("deleteStickerSet", Some(params)).await
-    }
-
-    async fn send_invoice(
-        &self,
-        params: &SendInvoiceParams,
-    ) -> Result<MethodResponse<Message>, Self::Error> {
-        self.request("sendInvoice", Some(params)).await
-    }
-
-    async fn create_invoice_link(
-        &self,
-        params: &CreateInvoiceLinkParams,
-    ) -> Result<MethodResponse<String>, Self::Error> {
-        self.request("createInvoiceLink", Some(params)).await
-    }
-
-    async fn answer_shipping_query(
-        &self,
-        params: &AnswerShippingQueryParams,
-    ) -> Result<MethodResponse<bool>, Self::Error> {
-        self.request("answerShippingQuery", Some(params)).await
-    }
-
-    async fn answer_pre_checkout_query(
-        &self,
-        params: &AnswerPreCheckoutQueryParams,
-    ) -> Result<MethodResponse<bool>, Self::Error> {
-        self.request("answerPreCheckoutQuery", Some(params)).await
-    }
-
-    async fn get_star_transactions(
-        &self,
-        params: &GetStarTransactionsParams,
-    ) -> Result<MethodResponse<StarTransactions>, Self::Error> {
-        self.request("getStarTransactions", Some(params)).await
-    }
-
-    async fn refund_star_payment(
-        &self,
-        params: &RefundStarPaymentParams,
-    ) -> Result<MethodResponse<bool>, Self::Error> {
-        self.request("refundStarPayment", Some(params)).await
-    }
-
-    async fn send_game(
-        &self,
-        params: &SendGameParams,
-    ) -> Result<MethodResponse<Message>, Self::Error> {
-        self.request("sendGame", Some(params)).await
-    }
-
-    async fn set_game_score(
-        &self,
-        params: &SetGameScoreParams,
-    ) -> Result<MethodResponse<MessageOrBool>, Self::Error> {
-        self.request("setGameScore", Some(params)).await
-    }
-
-    async fn get_game_high_scores(
-        &self,
-        params: &GetGameHighScoresParams,
-    ) -> Result<MethodResponse<Vec<GameHighScore>>, Self::Error> {
-        self.request("getGameHighScores", Some(params)).await
-    }
-
-    async fn set_my_default_administrator_rights(
-        &self,
-        params: &SetMyDefaultAdministratorRightsParams,
-    ) -> Result<MethodResponse<bool>, Self::Error> {
-        self.request("setMyDefaultAdministratorRights", Some(params))
-            .await
-    }
-
-    async fn get_my_default_administrator_rights(
-        &self,
-        params: &GetMyDefaultAdministratorRightsParams,
-    ) -> Result<MethodResponse<ChatAdministratorRights>, Self::Error> {
-        self.request("getMyDefaultAdministratorRights", Some(params))
-            .await
-    }
-
-    async fn answer_web_app_query(
-        &self,
-        params: &AnswerWebAppQueryParams,
-    ) -> Result<MethodResponse<SentWebAppMessage>, Self::Error> {
-        self.request("answerWebAppQuery", Some(params)).await
-    }
-
-    async fn set_chat_menu_button(
-        &self,
-        params: &SetChatMenuButtonParams,
-    ) -> Result<MethodResponse<bool>, Self::Error> {
-        self.request("setChatMenuButton", Some(params)).await
-    }
-
-    async fn get_chat_menu_button(
-        &self,
-        params: &GetChatMenuButtonParams,
-    ) -> Result<MethodResponse<MenuButton>, Self::Error> {
-        self.request("getChatMenuButton", Some(params)).await
-    }
-
-    async fn unpin_all_general_forum_topic_messages(
-        &self,
-        params: &UnpinAllGeneralForumTopicMessagesParams,
-    ) -> Result<MethodResponse<bool>, Self::Error> {
-        self.request("unpinAllGeneralForumTopicMessages", Some(params))
-            .await
-    }
+    request!(setCustomEmojiStickerSetThumbnail, bool);
+    request!(deleteStickerSet, bool);
+    request!(sendInvoice, Message);
+    request!(createInvoiceLink, String);
+    request!(answerShippingQuery, bool);
+    request!(answerPreCheckoutQuery, bool);
+    request!(getStarTransactions, StarTransactions);
+    request!(refundStarPayment, bool);
+    request!(sendGame, Message);
+    request!(setGameScore, MessageOrBool);
+    request!(getGameHighScores, Vec<GameHighScore>);
+    request!(setMyDefaultAdministratorRights, bool);
+    request!(getMyDefaultAdministratorRights, ChatAdministratorRights);
+    request!(answerWebAppQuery, SentWebAppMessage);
+    request!(setChatMenuButton, bool);
+    request!(getChatMenuButton, MenuButton);
+    request!(unpinAllGeneralForumTopicMessages, bool);
 
     async fn request_without_body<Output>(&self, method: &str) -> Result<Output, Self::Error>
     where

--- a/src/trait_sync.rs
+++ b/src/trait_sync.rs
@@ -147,7 +147,7 @@ use crate::objects::User;
 use crate::objects::UserChatBoosts;
 use crate::objects::UserProfilePhotos;
 use crate::objects::WebhookInfo;
-use crate::response::{EditMessageResponse, MethodResponse};
+use crate::response::{MessageOrBool, MethodResponse};
 use std::path::PathBuf;
 
 pub trait TelegramApi {
@@ -452,14 +452,14 @@ pub trait TelegramApi {
     fn edit_message_live_location(
         &self,
         params: &EditMessageLiveLocationParams,
-    ) -> Result<EditMessageResponse, Self::Error> {
+    ) -> Result<MethodResponse<MessageOrBool>, Self::Error> {
         self.request("editMessageLiveLocation", Some(params))
     }
 
     fn stop_message_live_location(
         &self,
         params: &StopMessageLiveLocationParams,
-    ) -> Result<EditMessageResponse, Self::Error> {
+    ) -> Result<MethodResponse<MessageOrBool>, Self::Error> {
         self.request("stopMessageLiveLocation", Some(params))
     }
 
@@ -888,21 +888,21 @@ pub trait TelegramApi {
     fn edit_message_text(
         &self,
         params: &EditMessageTextParams,
-    ) -> Result<EditMessageResponse, Self::Error> {
+    ) -> Result<MethodResponse<MessageOrBool>, Self::Error> {
         self.request("editMessageText", Some(params))
     }
 
     fn edit_message_caption(
         &self,
         params: &EditMessageCaptionParams,
-    ) -> Result<EditMessageResponse, Self::Error> {
+    ) -> Result<MethodResponse<MessageOrBool>, Self::Error> {
         self.request("editMessageCaption", Some(params))
     }
 
     fn edit_message_media(
         &self,
         params: &EditMessageMediaParams,
-    ) -> Result<EditMessageResponse, Self::Error> {
+    ) -> Result<MethodResponse<MessageOrBool>, Self::Error> {
         let method_name = "editMessageMedia";
         let mut files: Vec<(String, PathBuf)> = vec![];
 
@@ -1029,7 +1029,7 @@ pub trait TelegramApi {
     fn edit_message_reply_markup(
         &self,
         params: &EditMessageReplyMarkupParams,
-    ) -> Result<EditMessageResponse, Self::Error> {
+    ) -> Result<MethodResponse<MessageOrBool>, Self::Error> {
         self.request("editMessageReplyMarkup", Some(params))
     }
 
@@ -1268,7 +1268,7 @@ pub trait TelegramApi {
     fn set_game_score(
         &self,
         params: &SetGameScoreParams,
-    ) -> Result<EditMessageResponse, Self::Error> {
+    ) -> Result<MethodResponse<MessageOrBool>, Self::Error> {
         self.request("setGameScore", Some(params))
     }
 

--- a/src/trait_sync.rs
+++ b/src/trait_sync.rs
@@ -437,7 +437,7 @@ pub trait TelegramApi {
 
     fn send_paid_media(
         &self,
-        params: SendPaidMediaParams,
+        params: &SendPaidMediaParams,
     ) -> Result<MethodResponse<Message>, Self::Error> {
         self.request("sendPaidMedia", Some(params))
     }
@@ -1249,7 +1249,7 @@ pub trait TelegramApi {
 
     fn get_star_transactions(
         &self,
-        params: GetStarTransactionsParams,
+        params: &GetStarTransactionsParams,
     ) -> Result<MethodResponse<StarTransactions>, Self::Error> {
         self.request("getStarTransactions", Some(params))
     }
@@ -1302,21 +1302,21 @@ pub trait TelegramApi {
 
     fn set_chat_menu_button(
         &self,
-        params: SetChatMenuButtonParams,
+        params: &SetChatMenuButtonParams,
     ) -> Result<MethodResponse<bool>, Self::Error> {
         self.request("setChatMenuButton", Some(params))
     }
 
     fn get_chat_menu_button(
         &self,
-        params: GetChatMenuButtonParams,
+        params: &GetChatMenuButtonParams,
     ) -> Result<MethodResponse<MenuButton>, Self::Error> {
         self.request("getChatMenuButton", Some(params))
     }
 
     fn unpin_all_general_forum_topic_messages(
         &self,
-        params: UnpinAllGeneralForumTopicMessagesParams,
+        params: &UnpinAllGeneralForumTopicMessagesParams,
     ) -> Result<MethodResponse<bool>, Self::Error> {
         self.request("unpinAllGeneralForumTopicMessages", Some(params))
     }

--- a/src/trait_sync.rs
+++ b/src/trait_sync.rs
@@ -69,7 +69,8 @@ macro_rules! request_nb {
             fn [<$name:snake>] (
                 &self,
             ) -> Result<MethodResponse<$return>, Self::Error> {
-                self.request_without_body(stringify!($name))
+                let params: Option<()> = None;
+                self.request(stringify!($name), params)
             }
         }
     }
@@ -635,14 +636,6 @@ pub trait TelegramApi {
     request!(setChatMenuButton, bool);
     request!(getChatMenuButton, MenuButton);
     request!(unpinAllGeneralForumTopicMessages, bool);
-
-    fn request_without_body<Output>(&self, method: &str) -> Result<Output, Self::Error>
-    where
-        Output: serde::de::DeserializeOwned,
-    {
-        let params: Option<()> = None;
-        self.request(method, params)
-    }
 
     fn request_with_possible_form_data<Params, Output>(
         &self,

--- a/src/trait_sync.rs
+++ b/src/trait_sync.rs
@@ -1,125 +1,20 @@
 use crate::api_params::AddStickerToSetParams;
-use crate::api_params::AnswerCallbackQueryParams;
-use crate::api_params::AnswerInlineQueryParams;
-use crate::api_params::AnswerPreCheckoutQueryParams;
-use crate::api_params::AnswerShippingQueryParams;
-use crate::api_params::AnswerWebAppQueryParams;
-use crate::api_params::ApproveChatJoinRequestParams;
-use crate::api_params::BanChatMemberParams;
-use crate::api_params::BanChatSenderChatParams;
-use crate::api_params::CloseForumTopicParams;
-use crate::api_params::CloseGeneralForumTopicParams;
-use crate::api_params::CopyMessageParams;
-use crate::api_params::CopyMessagesParams;
-use crate::api_params::CreateChatInviteLinkParams;
-use crate::api_params::CreateChatSubscriptionInviteLinkParams;
-use crate::api_params::CreateForumTopicParams;
-use crate::api_params::CreateInvoiceLinkParams;
 use crate::api_params::CreateNewStickerSetParams;
-use crate::api_params::DeclineChatJoinRequestParams;
-use crate::api_params::DeleteChatPhotoParams;
-use crate::api_params::DeleteChatStickerSetParams;
-use crate::api_params::DeleteForumTopicParams;
-use crate::api_params::DeleteMessageParams;
-use crate::api_params::DeleteMessagesParams;
-use crate::api_params::DeleteMyCommandsParams;
-use crate::api_params::DeleteStickerFromSetParams;
-use crate::api_params::DeleteStickerSetParams;
-use crate::api_params::DeleteWebhookParams;
-use crate::api_params::EditChatInviteLinkParams;
-use crate::api_params::EditChatSubscriptionInviteLinkParams;
-use crate::api_params::EditForumTopicParams;
-use crate::api_params::EditGeneralForumTopicParams;
-use crate::api_params::EditMessageCaptionParams;
-use crate::api_params::EditMessageLiveLocationParams;
 use crate::api_params::EditMessageMediaParams;
-use crate::api_params::EditMessageReplyMarkupParams;
-use crate::api_params::EditMessageTextParams;
-use crate::api_params::ExportChatInviteLinkParams;
 use crate::api_params::FileUpload;
-use crate::api_params::ForwardMessageParams;
-use crate::api_params::ForwardMessagesParams;
-use crate::api_params::GetBusinessConnectionParams;
-use crate::api_params::GetChatAdministratorsParams;
-use crate::api_params::GetChatMemberCountParams;
-use crate::api_params::GetChatMemberParams;
-use crate::api_params::GetChatMenuButtonParams;
-use crate::api_params::GetChatParams;
-use crate::api_params::GetCustomEmojiStickersParams;
-use crate::api_params::GetFileParams;
-use crate::api_params::GetGameHighScoresParams;
-use crate::api_params::GetMyCommandsParams;
-use crate::api_params::GetMyDefaultAdministratorRightsParams;
-use crate::api_params::GetMyDescriptionParams;
-use crate::api_params::GetMyNameParams;
-use crate::api_params::GetMyShortDescriptionParams;
-use crate::api_params::GetStarTransactionsParams;
-use crate::api_params::GetStickerSetParams;
-use crate::api_params::GetUpdatesParams;
-use crate::api_params::GetUserChatBoostsParams;
-use crate::api_params::GetUserProfilePhotosParams;
-use crate::api_params::HideGeneralForumTopicParams;
 use crate::api_params::InputMedia;
-use crate::api_params::LeaveChatParams;
 use crate::api_params::Media;
-use crate::api_params::PinChatMessageParams;
-use crate::api_params::PromoteChatMemberParams;
-use crate::api_params::RefundStarPaymentParams;
-use crate::api_params::ReopenForumTopicParams;
-use crate::api_params::ReopenGeneralForumTopicParams;
-use crate::api_params::ReplaceStickerInSetParams;
-use crate::api_params::RestrictChatMemberParams;
-use crate::api_params::RevokeChatInviteLinkParams;
 use crate::api_params::SendAnimationParams;
 use crate::api_params::SendAudioParams;
-use crate::api_params::SendChatActionParams;
-use crate::api_params::SendContactParams;
-use crate::api_params::SendDiceParams;
 use crate::api_params::SendDocumentParams;
-use crate::api_params::SendGameParams;
-use crate::api_params::SendInvoiceParams;
-use crate::api_params::SendLocationParams;
 use crate::api_params::SendMediaGroupParams;
-use crate::api_params::SendMessageParams;
-use crate::api_params::SendPaidMediaParams;
 use crate::api_params::SendPhotoParams;
-use crate::api_params::SendPollParams;
 use crate::api_params::SendStickerParams;
-use crate::api_params::SendVenueParams;
 use crate::api_params::SendVideoNoteParams;
 use crate::api_params::SendVideoParams;
 use crate::api_params::SendVoiceParams;
-use crate::api_params::SetChatAdministratorCustomTitleParams;
-use crate::api_params::SetChatDescriptionParams;
-use crate::api_params::SetChatMenuButtonParams;
-use crate::api_params::SetChatPermissionsParams;
 use crate::api_params::SetChatPhotoParams;
-use crate::api_params::SetChatStickerSetParams;
-use crate::api_params::SetChatTitleParams;
-use crate::api_params::SetCustomEmojiStickerSetThumbnailParams;
-use crate::api_params::SetGameScoreParams;
-use crate::api_params::SetMessageReactionParams;
-use crate::api_params::SetMyCommandsParams;
-use crate::api_params::SetMyDefaultAdministratorRightsParams;
-use crate::api_params::SetMyDescriptionParams;
-use crate::api_params::SetMyNameParams;
-use crate::api_params::SetMyShortDescriptionParams;
-use crate::api_params::SetStickerEmojiListParams;
-use crate::api_params::SetStickerKeywordsParams;
-use crate::api_params::SetStickerMaskPositionParams;
-use crate::api_params::SetStickerPositionInSetParams;
 use crate::api_params::SetStickerSetThumbnailParams;
-use crate::api_params::SetStickerSetTitleParams;
-use crate::api_params::SetWebhookParams;
-use crate::api_params::StopMessageLiveLocationParams;
-use crate::api_params::StopPollParams;
-use crate::api_params::UnbanChatMemberParams;
-use crate::api_params::UnbanChatSenderChatParams;
-use crate::api_params::UnhideGeneralForumTopicParams;
-use crate::api_params::UnpinAllChatMessagesParams;
-use crate::api_params::UnpinAllForumTopicMessagesParams;
-use crate::api_params::UnpinAllGeneralForumTopicMessagesParams;
-use crate::api_params::UnpinChatMessageParams;
 use crate::api_params::UploadStickerFileParams;
 use crate::objects::BotCommand;
 use crate::objects::BotDescription;
@@ -150,77 +45,51 @@ use crate::objects::WebhookInfo;
 use crate::response::{MessageOrBool, MethodResponse};
 use std::path::PathBuf;
 
+macro_rules! request {
+    ($name:ident, $return:ty) => {
+        paste::paste! {
+            #[doc = "Call the `" $name "` method.\n\nSee <https://core.telegram.org/bots/api#" $name:lower ">."]
+            #[inline(always)]
+            fn [<$name:snake>] (
+                &self,
+                params: &crate::api_params::[<$name:camel Params>],
+            ) -> Result<MethodResponse<$return>, Self::Error> {
+                self.request(stringify!($name), Some(params))
+            }
+        }
+    }
+}
+
+/// request no body
+macro_rules! request_nb {
+    ($name:ident, $return:ty) => {
+        paste::paste! {
+            #[doc = "Call the `" $name "` method.\n\nSee <https://core.telegram.org/bots/api#" $name:lower ">."]
+            #[inline(always)]
+            fn [<$name:snake>] (
+                &self,
+            ) -> Result<MethodResponse<$return>, Self::Error> {
+                self.request_without_body(stringify!($name))
+            }
+        }
+    }
+}
+
 pub trait TelegramApi {
     type Error;
 
-    fn get_updates(
-        &self,
-        params: &GetUpdatesParams,
-    ) -> Result<MethodResponse<Vec<Update>>, Self::Error> {
-        self.request("getUpdates", Some(params))
-    }
-
-    fn send_message(
-        &self,
-        params: &SendMessageParams,
-    ) -> Result<MethodResponse<Message>, Self::Error> {
-        self.request("sendMessage", Some(params))
-    }
-
-    fn set_webhook(&self, params: &SetWebhookParams) -> Result<MethodResponse<bool>, Self::Error> {
-        self.request("setWebhook", Some(params))
-    }
-
-    fn delete_webhook(
-        &self,
-        params: &DeleteWebhookParams,
-    ) -> Result<MethodResponse<bool>, Self::Error> {
-        self.request("deleteWebhook", Some(params))
-    }
-
-    fn get_webhook_info(&self) -> Result<MethodResponse<WebhookInfo>, Self::Error> {
-        self.request_without_body("getWebhookInfo")
-    }
-
-    fn get_me(&self) -> Result<MethodResponse<User>, Self::Error> {
-        self.request_without_body("getMe")
-    }
-
-    fn log_out(&self) -> Result<MethodResponse<bool>, Self::Error> {
-        self.request_without_body("logOut")
-    }
-
-    fn close(&self) -> Result<MethodResponse<bool>, Self::Error> {
-        self.request_without_body("close")
-    }
-
-    fn forward_message(
-        &self,
-        params: &ForwardMessageParams,
-    ) -> Result<MethodResponse<Message>, Self::Error> {
-        self.request("forwardMessage", Some(params))
-    }
-
-    fn forward_messages(
-        &self,
-        params: &ForwardMessagesParams,
-    ) -> Result<MethodResponse<Vec<MessageId>>, Self::Error> {
-        self.request("forwardMessages", Some(params))
-    }
-
-    fn copy_message(
-        &self,
-        params: &CopyMessageParams,
-    ) -> Result<MethodResponse<MessageId>, Self::Error> {
-        self.request("copyMessage", Some(params))
-    }
-
-    fn copy_messages(
-        &self,
-        params: &CopyMessagesParams,
-    ) -> Result<MethodResponse<Vec<MessageId>>, Self::Error> {
-        self.request("copyMessages", Some(params))
-    }
+    request!(getUpdates, Vec<Update>);
+    request!(sendMessage, Message);
+    request!(setWebhook, bool);
+    request!(deleteWebhook, bool);
+    request_nb!(getWebhookInfo, WebhookInfo);
+    request_nb!(getMe, User);
+    request_nb!(logOut, bool);
+    request_nb!(close, bool);
+    request!(forwardMessage, Message);
+    request!(forwardMessages, Vec<MessageId>);
+    request!(copyMessage, MessageId);
+    request!(copyMessages, Vec<MessageId>);
 
     fn send_photo(&self, params: &SendPhotoParams) -> Result<MethodResponse<Message>, Self::Error> {
         let method_name = "sendPhoto";
@@ -435,189 +304,34 @@ pub trait TelegramApi {
         self.request_with_possible_form_data(method_name, params, files)
     }
 
-    fn send_paid_media(
-        &self,
-        params: &SendPaidMediaParams,
-    ) -> Result<MethodResponse<Message>, Self::Error> {
-        self.request("sendPaidMedia", Some(params))
-    }
-
-    fn send_location(
-        &self,
-        params: &SendLocationParams,
-    ) -> Result<MethodResponse<Message>, Self::Error> {
-        self.request("sendLocation", Some(params))
-    }
-
-    fn edit_message_live_location(
-        &self,
-        params: &EditMessageLiveLocationParams,
-    ) -> Result<MethodResponse<MessageOrBool>, Self::Error> {
-        self.request("editMessageLiveLocation", Some(params))
-    }
-
-    fn stop_message_live_location(
-        &self,
-        params: &StopMessageLiveLocationParams,
-    ) -> Result<MethodResponse<MessageOrBool>, Self::Error> {
-        self.request("stopMessageLiveLocation", Some(params))
-    }
-
-    fn send_venue(&self, params: &SendVenueParams) -> Result<MethodResponse<Message>, Self::Error> {
-        self.request("sendVenue", Some(params))
-    }
-
-    fn send_contact(
-        &self,
-        params: &SendContactParams,
-    ) -> Result<MethodResponse<Message>, Self::Error> {
-        self.request("sendContact", Some(params))
-    }
-
-    fn send_poll(&self, params: &SendPollParams) -> Result<MethodResponse<Message>, Self::Error> {
-        self.request("sendPoll", Some(params))
-    }
-
-    fn send_dice(&self, params: &SendDiceParams) -> Result<MethodResponse<Message>, Self::Error> {
-        self.request("sendDice", Some(params))
-    }
-
-    fn send_chat_action(
-        &self,
-        params: &SendChatActionParams,
-    ) -> Result<MethodResponse<bool>, Self::Error> {
-        self.request("sendChatAction", Some(params))
-    }
-
-    fn set_message_reaction(
-        &self,
-        params: &SetMessageReactionParams,
-    ) -> Result<MethodResponse<bool>, Self::Error> {
-        self.request("setMessageReaction", Some(params))
-    }
-
-    fn get_user_profile_photos(
-        &self,
-        params: &GetUserProfilePhotosParams,
-    ) -> Result<MethodResponse<UserProfilePhotos>, Self::Error> {
-        self.request("getUserProfilePhotos", Some(params))
-    }
-
-    fn get_file(&self, params: &GetFileParams) -> Result<MethodResponse<FileObject>, Self::Error> {
-        self.request("getFile", Some(params))
-    }
-
-    fn ban_chat_member(
-        &self,
-        params: &BanChatMemberParams,
-    ) -> Result<MethodResponse<bool>, Self::Error> {
-        self.request("banChatMember", Some(params))
-    }
-
-    fn unban_chat_member(
-        &self,
-        params: &UnbanChatMemberParams,
-    ) -> Result<MethodResponse<bool>, Self::Error> {
-        self.request("unbanChatMember", Some(params))
-    }
-
-    fn restrict_chat_member(
-        &self,
-        params: &RestrictChatMemberParams,
-    ) -> Result<MethodResponse<bool>, Self::Error> {
-        self.request("restrictChatMember", Some(params))
-    }
-
-    fn promote_chat_member(
-        &self,
-        params: &PromoteChatMemberParams,
-    ) -> Result<MethodResponse<bool>, Self::Error> {
-        self.request("promoteChatMember", Some(params))
-    }
-
-    fn set_chat_administrator_custom_title(
-        &self,
-        params: &SetChatAdministratorCustomTitleParams,
-    ) -> Result<MethodResponse<bool>, Self::Error> {
-        self.request("setChatAdministratorCustomTitle", Some(params))
-    }
-
-    fn ban_chat_sender_chat(
-        &self,
-        params: &BanChatSenderChatParams,
-    ) -> Result<MethodResponse<bool>, Self::Error> {
-        self.request("banChatSenderChat", Some(params))
-    }
-
-    fn unban_chat_sender_chat(
-        &self,
-        params: &UnbanChatSenderChatParams,
-    ) -> Result<MethodResponse<bool>, Self::Error> {
-        self.request("unbanChatSenderChat", Some(params))
-    }
-
-    fn set_chat_permissions(
-        &self,
-        params: &SetChatPermissionsParams,
-    ) -> Result<MethodResponse<bool>, Self::Error> {
-        self.request("setChatPermissions", Some(params))
-    }
-
-    fn export_chat_invite_link(
-        &self,
-        params: &ExportChatInviteLinkParams,
-    ) -> Result<MethodResponse<String>, Self::Error> {
-        self.request("exportChatInviteLink", Some(params))
-    }
-
-    fn create_chat_invite_link(
-        &self,
-        params: &CreateChatInviteLinkParams,
-    ) -> Result<MethodResponse<ChatInviteLink>, Self::Error> {
-        self.request("createChatInviteLink", Some(params))
-    }
-
-    fn edit_chat_invite_link(
-        &self,
-        params: &EditChatInviteLinkParams,
-    ) -> Result<MethodResponse<ChatInviteLink>, Self::Error> {
-        self.request("editChatInviteLink", Some(params))
-    }
-
-    fn create_chat_subscription_invite_link(
-        &self,
-        params: &CreateChatSubscriptionInviteLinkParams,
-    ) -> Result<MethodResponse<ChatInviteLink>, Self::Error> {
-        self.request("createChatSubscriptionInviteLink", Some(params))
-    }
-
-    fn edit_chat_subscription_invite_link(
-        &self,
-        params: &EditChatSubscriptionInviteLinkParams,
-    ) -> Result<MethodResponse<ChatInviteLink>, Self::Error> {
-        self.request("editChatSubscriptionInviteLink", Some(params))
-    }
-
-    fn revoke_chat_invite_link(
-        &self,
-        params: &RevokeChatInviteLinkParams,
-    ) -> Result<MethodResponse<ChatInviteLink>, Self::Error> {
-        self.request("revokeChatInviteLink", Some(params))
-    }
-
-    fn approve_chat_join_request(
-        &self,
-        params: &ApproveChatJoinRequestParams,
-    ) -> Result<MethodResponse<bool>, Self::Error> {
-        self.request("approveChatJoinRequest", Some(params))
-    }
-
-    fn decline_chat_join_request(
-        &self,
-        params: &DeclineChatJoinRequestParams,
-    ) -> Result<MethodResponse<bool>, Self::Error> {
-        self.request("declineChatJoinRequest", Some(params))
-    }
+    request!(sendPaidMedia, Message);
+    request!(sendLocation, Message);
+    request!(editMessageLiveLocation, MessageOrBool);
+    request!(stopMessageLiveLocation, MessageOrBool);
+    request!(sendVenue, Message);
+    request!(sendContact, Message);
+    request!(sendPoll, Message);
+    request!(sendDice, Message);
+    request!(sendChatAction, bool);
+    request!(setMessageReaction, bool);
+    request!(getUserProfilePhotos, UserProfilePhotos);
+    request!(getFile, FileObject);
+    request!(banChatMember, bool);
+    request!(unbanChatMember, bool);
+    request!(restrictChatMember, bool);
+    request!(promoteChatMember, bool);
+    request!(setChatAdministratorCustomTitle, bool);
+    request!(banChatSenderChat, bool);
+    request!(unbanChatSenderChat, bool);
+    request!(setChatPermissions, bool);
+    request!(exportChatInviteLink, String);
+    request!(createChatInviteLink, ChatInviteLink);
+    request!(editChatInviteLink, ChatInviteLink);
+    request!(createChatSubscriptionInviteLink, ChatInviteLink);
+    request!(editChatSubscriptionInviteLink, ChatInviteLink);
+    request!(revokeChatInviteLink, ChatInviteLink);
+    request!(approveChatJoinRequest, bool);
+    request!(declineChatJoinRequest, bool);
 
     fn set_chat_photo(
         &self,
@@ -628,276 +342,46 @@ pub trait TelegramApi {
         self.request_with_form_data("setChatPhoto", params, vec![("photo", photo.path.clone())])
     }
 
-    fn delete_chat_photo(
-        &self,
-        params: &DeleteChatPhotoParams,
-    ) -> Result<MethodResponse<bool>, Self::Error> {
-        self.request("deleteChatPhoto", Some(params))
-    }
-
-    fn set_chat_title(
-        &self,
-        params: &SetChatTitleParams,
-    ) -> Result<MethodResponse<bool>, Self::Error> {
-        self.request("setChatTitle", Some(params))
-    }
-
-    fn set_chat_description(
-        &self,
-        params: &SetChatDescriptionParams,
-    ) -> Result<MethodResponse<bool>, Self::Error> {
-        self.request("setChatDescription", Some(params))
-    }
-
-    fn pin_chat_message(
-        &self,
-        params: &PinChatMessageParams,
-    ) -> Result<MethodResponse<bool>, Self::Error> {
-        self.request("pinChatMessage", Some(params))
-    }
-
-    fn unpin_chat_message(
-        &self,
-        params: &UnpinChatMessageParams,
-    ) -> Result<MethodResponse<bool>, Self::Error> {
-        self.request("unpinChatMessage", Some(params))
-    }
-
-    fn unpin_all_chat_messages(
-        &self,
-        params: &UnpinAllChatMessagesParams,
-    ) -> Result<MethodResponse<bool>, Self::Error> {
-        self.request("unpinAllChatMessages", Some(params))
-    }
-
-    fn leave_chat(&self, params: &LeaveChatParams) -> Result<MethodResponse<bool>, Self::Error> {
-        self.request("leaveChat", Some(params))
-    }
-
-    fn get_chat(
-        &self,
-        params: &GetChatParams,
-    ) -> Result<MethodResponse<ChatFullInfo>, Self::Error> {
-        self.request("getChat", Some(params))
-    }
-
-    fn get_chat_administrators(
-        &self,
-        params: &GetChatAdministratorsParams,
-    ) -> Result<MethodResponse<Vec<ChatMember>>, Self::Error> {
-        self.request("getChatAdministrators", Some(params))
-    }
-
-    fn get_chat_member_count(
-        &self,
-        params: &GetChatMemberCountParams,
-    ) -> Result<MethodResponse<u32>, Self::Error> {
-        self.request("getChatMemberCount", Some(params))
-    }
-
-    fn get_chat_member(
-        &self,
-        params: &GetChatMemberParams,
-    ) -> Result<MethodResponse<ChatMember>, Self::Error> {
-        self.request("getChatMember", Some(params))
-    }
-
-    fn set_chat_sticker_set(
-        &self,
-        params: &SetChatStickerSetParams,
-    ) -> Result<MethodResponse<bool>, Self::Error> {
-        self.request("setChatStickerSet", Some(params))
-    }
-
-    fn delete_chat_sticker_set(
-        &self,
-        params: &DeleteChatStickerSetParams,
-    ) -> Result<MethodResponse<bool>, Self::Error> {
-        self.request("deleteChatStickerSet", Some(params))
-    }
-
-    fn get_forum_topic_icon_stickers(&self) -> Result<MethodResponse<Vec<Sticker>>, Self::Error> {
-        self.request_without_body("getForumTopicIconStickers")
-    }
-
-    fn create_forum_topic(
-        &self,
-        params: &CreateForumTopicParams,
-    ) -> Result<MethodResponse<ForumTopic>, Self::Error> {
-        self.request("createForumTopic", Some(params))
-    }
-
-    fn edit_forum_topic(
-        &self,
-        params: &EditForumTopicParams,
-    ) -> Result<MethodResponse<bool>, Self::Error> {
-        self.request("editForumTopic", Some(params))
-    }
-
-    fn close_forum_topic(
-        &self,
-        params: &CloseForumTopicParams,
-    ) -> Result<MethodResponse<bool>, Self::Error> {
-        self.request("closeForumTopic", Some(params))
-    }
-
-    fn reopen_forum_topic(
-        &self,
-        params: &ReopenForumTopicParams,
-    ) -> Result<MethodResponse<bool>, Self::Error> {
-        self.request("reopenForumTopic", Some(params))
-    }
-
-    fn delete_forum_topic(
-        &self,
-        params: &DeleteForumTopicParams,
-    ) -> Result<MethodResponse<bool>, Self::Error> {
-        self.request("deleteForumTopic", Some(params))
-    }
-
-    fn unpin_all_forum_topic_messages(
-        &self,
-        params: &UnpinAllForumTopicMessagesParams,
-    ) -> Result<MethodResponse<bool>, Self::Error> {
-        self.request("unpinAllForumTopicMessages", Some(params))
-    }
-
-    fn edit_general_forum_topic(
-        &self,
-        params: &EditGeneralForumTopicParams,
-    ) -> Result<MethodResponse<bool>, Self::Error> {
-        self.request("editGeneralForumTopic", Some(params))
-    }
-
-    fn close_general_forum_topic(
-        &self,
-        params: &CloseGeneralForumTopicParams,
-    ) -> Result<MethodResponse<bool>, Self::Error> {
-        self.request("closeGeneralForumTopic", Some(params))
-    }
-
-    fn reopen_general_forum_topic(
-        &self,
-        params: &ReopenGeneralForumTopicParams,
-    ) -> Result<MethodResponse<bool>, Self::Error> {
-        self.request("reopenGeneralForumTopic", Some(params))
-    }
-
-    fn hide_general_forum_topic(
-        &self,
-        params: &HideGeneralForumTopicParams,
-    ) -> Result<MethodResponse<bool>, Self::Error> {
-        self.request("hideGeneralForumTopic", Some(params))
-    }
-
-    fn unhide_general_forum_topic(
-        &self,
-        params: &UnhideGeneralForumTopicParams,
-    ) -> Result<MethodResponse<bool>, Self::Error> {
-        self.request("unhideGeneralForumTopic", Some(params))
-    }
-
-    fn answer_callback_query(
-        &self,
-        params: &AnswerCallbackQueryParams,
-    ) -> Result<MethodResponse<bool>, Self::Error> {
-        self.request("answerCallbackQuery", Some(params))
-    }
-
-    fn get_user_chat_boosts(
-        &self,
-        params: &GetUserChatBoostsParams,
-    ) -> Result<MethodResponse<UserChatBoosts>, Self::Error> {
-        self.request("getUserChatBoosts", Some(params))
-    }
-
-    fn get_business_connection(
-        &self,
-        params: &GetBusinessConnectionParams,
-    ) -> Result<MethodResponse<BusinessConnection>, Self::Error> {
-        self.request("getBusinessConnection", Some(params))
-    }
-
-    fn get_my_commands(
-        &self,
-        params: &GetMyCommandsParams,
-    ) -> Result<MethodResponse<Vec<BotCommand>>, Self::Error> {
-        self.request("getMyCommands", Some(params))
-    }
-
-    fn set_my_commands(
-        &self,
-        params: &SetMyCommandsParams,
-    ) -> Result<MethodResponse<bool>, Self::Error> {
-        self.request("setMyCommands", Some(params))
-    }
-
-    fn delete_my_commands(
-        &self,
-        params: &DeleteMyCommandsParams,
-    ) -> Result<MethodResponse<bool>, Self::Error> {
-        self.request("deleteMyCommands", Some(params))
-    }
-
-    fn set_my_name(&self, params: &SetMyNameParams) -> Result<MethodResponse<bool>, Self::Error> {
-        self.request("setMyName", Some(params))
-    }
-
-    fn get_my_name(
-        &self,
-        params: &GetMyNameParams,
-    ) -> Result<MethodResponse<BotName>, Self::Error> {
-        self.request("getMyName", Some(params))
-    }
-
-    fn set_my_description(
-        &self,
-        params: &SetMyDescriptionParams,
-    ) -> Result<MethodResponse<bool>, Self::Error> {
-        self.request("setMyDescription", Some(params))
-    }
-
-    fn get_my_description(
-        &self,
-        params: &GetMyDescriptionParams,
-    ) -> Result<MethodResponse<BotDescription>, Self::Error> {
-        self.request("getMyDescription", Some(params))
-    }
-
-    fn set_my_short_description(
-        &self,
-        params: &SetMyShortDescriptionParams,
-    ) -> Result<MethodResponse<bool>, Self::Error> {
-        self.request("setMyShortDescription", Some(params))
-    }
-
-    fn get_my_short_description(
-        &self,
-        params: &GetMyShortDescriptionParams,
-    ) -> Result<MethodResponse<BotShortDescription>, Self::Error> {
-        self.request("getMyShortDescription", Some(params))
-    }
-
-    fn answer_inline_query(
-        &self,
-        params: &AnswerInlineQueryParams,
-    ) -> Result<MethodResponse<bool>, Self::Error> {
-        self.request("answerInlineQuery", Some(params))
-    }
-
-    fn edit_message_text(
-        &self,
-        params: &EditMessageTextParams,
-    ) -> Result<MethodResponse<MessageOrBool>, Self::Error> {
-        self.request("editMessageText", Some(params))
-    }
-
-    fn edit_message_caption(
-        &self,
-        params: &EditMessageCaptionParams,
-    ) -> Result<MethodResponse<MessageOrBool>, Self::Error> {
-        self.request("editMessageCaption", Some(params))
-    }
+    request!(deleteChatPhoto, bool);
+    request!(setChatTitle, bool);
+    request!(setChatDescription, bool);
+    request!(pinChatMessage, bool);
+    request!(unpinChatMessage, bool);
+    request!(unpinAllChatMessages, bool);
+    request!(leaveChat, bool);
+    request!(getChat, ChatFullInfo);
+    request!(getChatAdministrators, Vec<ChatMember>);
+    request!(getChatMemberCount, u32);
+    request!(getChatMember, ChatMember);
+    request!(setChatStickerSet, bool);
+    request!(deleteChatStickerSet, bool);
+    request_nb!(getForumTopicIconStickers, Vec<Sticker>);
+    request!(createForumTopic, ForumTopic);
+    request!(editForumTopic, bool);
+    request!(closeForumTopic, bool);
+    request!(reopenForumTopic, bool);
+    request!(deleteForumTopic, bool);
+    request!(unpinAllForumTopicMessages, bool);
+    request!(editGeneralForumTopic, bool);
+    request!(closeGeneralForumTopic, bool);
+    request!(reopenGeneralForumTopic, bool);
+    request!(hideGeneralForumTopic, bool);
+    request!(unhideGeneralForumTopic, bool);
+    request!(answerCallbackQuery, bool);
+    request!(getUserChatBoosts, UserChatBoosts);
+    request!(getBusinessConnection, BusinessConnection);
+    request!(getMyCommands, Vec<BotCommand>);
+    request!(setMyCommands, bool);
+    request!(deleteMyCommands, bool);
+    request!(setMyName, bool);
+    request!(getMyName, BotName);
+    request!(setMyDescription, bool);
+    request!(getMyDescription, BotDescription);
+    request!(setMyShortDescription, bool);
+    request!(getMyShortDescription, BotShortDescription);
+    request!(answerInlineQuery, bool);
+    request!(editMessageText, MessageOrBool);
+    request!(editMessageCaption, MessageOrBool);
 
     fn edit_message_media(
         &self,
@@ -1026,30 +510,10 @@ pub trait TelegramApi {
         self.request_with_possible_form_data(method_name, &new_params, files_with_str_names)
     }
 
-    fn edit_message_reply_markup(
-        &self,
-        params: &EditMessageReplyMarkupParams,
-    ) -> Result<MethodResponse<MessageOrBool>, Self::Error> {
-        self.request("editMessageReplyMarkup", Some(params))
-    }
-
-    fn stop_poll(&self, params: &StopPollParams) -> Result<MethodResponse<Poll>, Self::Error> {
-        self.request("stopPoll", Some(params))
-    }
-
-    fn delete_message(
-        &self,
-        params: &DeleteMessageParams,
-    ) -> Result<MethodResponse<bool>, Self::Error> {
-        self.request("deleteMessage", Some(params))
-    }
-
-    fn delete_messages(
-        &self,
-        params: &DeleteMessagesParams,
-    ) -> Result<MethodResponse<bool>, Self::Error> {
-        self.request("deleteMessages", Some(params))
-    }
+    request!(editMessageReplyMarkup, MessageOrBool);
+    request!(stopPoll, Poll);
+    request!(deleteMessage, bool);
+    request!(deleteMessages, bool);
 
     fn send_sticker(
         &self,
@@ -1065,12 +529,7 @@ pub trait TelegramApi {
         self.request_with_possible_form_data(method_name, params, files)
     }
 
-    fn get_sticker_set(
-        &self,
-        params: &GetStickerSetParams,
-    ) -> Result<MethodResponse<StickerSet>, Self::Error> {
-        self.request("getStickerSet", Some(params))
-    }
+    request!(getStickerSet, StickerSet);
 
     fn upload_sticker_file(
         &self,
@@ -1121,12 +580,7 @@ pub trait TelegramApi {
         self.request_with_possible_form_data(method_name, &new_params, files_with_str_names)
     }
 
-    fn get_custom_emoji_stickers(
-        &self,
-        params: &GetCustomEmojiStickersParams,
-    ) -> Result<MethodResponse<Vec<Sticker>>, Self::Error> {
-        self.request("getCustomEmojiStickers", Some(params))
-    }
+    request!(getCustomEmojiStickers, Vec<Sticker>);
 
     fn add_sticker_to_set(
         &self,
@@ -1142,54 +596,13 @@ pub trait TelegramApi {
         self.request_with_possible_form_data(method_name, params, files)
     }
 
-    fn set_sticker_position_in_set(
-        &self,
-        params: &SetStickerPositionInSetParams,
-    ) -> Result<MethodResponse<bool>, Self::Error> {
-        self.request("setStickerPositionInSet", Some(params))
-    }
-
-    fn delete_sticker_from_set(
-        &self,
-        params: &DeleteStickerFromSetParams,
-    ) -> Result<MethodResponse<bool>, Self::Error> {
-        self.request("deleteStickerFromSet", Some(params))
-    }
-
-    fn replace_sticker_in_set(
-        &self,
-        params: &ReplaceStickerInSetParams,
-    ) -> Result<MethodResponse<bool>, Self::Error> {
-        self.request("replaceStickerInSet", Some(params))
-    }
-
-    fn set_sticker_emoji_list(
-        &self,
-        params: &SetStickerEmojiListParams,
-    ) -> Result<MethodResponse<bool>, Self::Error> {
-        self.request("setStickerEmojiList", Some(params))
-    }
-
-    fn set_sticker_keywords(
-        &self,
-        params: &SetStickerKeywordsParams,
-    ) -> Result<MethodResponse<bool>, Self::Error> {
-        self.request("setStickerKeywords", Some(params))
-    }
-
-    fn set_sticker_mask_position(
-        &self,
-        params: &SetStickerMaskPositionParams,
-    ) -> Result<MethodResponse<bool>, Self::Error> {
-        self.request("setStickerMaskPosition", Some(params))
-    }
-
-    fn set_sticker_set_title(
-        &self,
-        params: &SetStickerSetTitleParams,
-    ) -> Result<MethodResponse<bool>, Self::Error> {
-        self.request("setStickerSetTitle", Some(params))
-    }
+    request!(setStickerPositionInSet, bool);
+    request!(deleteStickerFromSet, bool);
+    request!(replaceStickerInSet, bool);
+    request!(setStickerEmojiList, bool);
+    request!(setStickerKeywords, bool);
+    request!(setStickerMaskPosition, bool);
+    request!(setStickerSetTitle, bool);
 
     fn set_sticker_set_thumbnail(
         &self,
@@ -1205,121 +618,23 @@ pub trait TelegramApi {
         self.request_with_possible_form_data(method_name, params, files)
     }
 
-    fn set_custom_emoji_sticker_set_thumbnail(
-        &self,
-        params: &SetCustomEmojiStickerSetThumbnailParams,
-    ) -> Result<MethodResponse<bool>, Self::Error> {
-        self.request("setCustomEmojiStickerSetThumbnail", Some(params))
-    }
-
-    fn delete_sticker_set(
-        &self,
-        params: &DeleteStickerSetParams,
-    ) -> Result<MethodResponse<bool>, Self::Error> {
-        self.request("deleteStickerSet", Some(params))
-    }
-
-    fn send_invoice(
-        &self,
-        params: &SendInvoiceParams,
-    ) -> Result<MethodResponse<Message>, Self::Error> {
-        self.request("sendInvoice", Some(params))
-    }
-
-    fn create_invoice_link(
-        &self,
-        params: &CreateInvoiceLinkParams,
-    ) -> Result<MethodResponse<String>, Self::Error> {
-        self.request("createInvoiceLink", Some(params))
-    }
-
-    fn answer_shipping_query(
-        &self,
-        params: &AnswerShippingQueryParams,
-    ) -> Result<MethodResponse<bool>, Self::Error> {
-        self.request("answerShippingQuery", Some(params))
-    }
-
-    fn answer_pre_checkout_query(
-        &self,
-        params: &AnswerPreCheckoutQueryParams,
-    ) -> Result<MethodResponse<bool>, Self::Error> {
-        self.request("answerPreCheckoutQuery", Some(params))
-    }
-
-    fn get_star_transactions(
-        &self,
-        params: &GetStarTransactionsParams,
-    ) -> Result<MethodResponse<StarTransactions>, Self::Error> {
-        self.request("getStarTransactions", Some(params))
-    }
-
-    fn refund_star_payment(
-        &self,
-        params: &RefundStarPaymentParams,
-    ) -> Result<MethodResponse<bool>, Self::Error> {
-        self.request("refundStarPayment", Some(params))
-    }
-
-    fn send_game(&self, params: &SendGameParams) -> Result<MethodResponse<Message>, Self::Error> {
-        self.request("sendGame", Some(params))
-    }
-
-    fn set_game_score(
-        &self,
-        params: &SetGameScoreParams,
-    ) -> Result<MethodResponse<MessageOrBool>, Self::Error> {
-        self.request("setGameScore", Some(params))
-    }
-
-    fn get_game_high_scores(
-        &self,
-        params: &GetGameHighScoresParams,
-    ) -> Result<MethodResponse<Vec<GameHighScore>>, Self::Error> {
-        self.request("getGameHighScores", Some(params))
-    }
-
-    fn set_my_default_administrator_rights(
-        &self,
-        params: &SetMyDefaultAdministratorRightsParams,
-    ) -> Result<MethodResponse<bool>, Self::Error> {
-        self.request("setMyDefaultAdministratorRights", Some(params))
-    }
-
-    fn get_my_default_administrator_rights(
-        &self,
-        params: &GetMyDefaultAdministratorRightsParams,
-    ) -> Result<MethodResponse<ChatAdministratorRights>, Self::Error> {
-        self.request("getMyDefaultAdministratorRights", Some(params))
-    }
-
-    fn answer_web_app_query(
-        &self,
-        params: &AnswerWebAppQueryParams,
-    ) -> Result<MethodResponse<SentWebAppMessage>, Self::Error> {
-        self.request("answerWebAppQuery", Some(params))
-    }
-
-    fn set_chat_menu_button(
-        &self,
-        params: &SetChatMenuButtonParams,
-    ) -> Result<MethodResponse<bool>, Self::Error> {
-        self.request("setChatMenuButton", Some(params))
-    }
-
-    fn get_chat_menu_button(
-        &self,
-        params: &GetChatMenuButtonParams,
-    ) -> Result<MethodResponse<MenuButton>, Self::Error> {
-        self.request("getChatMenuButton", Some(params))
-    }
-
-    fn unpin_all_general_forum_topic_messages(
-        &self,
-        params: &UnpinAllGeneralForumTopicMessagesParams,
-    ) -> Result<MethodResponse<bool>, Self::Error> {
-        self.request("unpinAllGeneralForumTopicMessages", Some(params))
-    }
+    request!(setCustomEmojiStickerSetThumbnail, bool);
+    request!(deleteStickerSet, bool);
+    request!(sendInvoice, Message);
+    request!(createInvoiceLink, String);
+    request!(answerShippingQuery, bool);
+    request!(answerPreCheckoutQuery, bool);
+    request!(getStarTransactions, StarTransactions);
+    request!(refundStarPayment, bool);
+    request!(sendGame, Message);
+    request!(setGameScore, MessageOrBool);
+    request!(getGameHighScores, Vec<GameHighScore>);
+    request!(setMyDefaultAdministratorRights, bool);
+    request!(getMyDefaultAdministratorRights, ChatAdministratorRights);
+    request!(answerWebAppQuery, SentWebAppMessage);
+    request!(setChatMenuButton, bool);
+    request!(getChatMenuButton, MenuButton);
+    request!(unpinAllGeneralForumTopicMessages, bool);
 
     fn request_without_body<Output>(&self, method: &str) -> Result<Output, Self::Error>
     where


### PR DESCRIPTION
Utilise macros to do the repetitive stuff.

This automatically adds doc comments with a link to the Telegram API of the given method.

BREAKING CHANGE: `request_without_body` method is gone. This was meant to be used internally and probably not used elsewhere.

BREAKING CHANGE: `AsyncTelegramApi` requires `Sync`.
This was likely the case already via `#[async_trait]` but wasn't explicitly specified.

