### PR TITLE
Use consistent builder derive configs across API types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,6 +77,7 @@ required-features = ["telegram-trait"]
 [dependencies]
 thiserror = "1"
 bon = "2.2.0"
+macro_rules_attribute = "0.2"
 
 [dependencies.async-trait]
 version = "0.1"

--- a/src/api_params.rs
+++ b/src/api_params.rs
@@ -1,5 +1,6 @@
 //! Parameters to Telegram API methods.
 
+use crate::builder;
 use crate::objects::{
     AllowedUpdate, BotCommand, ChatAdministratorRights, ChatPermissions, ForceReply,
     InlineKeyboardMarkup, InlineQueryResultArticle, InlineQueryResultAudio,
@@ -18,7 +19,7 @@ use crate::objects::{
     WebAppInfo,
 };
 use crate::ParseMode;
-use bon::Builder;
+use macro_rules_attribute::apply;
 use serde::Deserialize;
 use serde::Serialize;
 use std::path::PathBuf;
@@ -198,31 +199,33 @@ pub enum BotCommandScope {
     ChatMember(BotCommandScopeChatMember),
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct BotCommandScopeChat {
-    #[builder(into)]
     pub chat_id: ChatId,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct BotCommandScopeChatAdministrators {
-    #[builder(into)]
     pub chat_id: ChatId,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct BotCommandScopeChatMember {
-    #[builder(into)]
     pub chat_id: ChatId,
     pub user_id: u64,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct InputFile {
     pub path: PathBuf,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct GetUpdatesParams {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub offset: Option<i64>,
@@ -237,16 +240,15 @@ pub struct GetUpdatesParams {
     pub allowed_updates: Option<Vec<AllowedUpdate>>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SetWebhookParams {
-    #[builder(into)]
     pub url: String,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub certificate: Option<InputFile>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub ip_address: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -259,29 +261,27 @@ pub struct SetWebhookParams {
     pub drop_pending_updates: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub secret_token: Option<String>,
 }
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 pub struct DeleteWebhookParams {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub drop_pending_updates: Option<bool>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SendMessageParams {
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub business_connection_id: Option<String>,
 
-    #[builder(into)]
     pub chat_id: ChatId,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub message_thread_id: Option<i32>,
 
-    #[builder(into)]
     pub text: String,
 
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -300,7 +300,6 @@ pub struct SendMessageParams {
     pub protect_content: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub message_effect_id: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -310,15 +309,14 @@ pub struct SendMessageParams {
     pub reply_markup: Option<ReplyMarkup>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ForwardMessageParams {
-    #[builder(into)]
     pub chat_id: ChatId,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub message_thread_id: Option<i32>,
 
-    #[builder(into)]
     pub from_chat_id: ChatId,
 
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -330,15 +328,14 @@ pub struct ForwardMessageParams {
     pub message_id: i32,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ForwardMessagesParams {
-    #[builder(into)]
     pub chat_id: ChatId,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub message_thread_id: Option<i32>,
 
-    #[builder(into)]
     pub from_chat_id: ChatId,
 
     pub message_ids: Vec<i32>,
@@ -350,21 +347,19 @@ pub struct ForwardMessagesParams {
     pub protect_content: Option<bool>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct CopyMessageParams {
-    #[builder(into)]
     pub chat_id: ChatId,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub message_thread_id: Option<i32>,
 
-    #[builder(into)]
     pub from_chat_id: ChatId,
 
     pub message_id: i32,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub caption: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -389,15 +384,14 @@ pub struct CopyMessageParams {
     pub reply_markup: Option<ReplyMarkup>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct CopyMessagesParams {
-    #[builder(into)]
     pub chat_id: ChatId,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub message_thread_id: Option<i32>,
 
-    #[builder(into)]
     pub from_chat_id: ChatId,
 
     pub message_ids: Vec<i32>,
@@ -412,23 +406,20 @@ pub struct CopyMessagesParams {
     pub remove_caption: Option<bool>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SendPhotoParams {
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub business_connection_id: Option<String>,
 
-    #[builder(into)]
     pub chat_id: ChatId,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub message_thread_id: Option<i32>,
 
-    #[builder(into)]
     pub photo: FileUpload,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub caption: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -450,7 +441,6 @@ pub struct SendPhotoParams {
     pub protect_content: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub message_effect_id: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -460,23 +450,20 @@ pub struct SendPhotoParams {
     pub reply_markup: Option<ReplyMarkup>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SendAudioParams {
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub business_connection_id: Option<String>,
 
-    #[builder(into)]
     pub chat_id: ChatId,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub message_thread_id: Option<i32>,
 
-    #[builder(into)]
     pub audio: FileUpload,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub caption: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -489,15 +476,12 @@ pub struct SendAudioParams {
     pub duration: Option<u32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub performer: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub title: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub thumbnail: Option<FileUpload>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -507,7 +491,6 @@ pub struct SendAudioParams {
     pub protect_content: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub message_effect_id: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -517,27 +500,23 @@ pub struct SendAudioParams {
     pub reply_markup: Option<ReplyMarkup>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SendDocumentParams {
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub business_connection_id: Option<String>,
 
-    #[builder(into)]
     pub chat_id: ChatId,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub message_thread_id: Option<i32>,
 
-    #[builder(into)]
     pub document: FileUpload,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub thumbnail: Option<FileUpload>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub caption: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -556,7 +535,6 @@ pub struct SendDocumentParams {
     pub protect_content: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub message_effect_id: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -566,19 +544,17 @@ pub struct SendDocumentParams {
     pub reply_markup: Option<ReplyMarkup>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SendVideoParams {
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub business_connection_id: Option<String>,
 
-    #[builder(into)]
     pub chat_id: ChatId,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub message_thread_id: Option<i32>,
 
-    #[builder(into)]
     pub video: FileUpload,
 
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -591,11 +567,9 @@ pub struct SendVideoParams {
     pub height: Option<u32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub thumbnail: Option<FileUpload>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub caption: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -620,7 +594,6 @@ pub struct SendVideoParams {
     pub protect_content: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub message_effect_id: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -630,19 +603,17 @@ pub struct SendVideoParams {
     pub reply_markup: Option<ReplyMarkup>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SendAnimationParams {
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub business_connection_id: Option<String>,
 
-    #[builder(into)]
     pub chat_id: ChatId,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub message_thread_id: Option<i32>,
 
-    #[builder(into)]
     pub animation: FileUpload,
 
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -655,11 +626,9 @@ pub struct SendAnimationParams {
     pub height: Option<u32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub thumbnail: Option<FileUpload>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub caption: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -681,7 +650,6 @@ pub struct SendAnimationParams {
     pub protect_content: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub message_effect_id: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -691,23 +659,20 @@ pub struct SendAnimationParams {
     pub reply_markup: Option<ReplyMarkup>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SendVoiceParams {
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub business_connection_id: Option<String>,
 
-    #[builder(into)]
     pub chat_id: ChatId,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub message_thread_id: Option<i32>,
 
-    #[builder(into)]
     pub voice: FileUpload,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub caption: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -726,7 +691,6 @@ pub struct SendVoiceParams {
     pub protect_content: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub message_effect_id: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -736,19 +700,17 @@ pub struct SendVoiceParams {
     pub reply_markup: Option<ReplyMarkup>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SendVideoNoteParams {
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub business_connection_id: Option<String>,
 
-    #[builder(into)]
     pub chat_id: ChatId,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub message_thread_id: Option<i32>,
 
-    #[builder(into)]
     pub video_note: FileUpload,
 
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -758,7 +720,6 @@ pub struct SendVideoNoteParams {
     pub length: Option<u32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub thumbnail: Option<FileUpload>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -768,7 +729,6 @@ pub struct SendVideoNoteParams {
     pub protect_content: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub message_effect_id: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -778,13 +738,12 @@ pub struct SendVideoNoteParams {
     pub reply_markup: Option<ReplyMarkup>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SendPaidMediaParams {
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub business_connection_id: Option<String>,
 
-    #[builder(into)]
     pub chat_id: ChatId,
 
     pub star_count: u32,
@@ -792,11 +751,9 @@ pub struct SendPaidMediaParams {
     pub media: Vec<InputPaidMedia>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub payload: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub caption: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -821,13 +778,12 @@ pub struct SendPaidMediaParams {
     pub reply_markup: Option<ReplyMarkup>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SendMediaGroupParams {
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub business_connection_id: Option<String>,
 
-    #[builder(into)]
     pub chat_id: ChatId,
 
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -839,7 +795,6 @@ pub struct SendMediaGroupParams {
     pub disable_notification: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub message_effect_id: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -849,13 +804,12 @@ pub struct SendMediaGroupParams {
     pub reply_parameters: Option<ReplyParameters>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct SendLocationParams {
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub business_connection_id: Option<String>,
 
-    #[builder(into)]
     pub chat_id: ChatId,
 
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -884,7 +838,6 @@ pub struct SendLocationParams {
     pub protect_content: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub message_effect_id: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -894,21 +847,19 @@ pub struct SendLocationParams {
     pub reply_markup: Option<ReplyMarkup>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct EditMessageLiveLocationParams {
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub business_connection_id: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub chat_id: Option<ChatId>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub message_id: Option<i32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub inline_message_id: Option<String>,
 
     pub latitude: f64,
@@ -931,34 +882,31 @@ pub struct EditMessageLiveLocationParams {
     pub reply_markup: Option<InlineKeyboardMarkup>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct StopMessageLiveLocationParams {
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub business_connection_id: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub chat_id: Option<ChatId>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub message_id: Option<i32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub inline_message_id: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub reply_markup: Option<InlineKeyboardMarkup>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct SendVenueParams {
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub business_connection_id: Option<String>,
 
-    #[builder(into)]
     pub chat_id: ChatId,
 
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -968,26 +916,20 @@ pub struct SendVenueParams {
 
     pub longitude: f64,
 
-    #[builder(into)]
     pub title: String,
 
-    #[builder(into)]
     pub address: String,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub foursquare_id: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub foursquare_type: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub google_place_id: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub google_place_type: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -997,7 +939,6 @@ pub struct SendVenueParams {
     pub protect_content: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub message_effect_id: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1007,30 +948,25 @@ pub struct SendVenueParams {
     pub reply_markup: Option<ReplyMarkup>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SendContactParams {
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub business_connection_id: Option<String>,
 
-    #[builder(into)]
     pub chat_id: ChatId,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub message_thread_id: Option<i32>,
 
-    #[builder(into)]
     pub phone_number: String,
 
-    #[builder(into)]
     pub first_name: String,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub last_name: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub vcard: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1040,7 +976,6 @@ pub struct SendContactParams {
     pub protect_content: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub message_effect_id: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1050,19 +985,17 @@ pub struct SendContactParams {
     pub reply_markup: Option<ReplyMarkup>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SendPollParams {
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub business_connection_id: Option<String>,
 
-    #[builder(into)]
     pub chat_id: ChatId,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub message_thread_id: Option<i32>,
 
-    #[builder(into)]
     pub question: String,
 
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1086,7 +1019,6 @@ pub struct SendPollParams {
     pub correct_option_id: Option<u8>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub explanation: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1111,7 +1043,6 @@ pub struct SendPollParams {
     pub protect_content: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub message_effect_id: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1121,20 +1052,18 @@ pub struct SendPollParams {
     pub reply_markup: Option<ReplyMarkup>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SendDiceParams {
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub business_connection_id: Option<String>,
 
-    #[builder(into)]
     pub chat_id: ChatId,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub message_thread_id: Option<i32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub emoji: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1144,7 +1073,6 @@ pub struct SendDiceParams {
     pub protect_content: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub message_effect_id: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1154,13 +1082,12 @@ pub struct SendDiceParams {
     pub reply_markup: Option<ReplyMarkup>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SendChatActionParams {
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub business_connection_id: Option<String>,
 
-    #[builder(into)]
     pub chat_id: ChatId,
 
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1169,9 +1096,9 @@ pub struct SendChatActionParams {
     pub action: ChatAction,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SetMessageReactionParams {
-    #[builder(into)]
     pub chat_id: ChatId,
 
     pub message_id: i32,
@@ -1182,7 +1109,8 @@ pub struct SetMessageReactionParams {
     pub is_big: Option<bool>,
 }
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 pub struct GetUserProfilePhotosParams {
     pub user_id: u64,
 
@@ -1193,15 +1121,15 @@ pub struct GetUserProfilePhotosParams {
     pub limit: Option<u32>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct GetFileParams {
-    #[builder(into)]
     pub file_id: String,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct BanChatMemberParams {
-    #[builder(into)]
     pub chat_id: ChatId,
 
     pub user_id: u64,
@@ -1213,9 +1141,9 @@ pub struct BanChatMemberParams {
     pub revoke_messages: Option<bool>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct UnbanChatMemberParams {
-    #[builder(into)]
     pub chat_id: ChatId,
 
     pub user_id: u64,
@@ -1224,9 +1152,9 @@ pub struct UnbanChatMemberParams {
     pub only_if_banned: Option<bool>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct RestrictChatMemberParams {
-    #[builder(into)]
     pub chat_id: ChatId,
 
     pub user_id: u64,
@@ -1240,9 +1168,9 @@ pub struct RestrictChatMemberParams {
     pub until_date: Option<u64>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct PromoteChatMemberParams {
-    #[builder(into)]
     pub chat_id: ChatId,
 
     pub user_id: u64,
@@ -1293,36 +1221,35 @@ pub struct PromoteChatMemberParams {
     pub can_manage_topics: Option<bool>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SetChatAdministratorCustomTitleParams {
-    #[builder(into)]
     pub chat_id: ChatId,
 
     pub user_id: u64,
 
-    #[builder(into)]
     pub custom_title: String,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct BanChatSenderChatParams {
-    #[builder(into)]
     pub chat_id: ChatId,
 
     pub sender_chat_id: i64,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct UnbanChatSenderChatParams {
-    #[builder(into)]
     pub chat_id: ChatId,
 
     pub sender_chat_id: i64,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SetChatPermissionsParams {
-    #[builder(into)]
     pub chat_id: ChatId,
 
     pub permissions: ChatPermissions,
@@ -1331,19 +1258,18 @@ pub struct SetChatPermissionsParams {
     pub use_independent_chat_permissions: Option<bool>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ExportChatInviteLinkParams {
-    #[builder(into)]
     pub chat_id: ChatId,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct CreateChatInviteLinkParams {
-    #[builder(into)]
     pub chat_id: ChatId,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub name: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1356,16 +1282,14 @@ pub struct CreateChatInviteLinkParams {
     pub creates_join_request: Option<bool>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct EditChatInviteLinkParams {
-    #[builder(into)]
     pub chat_id: ChatId,
 
-    #[builder(into)]
     pub invite_link: String,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub name: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1378,13 +1302,12 @@ pub struct EditChatInviteLinkParams {
     pub creates_join_request: Option<bool>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct CreateChatSubscriptionInviteLinkParams {
-    #[builder(into)]
     pub chat_id: ChatId,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub name: Option<String>,
 
     pub subscription_period: u32,
@@ -1392,84 +1315,78 @@ pub struct CreateChatSubscriptionInviteLinkParams {
     pub subscription_price: u16,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct EditChatSubscriptionInviteLinkParams {
-    #[builder(into)]
     pub chat_id: ChatId,
 
-    #[builder(into)]
     pub invite_link: String,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub name: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct RevokeChatInviteLinkParams {
-    #[builder(into)]
     pub chat_id: ChatId,
 
-    #[builder(into)]
     pub invite_link: String,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ApproveChatJoinRequestParams {
-    #[builder(into)]
     pub chat_id: ChatId,
 
     pub user_id: u64,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct DeclineChatJoinRequestParams {
-    #[builder(into)]
     pub chat_id: ChatId,
 
     pub user_id: u64,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SetChatPhotoParams {
-    #[builder(into)]
     pub chat_id: ChatId,
 
     pub photo: InputFile,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct DeleteChatPhotoParams {
-    #[builder(into)]
     pub chat_id: ChatId,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SetChatTitleParams {
-    #[builder(into)]
     pub chat_id: ChatId,
 
-    #[builder(into)]
     pub title: String,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SetChatDescriptionParams {
-    #[builder(into)]
     pub chat_id: ChatId,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub description: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct PinChatMessageParams {
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub business_connection_id: Option<String>,
 
-    #[builder(into)]
     pub chat_id: ChatId,
 
     pub message_id: i32,
@@ -1478,204 +1395,196 @@ pub struct PinChatMessageParams {
     pub disable_notification: Option<bool>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct UnpinChatMessageParams {
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub business_connection_id: Option<String>,
 
-    #[builder(into)]
     pub chat_id: ChatId,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub message_id: Option<i32>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct UnpinAllChatMessagesParams {
-    #[builder(into)]
     pub chat_id: ChatId,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct LeaveChatParams {
-    #[builder(into)]
     pub chat_id: ChatId,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct GetChatParams {
-    #[builder(into)]
     pub chat_id: ChatId,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct GetChatAdministratorsParams {
-    #[builder(into)]
     pub chat_id: ChatId,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct GetChatMemberCountParams {
-    #[builder(into)]
     pub chat_id: ChatId,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct GetChatMemberParams {
-    #[builder(into)]
     pub chat_id: ChatId,
 
     pub user_id: u64,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SetChatStickerSetParams {
-    #[builder(into)]
     pub chat_id: ChatId,
 
-    #[builder(into)]
     pub sticker_set_name: String,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct DeleteChatStickerSetParams {
-    #[builder(into)]
     pub chat_id: ChatId,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct CreateForumTopicParams {
-    #[builder(into)]
     pub chat_id: ChatId,
 
-    #[builder(into)]
     pub name: String,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub icon_color: Option<u32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub icon_custom_emoji_id: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct EditForumTopicParams {
-    #[builder(into)]
     pub chat_id: ChatId,
 
     pub message_thread_id: i32,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub name: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub icon_custom_emoji_id: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct CloseForumTopicParams {
-    #[builder(into)]
     pub chat_id: ChatId,
 
     pub message_thread_id: i32,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ReopenForumTopicParams {
-    #[builder(into)]
     pub chat_id: ChatId,
 
     pub message_thread_id: i32,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct DeleteForumTopicParams {
-    #[builder(into)]
     pub chat_id: ChatId,
 
     pub message_thread_id: i32,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct UnpinAllForumTopicMessagesParams {
-    #[builder(into)]
     pub chat_id: ChatId,
 
     pub message_thread_id: i32,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct EditGeneralForumTopicParams {
-    #[builder(into)]
     pub chat_id: ChatId,
 
-    #[builder(into)]
     pub name: String,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct CloseGeneralForumTopicParams {
-    #[builder(into)]
     pub chat_id: ChatId,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ReopenGeneralForumTopicParams {
-    #[builder(into)]
     pub chat_id: ChatId,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct HideGeneralForumTopicParams {
-    #[builder(into)]
     pub chat_id: ChatId,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct UnhideGeneralForumTopicParams {
-    #[builder(into)]
     pub chat_id: ChatId,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct AnswerCallbackQueryParams {
-    #[builder(into)]
     pub callback_query_id: String,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub text: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub show_alert: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub url: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cache_time: Option<u32>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct GetUserChatBoostsParams {
-    #[builder(into)]
     pub chat_id: ChatId,
 
     pub user_id: u64,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct GetBusinessConnectionParams {
-    #[builder(into)]
     pub business_connection_id: String,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SetMyCommandsParams {
     pub commands: Vec<BotCommand>,
 
@@ -1683,102 +1592,95 @@ pub struct SetMyCommandsParams {
     pub scope: Option<BotCommandScope>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub language_code: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SetMyNameParams {
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub name: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub language_code: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct GetMyNameParams {
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub language_code: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SetMyDescriptionParams {
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub description: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub language_code: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct GetMyDescriptionParams {
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub language_code: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SetMyShortDescriptionParams {
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub short_description: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub language_code: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct GetMyShortDescriptionParams {
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub language_code: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct GetMyCommandsParams {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub scope: Option<BotCommandScope>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub language_code: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct DeleteMyCommandsParams {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub scope: Option<BotCommandScope>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub language_code: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct EditMessageTextParams {
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub business_connection_id: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub chat_id: Option<ChatId>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub message_id: Option<i32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub inline_message_id: Option<String>,
 
-    #[builder(into)]
     pub text: String,
 
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1794,25 +1696,22 @@ pub struct EditMessageTextParams {
     pub reply_markup: Option<InlineKeyboardMarkup>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct EditMessageCaptionParams {
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub business_connection_id: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub chat_id: Option<ChatId>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub message_id: Option<i32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub inline_message_id: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub caption: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1828,21 +1727,19 @@ pub struct EditMessageCaptionParams {
     pub reply_markup: Option<InlineKeyboardMarkup>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct EditMessageMediaParams {
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub business_connection_id: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub chat_id: Option<ChatId>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub message_id: Option<i32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub inline_message_id: Option<String>,
 
     pub media: InputMedia,
@@ -1851,34 +1748,31 @@ pub struct EditMessageMediaParams {
     pub reply_markup: Option<InlineKeyboardMarkup>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct EditMessageReplyMarkupParams {
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub business_connection_id: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub chat_id: Option<ChatId>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub message_id: Option<i32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub inline_message_id: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub reply_markup: Option<InlineKeyboardMarkup>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct StopPollParams {
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub business_connection_id: Option<String>,
 
-    #[builder(into)]
     pub chat_id: ChatId,
 
     pub message_id: i32,
@@ -1887,39 +1781,36 @@ pub struct StopPollParams {
     pub reply_markup: Option<InlineKeyboardMarkup>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct DeleteMessageParams {
-    #[builder(into)]
     pub chat_id: ChatId,
 
     pub message_id: i32,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct DeleteMessagesParams {
-    #[builder(into)]
     pub chat_id: ChatId,
 
     pub message_ids: Vec<i32>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SendStickerParams {
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub business_connection_id: Option<String>,
 
-    #[builder(into)]
     pub chat_id: ChatId,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub message_thread_id: Option<i32>,
 
-    #[builder(into)]
     pub sticker: FileUpload,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub emoji: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1929,7 +1820,6 @@ pub struct SendStickerParams {
     pub protect_content: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub message_effect_id: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1939,13 +1829,14 @@ pub struct SendStickerParams {
     pub reply_markup: Option<ReplyMarkup>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct GetStickerSetParams {
-    #[builder(into)]
     pub name: String,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct UploadStickerFileParams {
     pub user_id: u64,
 
@@ -1954,14 +1845,13 @@ pub struct UploadStickerFileParams {
     pub sticker_format: StickerFormat,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct CreateNewStickerSetParams {
     pub user_id: u64,
 
-    #[builder(into)]
     pub name: String,
 
-    #[builder(into)]
     pub title: String,
 
     pub stickers: Vec<InputSticker>,
@@ -1973,116 +1863,113 @@ pub struct CreateNewStickerSetParams {
     pub needs_repainting: Option<bool>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct GetCustomEmojiStickersParams {
     pub custom_emoji_ids: Vec<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct AddStickerToSetParams {
     pub user_id: u64,
 
-    #[builder(into)]
     pub name: String,
 
     pub sticker: InputSticker,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SetStickerPositionInSetParams {
-    #[builder(into)]
     pub sticker: String,
 
     pub position: u32,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct DeleteStickerFromSetParams {
-    #[builder(into)]
     pub sticker: String,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct ReplaceStickerInSetParams {
     pub user_id: u64,
 
-    #[builder(into)]
     pub name: String,
 
-    #[builder(into)]
     pub old_sticker: String,
 
     pub sticker: InputSticker,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SetStickerEmojiListParams {
-    #[builder(into)]
     pub sticker: String,
 
     pub emoji_list: Vec<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SetStickerKeywordsParams {
-    #[builder(into)]
     pub sticker: String,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub keywords: Option<Vec<String>>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct SetStickerMaskPositionParams {
-    #[builder(into)]
     pub sticker: String,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub mask_position: Option<MaskPosition>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SetStickerSetTitleParams {
-    #[builder(into)]
     pub name: String,
 
-    #[builder(into)]
     pub title: String,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SetStickerSetThumbnailParams {
-    #[builder(into)]
     pub name: String,
 
     pub user_id: u64,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub thumbnail: Option<FileUpload>,
 
     pub format: StickerFormat,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SetCustomEmojiStickerSetThumbnailParams {
-    #[builder(into)]
     pub name: String,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub custom_emoji_id: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct DeleteStickerSetParams {
-    #[builder(into)]
     pub name: String,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct AnswerInlineQueryParams {
-    #[builder(into)]
     pub inline_query_id: String,
 
     pub results: Vec<InlineQueryResult>,
@@ -2094,48 +1981,41 @@ pub struct AnswerInlineQueryParams {
     pub is_personal: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub next_offset: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub button: Option<InlineQueryResultsButton>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct InlineQueryResultsButton {
-    #[builder(into)]
     pub text: String,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub web_app: Option<WebAppInfo>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub start_parameter: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SendInvoiceParams {
-    #[builder(into)]
     pub chat_id: ChatId,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub message_thread_id: Option<i32>,
 
-    #[builder(into)]
     pub title: String,
 
-    #[builder(into)]
     pub description: String,
 
-    #[builder(into)]
     pub payload: String,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub provider_token: Option<String>,
 
-    #[builder(into)]
     pub currency: String,
 
     pub prices: Vec<LabeledPrice>,
@@ -2147,15 +2027,12 @@ pub struct SendInvoiceParams {
     pub suggested_tip_amounts: Option<Vec<u32>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub start_parameter: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub provider_data: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub photo_url: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -2195,7 +2072,6 @@ pub struct SendInvoiceParams {
     pub protect_content: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub message_effect_id: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -2205,22 +2081,18 @@ pub struct SendInvoiceParams {
     pub reply_markup: Option<InlineKeyboardMarkup>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct CreateInvoiceLinkParams {
-    #[builder(into)]
     pub title: String,
 
-    #[builder(into)]
     pub description: String,
 
-    #[builder(into)]
     pub payload: String,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub provider_token: Option<String>,
 
-    #[builder(into)]
     pub currency: String,
 
     pub prices: Vec<LabeledPrice>,
@@ -2232,11 +2104,9 @@ pub struct CreateInvoiceLinkParams {
     pub suggested_tip_amounts: Option<Vec<u32>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub provider_data: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub photo_url: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -2270,9 +2140,9 @@ pub struct CreateInvoiceLinkParams {
     pub is_flexible: Option<bool>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct AnswerShippingQueryParams {
-    #[builder(into)]
     pub shipping_query_id: String,
 
     pub ok: bool,
@@ -2281,47 +2151,48 @@ pub struct AnswerShippingQueryParams {
     pub shipping_options: Option<Vec<ShippingOption>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub error_message: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct AnswerPreCheckoutQueryParams {
-    #[builder(into)]
     pub pre_checkout_query_id: String,
 
     pub ok: bool,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub error_message: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct GetStarTransactionsParams {
     offset: u32,
 
     limit: u32,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct RefundStarPaymentParams {
     pub user_id: u64,
 
     pub telegram_payment_charge_id: String,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SetPassportDataErrorsParams {
     pub user_id: u64,
 
     pub errors: Vec<PassportElementError>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SendGameParams {
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub business_connection_id: Option<String>,
 
     pub chat_id: i64,
@@ -2329,7 +2200,6 @@ pub struct SendGameParams {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub message_thread_id: Option<i32>,
 
-    #[builder(into)]
     pub game_short_name: String,
 
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -2339,7 +2209,6 @@ pub struct SendGameParams {
     pub protect_content: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub message_effect_id: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -2349,7 +2218,8 @@ pub struct SendGameParams {
     pub reply_markup: Option<InlineKeyboardMarkup>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SetGameScoreParams {
     pub user_id: u64,
 
@@ -2368,11 +2238,11 @@ pub struct SetGameScoreParams {
     pub message_id: Option<i32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub inline_message_id: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct GetGameHighScoresParams {
     pub user_id: u64,
 
@@ -2383,17 +2253,15 @@ pub struct GetGameHighScoresParams {
     pub message_id: Option<i32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub inline_message_id: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct InputMediaPhoto {
-    #[builder(into)]
     pub media: FileUpload,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub caption: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -2409,17 +2277,15 @@ pub struct InputMediaPhoto {
     pub has_spoiler: Option<bool>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct InputMediaVideo {
-    #[builder(into)]
     pub media: FileUpload,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub thumbnail: Option<FileUpload>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub caption: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -2447,17 +2313,15 @@ pub struct InputMediaVideo {
     pub has_spoiler: Option<bool>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct InputMediaAnimation {
-    #[builder(into)]
     pub media: FileUpload,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub thumbnail: Option<FileUpload>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub caption: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -2482,17 +2346,15 @@ pub struct InputMediaAnimation {
     pub has_spoiler: Option<bool>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct InputMediaAudio {
-    #[builder(into)]
     pub media: FileUpload,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub thumbnail: Option<FileUpload>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub caption: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -2505,25 +2367,21 @@ pub struct InputMediaAudio {
     pub duration: Option<u32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub performer: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub title: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct InputMediaDocument {
-    #[builder(into)]
     pub media: FileUpload,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub thumbnail: Option<FileUpload>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub caption: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -2536,7 +2394,8 @@ pub struct InputMediaDocument {
     pub disable_content_type_detection: Option<bool>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SetMyDefaultAdministratorRightsParams {
     pub rights: ChatAdministratorRights,
 
@@ -2544,20 +2403,22 @@ pub struct SetMyDefaultAdministratorRightsParams {
     pub for_channels: Option<bool>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct GetMyDefaultAdministratorRightsParams {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub for_channels: Option<bool>,
 }
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct AnswerWebAppQueryParams {
-    #[builder(into)]
     pub web_app_query_id: String,
 
     pub result: InlineQueryResult,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SetChatMenuButtonParams {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub chat_id: Option<i64>,
@@ -2566,31 +2427,31 @@ pub struct SetChatMenuButtonParams {
     pub menu_button: Option<MenuButton>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct GetChatMenuButtonParams {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub chat_id: Option<i64>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct UnpinAllGeneralForumTopicMessagesParams {
-    #[builder(into)]
     pub chat_id: ChatId,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ReplyParameters {
     pub message_id: i32,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub chat_id: Option<ChatId>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub allow_sending_without_reply: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub quote: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,3 +37,14 @@ mod trait_sync;
 
 /// Default Bot API URL
 pub const BASE_API_URL: &str = "https://api.telegram.org/bot";
+
+macro_rules_attribute::attribute_alias! {
+    #[apply(builder!)] =
+        #[derive(::bon::Builder)]
+        #[builder(
+            on(String, into),
+            on(ChatId, into),
+            on(FileUpload, into),
+            on(Box<_>, into),
+        )];
+}

--- a/src/objects.rs
+++ b/src/objects.rs
@@ -3,8 +3,9 @@
 #![allow(deprecated)]
 use crate::api_params::FileUpload;
 use crate::ParseMode;
-use bon::Builder;
 use serde::{Deserialize, Serialize};
+use crate::builder;
+use macro_rules_attribute::apply;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -188,26 +189,27 @@ pub enum BackgroundFill {
     FreeformGradient(BackgroundFillFreeformGradient),
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct MenuButtonWebApp {
-    #[builder(into)]
     pub text: String,
 
     pub web_app: WebAppInfo,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ChatMemberOwner {
     pub user: User,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub custom_title: Option<String>,
 
     pub is_anonymous: bool,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ChatMemberAdministrator {
     pub user: User,
 
@@ -251,11 +253,11 @@ pub struct ChatMemberAdministrator {
     pub can_manage_topics: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub custom_title: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ChatMemberMember {
     pub user: User,
 
@@ -263,7 +265,8 @@ pub struct ChatMemberMember {
     pub until_date: Option<u64>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ChatMemberRestricted {
     pub user: User,
 
@@ -300,43 +303,48 @@ pub struct ChatMemberRestricted {
     pub until_date: u64,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ChatMemberLeft {
     pub user: User,
 }
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ChatMemberBanned {
     pub user: User,
 
     pub until_date: u64,
 }
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 pub struct VideoChatStarted {}
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 pub struct VideoChatScheduled {
     pub start_date: u64,
 }
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 pub struct CallbackGame {}
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct BotDescription {
-    #[builder(into)]
     pub description: String,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct BotName {
-    #[builder(into)]
     pub name: String,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct BotShortDescription {
-    #[builder(into)]
     pub short_description: String,
 }
 
@@ -380,9 +388,9 @@ pub enum UpdateContent {
     PurchasedPaidMedia(PaidMediaPurchased),
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct WebhookInfo {
-    #[builder(into)]
     pub url: String,
 
     pub has_custom_certificate: bool,
@@ -390,14 +398,12 @@ pub struct WebhookInfo {
     pub pending_update_count: u32,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub ip_address: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub last_error_date: Option<u64>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub last_error_message: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -437,25 +443,22 @@ pub enum AllowedUpdate {
     RemovedChatBoost,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct User {
     pub id: u64,
 
     pub is_bot: bool,
 
-    #[builder(into)]
     pub first_name: String,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub last_name: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub username: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub language_code: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -480,7 +483,8 @@ pub struct User {
     pub has_main_web_app: Option<bool>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Chat {
     pub id: i64,
 
@@ -488,26 +492,23 @@ pub struct Chat {
     pub type_field: ChatType,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub title: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub username: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub first_name: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub last_name: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub is_forum: Option<bool>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct ChatFullInfo {
     pub id: i64,
 
@@ -515,19 +516,15 @@ pub struct ChatFullInfo {
     pub type_field: ChatType,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub title: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub username: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub first_name: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub last_name: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -552,7 +549,6 @@ pub struct ChatFullInfo {
     pub business_opening_hours: Option<BusinessOpeningHours>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub personal_chat: Option<Box<Chat>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -565,25 +561,21 @@ pub struct ChatFullInfo {
     pub max_reaction_count: Option<u16>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub background_custom_emoji_id: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub profile_accent_color_id: Option<u16>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub profile_background_custom_emoji_id: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub emoji_status_custom_emoji_id: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub emoji_status_expiration_date: Option<u32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub bio: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -599,15 +591,12 @@ pub struct ChatFullInfo {
     pub join_by_request: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub description: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub invite_link: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub pinned_message: Option<Box<Message>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -638,14 +627,12 @@ pub struct ChatFullInfo {
     pub has_visible_history: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub sticker_set_name: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub can_set_sticker_set: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub custom_emoji_sticker_set_name: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -655,7 +642,8 @@ pub struct ChatFullInfo {
     pub location: Option<ChatLocation>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct Message {
     pub message_id: i32,
 
@@ -663,31 +651,25 @@ pub struct Message {
     pub message_thread_id: Option<i32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub from: Option<Box<User>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub sender_chat: Option<Box<Chat>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub sender_boost_count: Option<u32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub sender_business_bot: Option<Box<User>>,
 
     pub date: u64,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub business_connection_id: Option<String>,
 
-    #[builder(into)]
     pub chat: Box<Chat>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub forward_origin: Option<Box<MessageOrigin>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -697,23 +679,18 @@ pub struct Message {
     pub is_automatic_forward: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub reply_to_message: Option<Box<Message>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub external_reply: Option<Box<ExternalReplyInfo>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub quote: Option<Box<TextQuote>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub reply_to_story: Option<Box<Story>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub via_bot: Option<Box<User>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -726,15 +703,12 @@ pub struct Message {
     pub is_from_offline: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub media_group_id: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub author_signature: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub text: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -744,50 +718,39 @@ pub struct Message {
     pub link_preview_options: Option<LinkPreviewOptions>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub effect_id: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub animation: Option<Box<Animation>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub audio: Option<Box<Audio>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub document: Option<Box<Document>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub paid_media: Option<Box<PaidMediaInfo>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub photo: Option<Vec<PhotoSize>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub sticker: Option<Box<Sticker>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub story: Option<Box<Story>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub video: Option<Box<Video>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub video_note: Option<Box<VideoNote>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub voice: Option<Box<Voice>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub caption: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -800,38 +763,30 @@ pub struct Message {
     pub has_media_spoiler: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub contact: Option<Box<Contact>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub dice: Option<Box<Dice>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub game: Option<Box<Game>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub poll: Option<Box<Poll>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub venue: Option<Box<Venue>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub location: Option<Box<Location>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub new_chat_members: Option<Vec<User>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub left_chat_member: Option<Box<User>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub new_chat_title: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -850,7 +805,6 @@ pub struct Message {
     pub channel_chat_created: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub message_auto_delete_timer_changed: Option<Box<MessageAutoDeleteTimerChanged>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -860,74 +814,57 @@ pub struct Message {
     pub migrate_from_chat_id: Option<i64>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub pinned_message: Option<Box<MaybeInaccessibleMessage>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub invoice: Option<Box<Invoice>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub successful_payment: Option<Box<SuccessfulPayment>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub refunded_payment: Option<Box<RefundedPayment>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub users_shared: Option<Box<UsersShared>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub chat_shared: Option<Box<ChatShared>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub connected_website: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub write_access_allowed: Option<WriteAccessAllowed>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub passport_data: Option<Box<PassportData>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub proximity_alert_triggered: Option<Box<ProximityAlertTriggered>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub boost_added: Option<Box<ChatBoostAdded>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub chat_background_set: Option<Box<ChatBackground>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub forum_topic_created: Option<Box<ForumTopicCreated>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub forum_topic_edited: Option<Box<ForumTopicEdited>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub forum_topic_closed: Option<Box<ForumTopicClosed>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub forum_topic_reopened: Option<Box<ForumTopicReopened>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub general_forum_topic_hidden: Option<Box<GeneralForumTopicHidden>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub general_forum_topic_unhidden: Option<Box<GeneralForumTopicUnhidden>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -943,36 +880,32 @@ pub struct Message {
     pub giveaway_completed: Option<GiveawayCompleted>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub video_chat_started: Option<Box<VideoChatStarted>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub video_chat_ended: Option<Box<VideoChatEnded>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub video_chat_scheduled: Option<Box<VideoChatScheduled>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub video_chat_participants_invited: Option<Box<VideoChatParticipantsInvited>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub web_app_data: Option<Box<WebAppData>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub reply_markup: Option<Box<InlineKeyboardMarkup>>,
 }
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 pub struct MessageId {
     pub message_id: i32,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct MessageEntity {
     #[serde(rename = "type")]
     pub type_field: MessageEntityType,
@@ -982,24 +915,21 @@ pub struct MessageEntity {
     pub length: u16,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub url: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub user: Option<User>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub language: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub custom_emoji_id: Option<String>,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct TextQuote {
-    #[builder(into)]
     pub text: String,
 
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1011,7 +941,8 @@ pub struct TextQuote {
     pub is_manual: Option<bool>,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Builder)]
+#[apply(builder!)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct ExternalReplyInfo {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub origin: Option<MessageOrigin>,
@@ -1095,31 +1026,33 @@ pub enum MessageOrigin {
     Channel(MessageOriginChannel),
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct MessageOriginUser {
     pub date: u64,
     pub sender_user: User,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct MessageOriginHiddenUser {
     pub date: u64,
-    #[builder(into)]
     pub sender_user_name: String,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct MessageOriginChat {
     pub date: u64,
 
     pub sender_chat: Chat,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub author_signature: Option<String>,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct MessageOriginChannel {
     pub date: u64,
 
@@ -1128,17 +1061,16 @@ pub struct MessageOriginChannel {
     pub message_id: i32,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub author_signature: Option<String>,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct LinkPreviewOptions {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub is_disabled: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub url: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1151,12 +1083,11 @@ pub struct LinkPreviewOptions {
     pub show_above_text: Option<bool>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct PhotoSize {
-    #[builder(into)]
     pub file_id: String,
 
-    #[builder(into)]
     pub file_unique_id: String,
 
     pub width: u32,
@@ -1167,12 +1098,11 @@ pub struct PhotoSize {
     pub file_size: Option<u64>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Animation {
-    #[builder(into)]
     pub file_id: String,
 
-    #[builder(into)]
     pub file_unique_id: String,
 
     pub width: u32,
@@ -1185,41 +1115,34 @@ pub struct Animation {
     pub thumbnail: Option<PhotoSize>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub file_name: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub mime_type: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub file_size: Option<u64>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Audio {
-    #[builder(into)]
     pub file_id: String,
 
-    #[builder(into)]
     pub file_unique_id: String,
 
     pub duration: u32,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub performer: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub title: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub file_name: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub mime_type: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1229,35 +1152,31 @@ pub struct Audio {
     pub thumbnail: Option<PhotoSize>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Document {
-    #[builder(into)]
     pub file_id: String,
 
-    #[builder(into)]
     pub file_unique_id: String,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub thumbnail: Option<PhotoSize>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub file_name: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub mime_type: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub file_size: Option<u64>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Video {
-    #[builder(into)]
     pub file_id: String,
 
-    #[builder(into)]
     pub file_unique_id: String,
 
     pub width: u32,
@@ -1270,23 +1189,20 @@ pub struct Video {
     pub thumbnail: Option<PhotoSize>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub file_name: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub mime_type: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub file_size: Option<u64>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct VideoNote {
-    #[builder(into)]
     pub file_id: String,
 
-    #[builder(into)]
     pub file_unique_id: String,
 
     pub length: u32,
@@ -1300,55 +1216,50 @@ pub struct VideoNote {
     pub file_size: Option<u64>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Voice {
-    #[builder(into)]
     pub file_id: String,
 
-    #[builder(into)]
     pub file_unique_id: String,
 
     pub duration: u32,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub mime_type: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub file_size: Option<u64>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Contact {
-    #[builder(into)]
     pub phone_number: String,
 
-    #[builder(into)]
     pub first_name: String,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub last_name: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub user_id: Option<u64>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub vcard: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Dice {
-    #[builder(into)]
     pub emoji: String,
 
     pub value: u8,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct PollOption {
-    #[builder(into)]
     pub text: String,
 
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1357,10 +1268,10 @@ pub struct PollOption {
     pub voter_count: u32,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct InputPollOption {
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub text: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1370,27 +1281,25 @@ pub struct InputPollOption {
     pub text_entities: Option<Vec<MessageEntity>>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct PollAnswer {
-    #[builder(into)]
     pub poll_id: String,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub voter_chat: Option<Chat>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub user: Option<Box<User>>,
 
     pub option_ids: Vec<u8>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Poll {
-    #[builder(into)]
     pub id: String,
 
-    #[builder(into)]
     pub question: String,
 
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1412,7 +1321,6 @@ pub struct Poll {
     pub correct_option_id: Option<u8>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub explanation: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1425,7 +1333,8 @@ pub struct Poll {
     pub close_date: Option<u64>,
 }
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]
 pub struct Location {
     pub longitude: f64,
 
@@ -1444,34 +1353,30 @@ pub struct Location {
     pub proximity_alert_radius: Option<u32>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct Venue {
     pub location: Location,
 
-    #[builder(into)]
     pub title: String,
 
-    #[builder(into)]
     pub address: String,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub foursquare_id: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub foursquare_type: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub google_place_id: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub google_place_type: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ProximityAlertTriggered {
     pub traveler: User,
 
@@ -1480,22 +1385,26 @@ pub struct ProximityAlertTriggered {
     pub distance: u32,
 }
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 pub struct MessageAutoDeleteTimerChanged {
     pub message_auto_delete_time: u32,
 }
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ChatBoostAdded {
     pub boost_count: u32,
 }
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 pub struct BackgroundFillSolid {
     pub color: u32,
 }
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 pub struct BackgroundFillGradient {
     pub top_color: u32,
 
@@ -1504,19 +1413,22 @@ pub struct BackgroundFillGradient {
     pub rotation_angle: u16,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct BackgroundFillFreeformGradient {
     pub colors: Vec<u32>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct BackgroundTypeFill {
     pub fill: BackgroundFill,
 
     pub dark_theme_dimming: u8,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct BackgroundTypeWallpaper {
     pub document: Document,
 
@@ -1529,7 +1441,8 @@ pub struct BackgroundTypeWallpaper {
     pub is_moving: Option<bool>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct BackgroundTypePattern {
     pub document: Document,
 
@@ -1544,140 +1457,142 @@ pub struct BackgroundTypePattern {
     pub is_moving: Option<bool>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct BackgroundTypeChatTheme {
-    #[builder(into)]
     pub theme_name: String,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ForumTopicCreated {
-    #[builder(into)]
     pub name: String,
 
     pub icon_color: u32,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub icon_custom_emoji_id: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ForumTopicClosed {}
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ForumTopicEdited {
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub name: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub icon_custom_emoji_id: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ForumTopicReopened {}
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct GeneralForumTopicHidden {}
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct GeneralForumTopicUnhidden {}
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SharedUser {
     pub user_id: u64,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub first_name: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub last_name: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub username: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub photo: Option<Vec<PhotoSize>>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct UsersShared {
     pub request_id: i32,
 
     pub users: Vec<SharedUser>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ChatShared {
     pub request_id: i32,
 
     pub chat_id: i64,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub title: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub username: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub photo: Option<Vec<PhotoSize>>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct WriteAccessAllowed {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub from_request: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub web_app_name: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub from_attachment_menu: Option<bool>,
 }
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 pub struct VideoChatEnded {
     pub duration: u32,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct VideoChatParticipantsInvited {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub users: Option<Vec<User>>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct UserProfilePhotos {
     pub total_count: u32,
 
     pub photos: Vec<Vec<PhotoSize>>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct File {
-    #[builder(into)]
     pub file_id: String,
 
-    #[builder(into)]
     pub file_unique_id: String,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub file_size: Option<u64>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub file_path: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ReplyKeyboardMarkup {
     pub keyboard: Vec<Vec<KeyboardButton>>,
 
@@ -1691,16 +1606,15 @@ pub struct ReplyKeyboardMarkup {
     pub one_time_keyboard: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub input_field_placeholder: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub selective: Option<bool>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct KeyboardButton {
-    #[builder(into)]
     pub text: String,
 
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1722,7 +1636,8 @@ pub struct KeyboardButton {
     pub web_app: Option<WebAppInfo>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct KeyboardButtonRequestUsers {
     pub request_id: i32,
 
@@ -1745,7 +1660,8 @@ pub struct KeyboardButtonRequestUsers {
     pub request_photo: Option<bool>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct KeyboardButtonRequestChat {
     pub request_id: i32,
 
@@ -1779,14 +1695,16 @@ pub struct KeyboardButtonRequestChat {
     pub request_photo: Option<bool>,
 }
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 pub struct KeyboardButtonPollType {
     #[serde(rename = "type")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub type_field: Option<PollType>,
 }
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ReplyKeyboardRemove {
     pub remove_keyboard: bool,
 
@@ -1794,36 +1712,33 @@ pub struct ReplyKeyboardRemove {
     pub selective: Option<bool>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct InlineKeyboardMarkup {
     pub inline_keyboard: Vec<Vec<InlineKeyboardButton>>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct InlineKeyboardButton {
-    #[builder(into)]
     pub text: String,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub url: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub login_url: Option<LoginUrl>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub callback_data: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub web_app: Option<WebAppInfo>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub switch_inline_query: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub switch_inline_query_current_chat: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1836,27 +1751,25 @@ pub struct InlineKeyboardButton {
     pub pay: Option<bool>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct LoginUrl {
-    #[builder(into)]
     pub url: String,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub forward_text: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub bot_username: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub request_write_access: Option<bool>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SwitchInlineQueryChosenChat {
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub query: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1872,9 +1785,9 @@ pub struct SwitchInlineQueryChosenChat {
     pub allow_channel_chats: Option<bool>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct CallbackQuery {
-    #[builder(into)]
     pub id: String,
 
     pub from: User,
@@ -1883,51 +1796,44 @@ pub struct CallbackQuery {
     pub message: Option<MaybeInaccessibleMessage>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub inline_message_id: Option<String>,
 
-    #[builder(into)]
     pub chat_instance: String,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub data: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub game_short_name: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ForceReply {
     pub force_reply: bool,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub input_field_placeholder: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub selective: Option<bool>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ChatPhoto {
-    #[builder(into)]
     pub small_file_id: String,
 
-    #[builder(into)]
     pub small_file_unique_id: String,
 
-    #[builder(into)]
     pub big_file_id: String,
 
-    #[builder(into)]
     pub big_file_unique_id: String,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ChatInviteLink {
-    #[builder(into)]
     pub invite_link: String,
 
     pub creator: User,
@@ -1939,7 +1845,6 @@ pub struct ChatInviteLink {
     pub is_revoked: bool,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub name: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1952,7 +1857,8 @@ pub struct ChatInviteLink {
     pub pending_join_request_count: Option<u32>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ChatMemberUpdated {
     pub chat: Chat,
 
@@ -1974,7 +1880,8 @@ pub struct ChatMemberUpdated {
     pub via_chat_folder_invite_link: Option<bool>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ChatJoinRequest {
     pub chat: Chat,
 
@@ -1985,14 +1892,14 @@ pub struct ChatJoinRequest {
     pub date: u64,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub bio: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub invite_link: Option<ChatInviteLink>,
 }
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ChatPermissions {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub can_send_messages: Option<bool>,
@@ -2037,7 +1944,8 @@ pub struct ChatPermissions {
     pub can_manage_topics: Option<bool>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Birthdate {
     pub day: u8,
 
@@ -2046,48 +1954,49 @@ pub struct Birthdate {
     pub year: u16,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct BusinessIntro {
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub title: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub message: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub sticker: Option<Sticker>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct BusinessLocation {
-    #[builder(into)]
     pub address: String,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub location: Option<Location>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct BusinessOpeningHoursInterval {
     pub opening_minute: u16,
 
     pub closing_minute: u16,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct BusinessOpeningHours {
     pub time_zone_name: String,
 
     pub opening_hours: Vec<BusinessOpeningHoursInterval>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct ChatLocation {
     pub location: Location,
 
-    #[builder(into)]
     pub address: String,
 }
 
@@ -2099,22 +2008,24 @@ pub enum ReactionType {
     Paid(ReactionTypePaid),
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ReactionTypeEmoji {
-    #[builder(into)]
     pub emoji: String,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ReactionTypeCustomEmoji {
-    #[builder(into)]
     pub custom_emoji_id: String,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ReactionTypePaid {}
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ReactionCount {
     #[serde(rename = "type")]
     pub type_field: ReactionType,
@@ -2122,7 +2033,8 @@ pub struct ReactionCount {
     pub total_count: i32,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct MessageReactionUpdated {
     pub chat: Chat,
 
@@ -2141,7 +2053,8 @@ pub struct MessageReactionUpdated {
     pub new_reaction: Vec<ReactionType>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct MessageReactionCountUpdated {
     pub chat: Chat,
 
@@ -2152,30 +2065,29 @@ pub struct MessageReactionCountUpdated {
     pub reactions: Vec<ReactionCount>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
 pub struct ForumTopic {
     pub message_thread_id: i32,
 
-    #[builder(into)]
     pub name: String,
 
     pub icon_color: u32,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub icon_custom_emoji_id: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct BotCommand {
-    #[builder(into)]
     pub command: String,
 
-    #[builder(into)]
     pub description: String,
 }
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ResponseParameters {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub migrate_to_chat_id: Option<i64>,
@@ -2184,12 +2096,11 @@ pub struct ResponseParameters {
     pub retry_after: Option<u16>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct Sticker {
-    #[builder(into)]
     pub file_id: String,
 
-    #[builder(into)]
     pub file_unique_id: String,
 
     #[serde(rename = "type")]
@@ -2207,11 +2118,9 @@ pub struct Sticker {
     pub thumbnail: Option<PhotoSize>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub emoji: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub set_name: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -2221,7 +2130,6 @@ pub struct Sticker {
     pub mask_position: Option<MaskPosition>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub custom_emoji_id: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -2231,7 +2139,8 @@ pub struct Sticker {
     pub file_size: Option<u64>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct InputSticker {
     pub sticker: FileUpload,
     pub format: StickerFormat,
@@ -2244,18 +2153,18 @@ pub struct InputSticker {
     pub keywords: Option<Vec<String>>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Story {
     pub chat: Chat,
     pub id: u64,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct StickerSet {
-    #[builder(into)]
     pub name: String,
 
-    #[builder(into)]
     pub title: String,
 
     #[serde(rename = "sticker_type")]
@@ -2271,9 +2180,9 @@ pub struct StickerSet {
     pub thumbnail: Option<PhotoSize>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct MaskPosition {
-    #[builder(into)]
     pub point: String,
 
     pub x_shift: f64,
@@ -2283,9 +2192,9 @@ pub struct MaskPosition {
     pub scale: f64,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct InlineQuery {
-    #[builder(into)]
     pub id: String,
 
     pub from: User,
@@ -2294,22 +2203,18 @@ pub struct InlineQuery {
     pub location: Option<Location>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub chat_type: Option<String>,
 
-    #[builder(into)]
     pub query: String,
 
-    #[builder(into)]
     pub offset: String,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct InlineQueryResultArticle {
-    #[builder(into)]
     pub id: String,
 
-    #[builder(into)]
     pub title: String,
 
     pub input_message_content: InputMessageContent,
@@ -2318,18 +2223,15 @@ pub struct InlineQueryResultArticle {
     pub reply_markup: Option<InlineKeyboardMarkup>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub url: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub hide_url: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub description: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub thumbnail_url: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -2339,15 +2241,13 @@ pub struct InlineQueryResultArticle {
     pub thumbnail_height: Option<u32>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct InlineQueryResultPhoto {
-    #[builder(into)]
     pub id: String,
 
-    #[builder(into)]
     pub photo_url: String,
 
-    #[builder(into)]
     pub thumbnail_url: String,
 
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -2357,15 +2257,12 @@ pub struct InlineQueryResultPhoto {
     pub photo_height: Option<u32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub title: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub description: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub caption: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -2384,12 +2281,11 @@ pub struct InlineQueryResultPhoto {
     pub input_message_content: Option<InputMessageContent>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct InlineQueryResultGif {
-    #[builder(into)]
     pub id: String,
 
-    #[builder(into)]
     pub gif_url: String,
 
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -2401,19 +2297,15 @@ pub struct InlineQueryResultGif {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub gif_duration: Option<u32>,
 
-    #[builder(into)]
     pub thumbnail_url: String,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub thumbnail_mime_type: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub title: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub caption: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -2432,12 +2324,11 @@ pub struct InlineQueryResultGif {
     pub input_message_content: Option<InputMessageContent>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct InlineQueryResultMpeg4Gif {
-    #[builder(into)]
     pub id: String,
 
-    #[builder(into)]
     pub mpeg4_url: String,
 
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -2449,19 +2340,15 @@ pub struct InlineQueryResultMpeg4Gif {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub mpeg4_duration: Option<u32>,
 
-    #[builder(into)]
     pub thumbnail_url: String,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub thumbnail_mime_type: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub title: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub caption: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -2480,25 +2367,20 @@ pub struct InlineQueryResultMpeg4Gif {
     pub input_message_content: Option<InputMessageContent>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct InlineQueryResultVideo {
-    #[builder(into)]
     pub id: String,
 
-    #[builder(into)]
     pub video_url: String,
 
-    #[builder(into)]
     pub mime_type: String,
 
-    #[builder(into)]
     pub thumbnail_url: String,
 
-    #[builder(into)]
     pub title: String,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub caption: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -2517,7 +2399,6 @@ pub struct InlineQueryResultVideo {
     pub video_duration: Option<u32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub description: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -2530,19 +2411,16 @@ pub struct InlineQueryResultVideo {
     pub input_message_content: Option<InputMessageContent>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct InlineQueryResultAudio {
-    #[builder(into)]
     pub id: String,
 
-    #[builder(into)]
     pub audio_url: String,
 
-    #[builder(into)]
     pub title: String,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub caption: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -2552,7 +2430,6 @@ pub struct InlineQueryResultAudio {
     pub caption_entities: Option<Vec<MessageEntity>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub performer: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -2565,19 +2442,16 @@ pub struct InlineQueryResultAudio {
     pub input_message_content: Option<InputMessageContent>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct InlineQueryResultVoice {
-    #[builder(into)]
     pub id: String,
 
-    #[builder(into)]
     pub voice_url: String,
 
-    #[builder(into)]
     pub title: String,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub caption: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -2596,16 +2470,14 @@ pub struct InlineQueryResultVoice {
     pub input_message_content: Option<InputMessageContent>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct InlineQueryResultDocument {
-    #[builder(into)]
     pub id: String,
 
-    #[builder(into)]
     pub title: String,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub caption: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -2614,14 +2486,11 @@ pub struct InlineQueryResultDocument {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub caption_entities: Option<Vec<MessageEntity>>,
 
-    #[builder(into)]
     pub document_url: String,
 
-    #[builder(into)]
     pub mime_type: String,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub description: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -2631,7 +2500,6 @@ pub struct InlineQueryResultDocument {
     pub input_message_content: Option<InputMessageContent>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub thumbnail_url: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -2641,16 +2509,15 @@ pub struct InlineQueryResultDocument {
     pub thumbnail_height: Option<u32>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct InlineQueryResultLocation {
-    #[builder(into)]
     pub id: String,
 
     pub latitude: f64,
 
     pub longitude: f64,
 
-    #[builder(into)]
     pub title: String,
 
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -2672,7 +2539,6 @@ pub struct InlineQueryResultLocation {
     pub input_message_content: Option<InputMessageContent>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub thumbnail_url: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -2682,35 +2548,29 @@ pub struct InlineQueryResultLocation {
     pub thumbnail_height: Option<u32>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct InlineQueryResultVenue {
-    #[builder(into)]
     pub id: String,
 
     pub latitude: f64,
 
     pub longitude: f64,
 
-    #[builder(into)]
     pub title: String,
 
-    #[builder(into)]
     pub address: String,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub foursquare_id: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub foursquare_type: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub google_place_id: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub google_place_type: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -2720,7 +2580,6 @@ pub struct InlineQueryResultVenue {
     pub input_message_content: Option<InputMessageContent>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub thumbnail_url: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -2730,23 +2589,19 @@ pub struct InlineQueryResultVenue {
     pub thumbnail_height: Option<u32>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct InlineQueryResultContact {
-    #[builder(into)]
     pub id: String,
 
-    #[builder(into)]
     pub phone_number: String,
 
-    #[builder(into)]
     pub first_name: String,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub last_name: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub vcard: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -2756,7 +2611,6 @@ pub struct InlineQueryResultContact {
     pub input_message_content: Option<InputMessageContent>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub thumbnail_url: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -2766,36 +2620,31 @@ pub struct InlineQueryResultContact {
     pub thumbnail_height: Option<u32>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct InlineQueryResultGame {
-    #[builder(into)]
     pub id: String,
 
-    #[builder(into)]
     pub game_short_name: String,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub reply_markup: Option<InlineKeyboardMarkup>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct InlineQueryResultCachedPhoto {
-    #[builder(into)]
     pub id: String,
 
-    #[builder(into)]
     pub photo_file_id: String,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub title: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub description: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub caption: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -2814,20 +2663,17 @@ pub struct InlineQueryResultCachedPhoto {
     pub input_message_content: Option<InputMessageContent>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct InlineQueryResultCachedGif {
-    #[builder(into)]
     pub id: String,
 
-    #[builder(into)]
     pub gif_file_id: String,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub title: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub caption: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -2846,20 +2692,17 @@ pub struct InlineQueryResultCachedGif {
     pub input_message_content: Option<InputMessageContent>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct InlineQueryResultCachedMpeg4Gif {
-    #[builder(into)]
     pub id: String,
 
-    #[builder(into)]
     pub mpeg4_file_id: String,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub title: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub caption: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -2878,12 +2721,11 @@ pub struct InlineQueryResultCachedMpeg4Gif {
     pub input_message_content: Option<InputMessageContent>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct InlineQueryResultCachedSticker {
-    #[builder(into)]
     pub id: String,
 
-    #[builder(into)]
     pub sticker_file_id: String,
 
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -2893,23 +2735,19 @@ pub struct InlineQueryResultCachedSticker {
     pub input_message_content: Option<InputMessageContent>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct InlineQueryResultCachedDocument {
-    #[builder(into)]
     pub id: String,
 
-    #[builder(into)]
     pub title: String,
 
-    #[builder(into)]
     pub document_file_id: String,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub description: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub caption: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -2925,23 +2763,19 @@ pub struct InlineQueryResultCachedDocument {
     pub input_message_content: Option<InputMessageContent>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct InlineQueryResultCachedVideo {
-    #[builder(into)]
     pub id: String,
 
-    #[builder(into)]
     pub video_file_id: String,
 
-    #[builder(into)]
     pub title: String,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub description: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub caption: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -2960,19 +2794,16 @@ pub struct InlineQueryResultCachedVideo {
     pub input_message_content: Option<InputMessageContent>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct InlineQueryResultCachedVoice {
-    #[builder(into)]
     pub id: String,
 
-    #[builder(into)]
     pub voice_file_id: String,
 
-    #[builder(into)]
     pub title: String,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub caption: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -2988,16 +2819,14 @@ pub struct InlineQueryResultCachedVoice {
     pub input_message_content: Option<InputMessageContent>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct InlineQueryResultCachedAudio {
-    #[builder(into)]
     pub id: String,
 
-    #[builder(into)]
     pub audio_file_id: String,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub caption: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -3013,9 +2842,9 @@ pub struct InlineQueryResultCachedAudio {
     pub input_message_content: Option<InputMessageContent>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct InputTextMessageContent {
-    #[builder(into)]
     pub message_text: String,
 
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -3028,7 +2857,8 @@ pub struct InputTextMessageContent {
     pub link_preview_options: Option<LinkPreviewOptions>,
 }
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]
 pub struct InputLocationMessageContent {
     pub latitude: f64,
 
@@ -3047,22 +2877,18 @@ pub struct InputLocationMessageContent {
     pub proximity_alert_radius: Option<u32>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct InputInvoiceMessageContent {
-    #[builder(into)]
     pub title: String,
 
-    #[builder(into)]
     pub description: String,
 
-    #[builder(into)]
     pub payload: String,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub provider_token: Option<String>,
 
-    #[builder(into)]
     pub currency: String,
 
     pub prices: Vec<LabeledPrice>,
@@ -3074,11 +2900,9 @@ pub struct InputInvoiceMessageContent {
     pub suggested_tip_amounts: Option<Vec<u32>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub provider_data: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub photo_url: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -3112,55 +2936,47 @@ pub struct InputInvoiceMessageContent {
     pub is_flexible: Option<bool>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct InputVenueMessageContent {
     pub latitude: f64,
 
     pub longitude: f64,
 
-    #[builder(into)]
     pub title: String,
 
-    #[builder(into)]
     pub address: String,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub foursquare_id: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub foursquare_type: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub google_place_id: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub google_place_type: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct InputContactMessageContent {
-    #[builder(into)]
     pub phone_number: String,
 
-    #[builder(into)]
     pub first_name: String,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub last_name: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub vcard: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct ChosenInlineResult {
-    #[builder(into)]
     pub result_id: String,
 
     pub from: User,
@@ -3169,39 +2985,35 @@ pub struct ChosenInlineResult {
     pub location: Option<Location>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub inline_message_id: Option<String>,
 
-    #[builder(into)]
     pub query: String,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct LabeledPrice {
-    #[builder(into)]
     pub label: String,
 
     pub amount: u32,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Invoice {
-    #[builder(into)]
     pub title: String,
 
-    #[builder(into)]
     pub description: String,
 
-    #[builder(into)]
     pub start_parameter: String,
 
-    #[builder(into)]
     pub currency: String,
 
     pub total_amount: u32,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct PaidMediaInfo {
     pub star_count: u32,
 
@@ -3216,7 +3028,8 @@ pub enum PaidMedia {
     Video(PaidMediaVideo),
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct PaidMediaPreview {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub width: Option<u32>,
@@ -3245,18 +3058,17 @@ pub enum InputPaidMedia {
     Video(InputPaidMediaVideo),
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct InputPaidMediaPhoto {
-    #[builder(into)]
     pub media: String,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct InputPaidMediaVideo {
-    #[builder(into)]
     pub media: String,
 
-    #[builder(into)]
     pub thumbnail: String,
 
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -3272,154 +3084,135 @@ pub struct InputPaidMediaVideo {
     pub supports_streaming: Option<bool>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ShippingAddress {
-    #[builder(into)]
     pub country_code: String,
 
-    #[builder(into)]
     pub state: String,
 
-    #[builder(into)]
     pub city: String,
 
-    #[builder(into)]
     pub street_line1: String,
 
-    #[builder(into)]
     pub street_line2: String,
 
-    #[builder(into)]
     pub post_code: String,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct OrderInfo {
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub name: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub phone_number: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub email: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub shipping_address: Option<ShippingAddress>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ShippingOption {
-    #[builder(into)]
     pub id: String,
 
-    #[builder(into)]
     pub title: String,
 
     pub prices: Vec<LabeledPrice>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SuccessfulPayment {
-    #[builder(into)]
     pub currency: String,
 
     pub total_amount: u32,
 
-    #[builder(into)]
     pub invoice_payload: String,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub shipping_option_id: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub order_info: Option<OrderInfo>,
 
-    #[builder(into)]
     pub telegram_payment_charge_id: String,
 
-    #[builder(into)]
     pub provider_payment_charge_id: String,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct RefundedPayment {
-    #[builder(into)]
     pub currency: String,
 
     pub total_amount: u32,
 
-    #[builder(into)]
     pub invoice_payload: String,
 
-    #[builder(into)]
     pub telegram_payment_charge_id: String,
 
-    #[builder(into)]
     pub provider_payment_charge_id: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ShippingQuery {
-    #[builder(into)]
     pub id: String,
 
     pub from: User,
 
-    #[builder(into)]
     pub invoice_payload: String,
 
     pub shipping_address: ShippingAddress,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct PreCheckoutQuery {
-    #[builder(into)]
     pub id: String,
 
     pub from: User,
 
-    #[builder(into)]
     pub currency: String,
 
     pub total_amount: u32,
 
-    #[builder(into)]
     pub invoice_payload: String,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub shipping_option_id: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub order_info: Option<OrderInfo>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct PaidMediaPurchased {
     pub from: User,
 
-    #[builder(into)]
     pub paid_media_payload: String,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct PassportData {
     pub data: Vec<EncryptedPassportElement>,
 
     pub credentials: EncryptedCredentials,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct PassportFile {
-    #[builder(into)]
     pub file_id: String,
 
-    #[builder(into)]
     pub file_unique_id: String,
 
     pub file_size: u64,
@@ -3427,21 +3220,19 @@ pub struct PassportFile {
     pub file_date: u64,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct EncryptedPassportElement {
     #[serde(rename = "type")]
     pub type_field: EncryptedPassportElementType,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub data: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub phone_number: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub email: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -3459,143 +3250,130 @@ pub struct EncryptedPassportElement {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub translation: Option<Vec<PassportFile>>,
 
-    #[builder(into)]
     pub hash: String,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct EncryptedCredentials {
-    #[builder(into)]
     pub data: String,
 
-    #[builder(into)]
     pub hash: String,
 
-    #[builder(into)]
     pub secret: String,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct PassportElementErrorDataField {
     #[serde(rename = "type")]
     pub type_field: PassportElementErrorDataFieldType,
 
-    #[builder(into)]
     pub field_name: String,
 
-    #[builder(into)]
     pub data_hash: String,
 
-    #[builder(into)]
     pub message: String,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct PassportElementErrorFrontSide {
     #[serde(rename = "type")]
     pub type_field: PassportElementErrorFrontSideType,
 
-    #[builder(into)]
     pub file_hash: String,
 
-    #[builder(into)]
     pub message: String,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct PassportElementErrorReverseSide {
     #[serde(rename = "type")]
     pub type_field: PassportElementErrorReverseSideType,
 
-    #[builder(into)]
     pub file_hash: String,
 
-    #[builder(into)]
     pub message: String,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct PassportElementErrorSelfie {
     #[serde(rename = "type")]
     pub type_field: PassportElementErrorSelfieType,
 
-    #[builder(into)]
     pub file_hash: String,
 
-    #[builder(into)]
     pub message: String,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct PassportElementErrorFile {
     #[serde(rename = "type")]
     pub type_field: PassportElementErrorFileType,
 
-    #[builder(into)]
     pub file_hash: String,
 
-    #[builder(into)]
     pub message: String,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct PassportElementErrorFiles {
     #[serde(rename = "type")]
     pub type_field: PassportElementErrorFileType,
 
     pub file_hashes: Vec<String>,
 
-    #[builder(into)]
     pub message: String,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct PassportElementErrorTranslationFile {
     #[serde(rename = "type")]
     pub type_field: PassportElementErrorTranslationFileType,
 
-    #[builder(into)]
     pub file_hash: String,
 
-    #[builder(into)]
     pub message: String,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct PassportElementErrorTranslationFiles {
     #[serde(rename = "type")]
     pub type_field: PassportElementErrorTranslationFileType,
 
     pub file_hashes: Vec<String>,
 
-    #[builder(into)]
     pub message: String,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct PassportElementErrorUnspecified {
     #[serde(rename = "type")]
     pub type_field: EncryptedPassportElementType,
 
-    #[builder(into)]
     pub element_hash: String,
 
-    #[builder(into)]
     pub message: String,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Game {
-    #[builder(into)]
     pub title: String,
 
-    #[builder(into)]
     pub description: String,
 
     pub photo: Vec<PhotoSize>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub text: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -3605,7 +3383,8 @@ pub struct Game {
     pub animation: Option<Animation>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct GameHighScore {
     pub position: u32,
 
@@ -3614,13 +3393,15 @@ pub struct GameHighScore {
     pub score: i32,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct GiveawayCreated {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub prize_star_count: Option<u32>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Giveaway {
     pub chats: Vec<Chat>,
 
@@ -3635,7 +3416,6 @@ pub struct Giveaway {
     pub has_public_winners: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub prize_description: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -3648,7 +3428,8 @@ pub struct Giveaway {
     pub premium_subscription_month_count: Option<u32>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct GiveawayWinners {
     pub chat: Chat,
 
@@ -3679,11 +3460,11 @@ pub struct GiveawayWinners {
     pub was_refunded: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub prize_description: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct GiveawayCompleted {
     pub winner_count: u32,
 
@@ -3691,14 +3472,14 @@ pub struct GiveawayCompleted {
     pub unclaimed_prize_count: Option<u32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub giveaway_message: Option<Box<Message>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub is_star_giveaway: Option<bool>,
 }
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ChatAdministratorRights {
     pub is_anonymous: bool,
 
@@ -3738,24 +3519,23 @@ pub struct ChatAdministratorRights {
     pub can_manage_topics: Option<bool>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct WebAppInfo {
-    #[builder(into)]
     pub url: String,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SentWebAppMessage {
-    #[builder(into)]
     pub inline_message_id: String,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct WebAppData {
-    #[builder(into)]
     pub data: String,
 
-    #[builder(into)]
     pub button_text: String,
 }
 
@@ -3767,17 +3547,20 @@ pub enum ChatBoostSource {
     Giveaway(ChatBoostSourceGiveaway),
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ChatBoostSourcePremium {
     pub user: User,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ChatBoostSourceGiftCode {
     pub user: User,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ChatBoostSourceGiveaway {
     pub giveaway_message_id: i32,
 
@@ -3791,9 +3574,9 @@ pub struct ChatBoostSourceGiveaway {
     pub is_unclaimed: Option<bool>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ChatBoost {
-    #[builder(into)]
     pub boost_id: String,
 
     pub add_date: u64,
@@ -3803,18 +3586,19 @@ pub struct ChatBoost {
     pub source: ChatBoostSource,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ChatBoostUpdated {
     pub chat: Chat,
 
     pub boost: ChatBoost,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ChatBoostRemoved {
     pub chat: Chat,
 
-    #[builder(into)]
     pub boost_id: String,
 
     pub remove_date: u64,
@@ -3822,14 +3606,15 @@ pub struct ChatBoostRemoved {
     pub source: ChatBoostSource,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct UserChatBoosts {
     pub boosts: Vec<ChatBoost>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct BusinessConnection {
-    #[builder(into)]
     pub id: String,
 
     pub user: User,
@@ -3843,9 +3628,9 @@ pub struct BusinessConnection {
     pub is_enabled: bool,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct BusinessMessagesDeleted {
-    #[builder(into)]
     pub business_connection_id: String,
 
     pub chat: Chat,
@@ -3860,7 +3645,8 @@ pub enum MaybeInaccessibleMessage {
     InaccessibleMessage(InaccessibleMessage),
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct InaccessibleMessage {
     pub chat: Chat,
 
@@ -3877,18 +3663,20 @@ pub enum RevenueWithdrawalState {
     Failed(RevenueWithdrawalStateFailed),
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct RevenueWithdrawalStatePending {}
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct RevenueWithdrawalStateSucceeded {
     pub date: u64,
 
-    #[builder(into)]
     pub url: String,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct RevenueWithdrawalStateFailed {}
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -3900,33 +3688,36 @@ pub enum TransactionPartner {
     Other(TransactionPartnerOther),
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct TransactionPartnerUser {
     pub user: User,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(into)]
     pub invoice_payload: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub paid_media: Option<Vec<PaidMedia>>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct TransactionPartnerFragment {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub withdrawal_state: Option<RevenueWithdrawalState>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct TransactionPartnerTelegramAds {}
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct TransactionPartnerOther {}
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct StarTransaction {
-    #[builder(into)]
     pub id: String,
 
     pub amount: u32,
@@ -3940,7 +3731,8 @@ pub struct StarTransaction {
     pub receiver: Option<TransactionPartner>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
+#[apply(builder!)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct StarTransactions {
     pub transactions: Vec<StarTransaction>,
 }


### PR DESCRIPTION
I found a really [handy crate](https://github.com/danielhenrymantilla/macro_rules_attribute-rs) that allows you to define derive/attribute aliases etc. without defining a separate proc macro crate. This crate doesn't even depend on syn/quote/proc-macro-2. The compile time is still the same for me (~17 seconds from scratch) after this change.

I think I'll add this hack to `bon` docs as "global builder config" pattern.

