### PR TITLE
build!: remove implicit features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,10 +15,10 @@ all-features = true
 
 [features]
 default = ["http-client"]
-http-client = ["ureq", "multipart", "mime_guess", "telegram-trait", "serde_json"]
+http-client = ["telegram-trait", "dep:ureq", "dep:multipart", "dep:mime_guess", "dep:serde_json"]
 telegram-trait = []
-async-http-client = ["reqwest", "tokio", "async-telegram-trait", "serde_json"]
-async-telegram-trait = ["async-trait"]
+async-http-client = ["async-telegram-trait", "dep:reqwest", "dep:tokio", "dep:serde_json"]
+async-telegram-trait = ["dep:async-trait"]
 
 [lints.rust]
 unsafe_code = "forbid"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,8 @@
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
-#[cfg(feature = "reqwest")]
+#[cfg(feature = "async-http-client")]
 pub use reqwest;
-#[cfg(feature = "ureq")]
+#[cfg(feature = "http-client")]
 pub use ureq;
 
 pub use self::api_params::*;
@@ -25,7 +25,7 @@ mod client_reqwest;
 #[cfg(feature = "http-client")]
 mod client_ureq;
 mod error;
-#[cfg(feature = "serde_json")]
+#[cfg(any(feature = "http-client", feature = "async-http-client"))]
 mod json;
 pub mod objects;
 mod parse_mode;


### PR DESCRIPTION
As this causes confusion it will also be the default in the upcoming Rust edition 2024. See https://doc.rust-lang.org/nightly/edition-guide/rust-2024/cargo-remove-implicit-features.html

BREAKING CHANGE: Optional dependencies are no longer features. They were never intended to be used directly.