### PR TITLE
test: improve testing for api error response

### DIFF
--- a/src/client_reqwest.rs
+++ b/src/client_reqwest.rs
@@ -145,7 +145,6 @@ impl AsyncTelegramApi for AsyncApi {
 mod async_tests {
     use super::*;
     use crate::api_params::SendMessageParams;
-    use crate::response::ErrorResponse;
 
     #[tokio::test]
     async fn async_send_message_success() {
@@ -186,16 +185,13 @@ mod async_tests {
             .await;
         let api = AsyncApi::new_url(server.url());
 
-        if let Err(Error::Api(ErrorResponse {
-            ok: false,
-            description,
-            error_code: 400,
-            parameters: None,
-        })) = api.send_message(&params).await
-        {
-            assert_eq!("Bad Request: chat not found".to_string(), description);
+        if let Err(Error::Api(error)) = dbg!(api.send_message(&params).await) {
+            assert_eq!(error.description, "Bad Request: chat not found");
+            assert_eq!(error.error_code, 400);
+            assert_eq!(error.parameters, None);
+            assert!(!error.ok);
         } else {
-            panic!("Error was expected but there is none");
+            panic!("API Error expected");
         }
     }
 }

--- a/src/client_ureq.rs
+++ b/src/client_ureq.rs
@@ -216,7 +216,6 @@ mod tests {
     use crate::objects::ChatPermissions;
     use crate::objects::InlineQueryResultVenue;
     use crate::objects::InputPollOption;
-    use crate::response::ErrorResponse;
 
     #[test]
     fn new_sets_correct_url() {
@@ -289,16 +288,13 @@ mod tests {
             .create();
         let api = Api::new_url(server.url());
 
-        if let Err(Error::Api(ErrorResponse {
-            ok: false,
-            description,
-            error_code: 400,
-            parameters: None,
-        })) = api.send_message(&params)
-        {
-            assert_eq!("Bad Request: chat not found".to_string(), description);
+        if let Err(Error::Api(error)) = dbg!(api.send_message(&params)) {
+            assert_eq!(error.description, "Bad Request: chat not found");
+            assert_eq!(error.error_code, 400);
+            assert_eq!(error.parameters, None);
+            assert!(!error.ok);
         } else {
-            panic!("Error was expected but there is none");
+            panic!("API Error expected");
         }
     }
 


### PR DESCRIPTION
Using the destructuring might mistakenly result in a wrong output. This could be misleading. For example an error code of 500 would result in the panic message while its still an API Error.

This moves the assertions to `assert_eq` and only destructures the `Error::Api`