### PR TITLE
refactor!: use MessageOrBool over EditMessageResponse

### DIFF
--- a/src/response.rs
+++ b/src/response.rs
@@ -36,7 +36,7 @@ pub struct ErrorResponse {
 
 #[derive(Debug, Serialize, Deserialize, PartialEq)]
 #[serde(untagged)]
-pub enum EditMessageResponse {
-    Message(MethodResponse<Message>),
-    Bool(MethodResponse<bool>),
+pub enum MessageOrBool {
+    Message(Message),
+    Bool(bool),
 }

--- a/src/trait_async.rs
+++ b/src/trait_async.rs
@@ -147,7 +147,7 @@ use crate::objects::User;
 use crate::objects::UserChatBoosts;
 use crate::objects::UserProfilePhotos;
 use crate::objects::WebhookInfo;
-use crate::response::{EditMessageResponse, MethodResponse};
+use crate::response::{MethodResponse, MessageOrBool};
 use async_trait::async_trait;
 use std::path::PathBuf;
 
@@ -477,14 +477,14 @@ pub trait AsyncTelegramApi {
     async fn edit_message_live_location(
         &self,
         params: &EditMessageLiveLocationParams,
-    ) -> Result<EditMessageResponse, Self::Error> {
+    ) -> Result<MethodResponse<MessageOrBool>, Self::Error> {
         self.request("editMessageLiveLocation", Some(params)).await
     }
 
     async fn stop_message_live_location(
         &self,
         params: &StopMessageLiveLocationParams,
-    ) -> Result<EditMessageResponse, Self::Error> {
+    ) -> Result<MethodResponse<MessageOrBool>, Self::Error> {
         self.request("stopMessageLiveLocation", Some(params)).await
     }
 
@@ -938,21 +938,21 @@ pub trait AsyncTelegramApi {
     async fn edit_message_text(
         &self,
         params: &EditMessageTextParams,
-    ) -> Result<EditMessageResponse, Self::Error> {
+    ) -> Result<MethodResponse<MessageOrBool>, Self::Error> {
         self.request("editMessageText", Some(params)).await
     }
 
     async fn edit_message_caption(
         &self,
         params: &EditMessageCaptionParams,
-    ) -> Result<EditMessageResponse, Self::Error> {
+    ) -> Result<MethodResponse<MessageOrBool>, Self::Error> {
         self.request("editMessageCaption", Some(params)).await
     }
 
     async fn edit_message_media(
         &self,
         params: &EditMessageMediaParams,
-    ) -> Result<EditMessageResponse, Self::Error> {
+    ) -> Result<MethodResponse<MessageOrBool>, Self::Error> {
         let method_name = "editMessageMedia";
         let mut files: Vec<(String, PathBuf)> = vec![];
 
@@ -1080,7 +1080,7 @@ pub trait AsyncTelegramApi {
     async fn edit_message_reply_markup(
         &self,
         params: &EditMessageReplyMarkupParams,
-    ) -> Result<EditMessageResponse, Self::Error> {
+    ) -> Result<MethodResponse<MessageOrBool>, Self::Error> {
         self.request("editMessageReplyMarkup", Some(params)).await
     }
 
@@ -1330,7 +1330,7 @@ pub trait AsyncTelegramApi {
     async fn set_game_score(
         &self,
         params: &SetGameScoreParams,
-    ) -> Result<EditMessageResponse, Self::Error> {
+    ) -> Result<MethodResponse<MessageOrBool>, Self::Error> {
         self.request("setGameScore", Some(params)).await
     }
 

--- a/src/trait_async.rs
+++ b/src/trait_async.rs
@@ -147,7 +147,7 @@ use crate::objects::User;
 use crate::objects::UserChatBoosts;
 use crate::objects::UserProfilePhotos;
 use crate::objects::WebhookInfo;
-use crate::response::{MethodResponse, MessageOrBool};
+use crate::response::{MessageOrBool, MethodResponse};
 use async_trait::async_trait;
 use std::path::PathBuf;
 

--- a/src/trait_sync.rs
+++ b/src/trait_sync.rs
@@ -147,7 +147,7 @@ use crate::objects::User;
 use crate::objects::UserChatBoosts;
 use crate::objects::UserProfilePhotos;
 use crate::objects::WebhookInfo;
-use crate::response::{EditMessageResponse, MethodResponse};
+use crate::response::{MessageOrBool, MethodResponse};
 use std::path::PathBuf;
 
 pub trait TelegramApi {
@@ -452,14 +452,14 @@ pub trait TelegramApi {
     fn edit_message_live_location(
         &self,
         params: &EditMessageLiveLocationParams,
-    ) -> Result<EditMessageResponse, Self::Error> {
+    ) -> Result<MethodResponse<MessageOrBool>, Self::Error> {
         self.request("editMessageLiveLocation", Some(params))
     }
 
     fn stop_message_live_location(
         &self,
         params: &StopMessageLiveLocationParams,
-    ) -> Result<EditMessageResponse, Self::Error> {
+    ) -> Result<MethodResponse<MessageOrBool>, Self::Error> {
         self.request("stopMessageLiveLocation", Some(params))
     }
 
@@ -888,21 +888,21 @@ pub trait TelegramApi {
     fn edit_message_text(
         &self,
         params: &EditMessageTextParams,
-    ) -> Result<EditMessageResponse, Self::Error> {
+    ) -> Result<MethodResponse<MessageOrBool>, Self::Error> {
         self.request("editMessageText", Some(params))
     }
 
     fn edit_message_caption(
         &self,
         params: &EditMessageCaptionParams,
-    ) -> Result<EditMessageResponse, Self::Error> {
+    ) -> Result<MethodResponse<MessageOrBool>, Self::Error> {
         self.request("editMessageCaption", Some(params))
     }
 
     fn edit_message_media(
         &self,
         params: &EditMessageMediaParams,
-    ) -> Result<EditMessageResponse, Self::Error> {
+    ) -> Result<MethodResponse<MessageOrBool>, Self::Error> {
         let method_name = "editMessageMedia";
         let mut files: Vec<(String, PathBuf)> = vec![];
 
@@ -1029,7 +1029,7 @@ pub trait TelegramApi {
     fn edit_message_reply_markup(
         &self,
         params: &EditMessageReplyMarkupParams,
-    ) -> Result<EditMessageResponse, Self::Error> {
+    ) -> Result<MethodResponse<MessageOrBool>, Self::Error> {
         self.request("editMessageReplyMarkup", Some(params))
     }
 
@@ -1268,7 +1268,7 @@ pub trait TelegramApi {
     fn set_game_score(
         &self,
         params: &SetGameScoreParams,
-    ) -> Result<EditMessageResponse, Self::Error> {
+    ) -> Result<MethodResponse<MessageOrBool>, Self::Error> {
         self.request("setGameScore", Some(params))
     }
 


### PR DESCRIPTION
This results in all methods returning a `MessageResponse<T>` which is more consistent. (and allows for #210)

BREAKING CHANGE: EditMessageResponse is gone