### PR TITLE
refactor: generalize serde logic into macro

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,6 +78,9 @@ required-features = ["telegram-trait"]
 bon = "2.2.0"
 macro_rules_attribute = "0.2.0"
 paste = "1.0.2"
+serde = { version = "1.0.157", features = ["derive"] }
+serde_json = { version = "1.0.45", optional = true }
+serde_with = "3.0.0"
 thiserror = "1"
 
 [dependencies.async-trait]
@@ -98,14 +101,6 @@ optional = true
 version = "0.12"
 default-features = false
 features = ["multipart", "stream", "rustls-tls"]
-optional = true
-
-[dependencies.serde]
-version = "1"
-features = ["derive"]
-
-[dependencies.serde_json]
-version = "1"
 optional = true
 
 [dependencies.tokio]

--- a/src/api_params.rs
+++ b/src/api_params.rs
@@ -4,6 +4,7 @@ use std::path::PathBuf;
 
 use macro_rules_attribute::apply;
 use serde::{Deserialize, Serialize};
+use serde_with::skip_serializing_none;
 
 use crate::macros::builder;
 use crate::objects::{
@@ -225,900 +226,449 @@ pub struct InputFile {
     pub path: PathBuf,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct GetUpdatesParams {
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub offset: Option<i64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub limit: Option<u32>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub timeout: Option<u32>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub allowed_updates: Option<Vec<AllowedUpdate>>,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SetWebhookParams {
     pub url: String,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub certificate: Option<InputFile>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub ip_address: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub max_connections: Option<u32>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub allowed_updates: Option<Vec<AllowedUpdate>>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub drop_pending_updates: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub secret_token: Option<String>,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 pub struct DeleteWebhookParams {
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub drop_pending_updates: Option<bool>,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SendMessageParams {
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub business_connection_id: Option<String>,
-
     pub chat_id: ChatId,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub message_thread_id: Option<i32>,
-
     pub text: String,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub parse_mode: Option<ParseMode>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub entities: Option<Vec<MessageEntity>>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub link_preview_options: Option<LinkPreviewOptions>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub disable_notification: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub protect_content: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub message_effect_id: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub reply_parameters: Option<ReplyParameters>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub reply_markup: Option<ReplyMarkup>,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ForwardMessageParams {
     pub chat_id: ChatId,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub message_thread_id: Option<i32>,
-
     pub from_chat_id: ChatId,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub disable_notification: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub protect_content: Option<bool>,
-
     pub message_id: i32,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ForwardMessagesParams {
     pub chat_id: ChatId,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub message_thread_id: Option<i32>,
-
     pub from_chat_id: ChatId,
-
     pub message_ids: Vec<i32>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub disable_notification: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub protect_content: Option<bool>,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct CopyMessageParams {
     pub chat_id: ChatId,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub message_thread_id: Option<i32>,
-
     pub from_chat_id: ChatId,
-
     pub message_id: i32,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub caption: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub parse_mode: Option<ParseMode>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub caption_entities: Option<Vec<MessageEntity>>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub show_caption_above_media: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub disable_notification: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub protect_content: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub reply_parameters: Option<ReplyParameters>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub reply_markup: Option<ReplyMarkup>,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct CopyMessagesParams {
     pub chat_id: ChatId,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub message_thread_id: Option<i32>,
-
     pub from_chat_id: ChatId,
-
     pub message_ids: Vec<i32>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub disable_notification: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub protect_content: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub remove_caption: Option<bool>,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SendPhotoParams {
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub business_connection_id: Option<String>,
-
     pub chat_id: ChatId,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub message_thread_id: Option<i32>,
-
     pub photo: FileUpload,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub caption: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub parse_mode: Option<ParseMode>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub caption_entities: Option<Vec<MessageEntity>>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub show_caption_above_media: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub has_spoiler: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub disable_notification: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub protect_content: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub message_effect_id: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub reply_parameters: Option<ReplyParameters>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub reply_markup: Option<ReplyMarkup>,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SendAudioParams {
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub business_connection_id: Option<String>,
-
     pub chat_id: ChatId,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub message_thread_id: Option<i32>,
-
     pub audio: FileUpload,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub caption: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub parse_mode: Option<ParseMode>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub caption_entities: Option<Vec<MessageEntity>>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub duration: Option<u32>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub performer: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub title: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub thumbnail: Option<FileUpload>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub disable_notification: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub protect_content: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub message_effect_id: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub reply_parameters: Option<ReplyParameters>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub reply_markup: Option<ReplyMarkup>,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SendDocumentParams {
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub business_connection_id: Option<String>,
-
     pub chat_id: ChatId,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub message_thread_id: Option<i32>,
-
     pub document: FileUpload,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub thumbnail: Option<FileUpload>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub caption: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub parse_mode: Option<ParseMode>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub caption_entities: Option<Vec<MessageEntity>>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub disable_content_type_detection: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub disable_notification: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub protect_content: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub message_effect_id: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub reply_parameters: Option<ReplyParameters>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub reply_markup: Option<ReplyMarkup>,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SendVideoParams {
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub business_connection_id: Option<String>,
-
     pub chat_id: ChatId,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub message_thread_id: Option<i32>,
-
     pub video: FileUpload,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub duration: Option<u32>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub width: Option<u32>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub height: Option<u32>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub thumbnail: Option<FileUpload>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub caption: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub parse_mode: Option<ParseMode>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub caption_entities: Option<Vec<MessageEntity>>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub show_caption_above_media: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub has_spoiler: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub supports_streaming: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub disable_notification: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub protect_content: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub message_effect_id: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub reply_parameters: Option<ReplyParameters>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub reply_markup: Option<ReplyMarkup>,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SendAnimationParams {
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub business_connection_id: Option<String>,
-
     pub chat_id: ChatId,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub message_thread_id: Option<i32>,
-
     pub animation: FileUpload,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub duration: Option<u32>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub width: Option<u32>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub height: Option<u32>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub thumbnail: Option<FileUpload>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub caption: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub parse_mode: Option<ParseMode>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub caption_entities: Option<Vec<MessageEntity>>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub show_caption_above_media: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub has_spoiler: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub disable_notification: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub protect_content: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub message_effect_id: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub reply_parameters: Option<ReplyParameters>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub reply_markup: Option<ReplyMarkup>,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SendVoiceParams {
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub business_connection_id: Option<String>,
-
     pub chat_id: ChatId,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub message_thread_id: Option<i32>,
-
     pub voice: FileUpload,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub caption: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub parse_mode: Option<ParseMode>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub caption_entities: Option<Vec<MessageEntity>>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub duration: Option<u32>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub disable_notification: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub protect_content: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub message_effect_id: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub reply_parameters: Option<ReplyParameters>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub reply_markup: Option<ReplyMarkup>,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SendVideoNoteParams {
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub business_connection_id: Option<String>,
-
     pub chat_id: ChatId,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub message_thread_id: Option<i32>,
-
     pub video_note: FileUpload,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub duration: Option<u32>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub length: Option<u32>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub thumbnail: Option<FileUpload>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub disable_notification: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub protect_content: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub message_effect_id: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub reply_parameters: Option<ReplyParameters>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub reply_markup: Option<ReplyMarkup>,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SendPaidMediaParams {
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub business_connection_id: Option<String>,
-
     pub chat_id: ChatId,
-
     pub star_count: u32,
-
     pub media: Vec<InputPaidMedia>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub payload: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub caption: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub parse_mode: Option<ParseMode>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub caption_entities: Option<Vec<MessageEntity>>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub show_caption_above_media: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub disable_notification: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub protect_content: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub reply_parameters: Option<ReplyParameters>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub reply_markup: Option<ReplyMarkup>,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SendMediaGroupParams {
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub business_connection_id: Option<String>,
-
     pub chat_id: ChatId,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub message_thread_id: Option<i32>,
-
     pub media: Vec<Media>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub disable_notification: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub message_effect_id: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub protect_content: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub reply_parameters: Option<ReplyParameters>,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct SendLocationParams {
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub business_connection_id: Option<String>,
-
     pub chat_id: ChatId,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub message_thread_id: Option<i32>,
-
     pub latitude: f64,
-
     pub longitude: f64,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub horizontal_accuracy: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub live_period: Option<u32>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub heading: Option<u16>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub proximity_alert_radius: Option<u32>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub disable_notification: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub protect_content: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub message_effect_id: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub reply_parameters: Option<ReplyParameters>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub reply_markup: Option<ReplyMarkup>,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct EditMessageLiveLocationParams {
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub business_connection_id: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub chat_id: Option<ChatId>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub message_id: Option<i32>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub inline_message_id: Option<String>,
-
     pub latitude: f64,
-
     pub longitude: f64,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub live_period: Option<u32>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub horizontal_accuracy: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub heading: Option<u16>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub proximity_alert_radius: Option<u32>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub reply_markup: Option<InlineKeyboardMarkup>,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct StopMessageLiveLocationParams {
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub business_connection_id: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub chat_id: Option<ChatId>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub message_id: Option<i32>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub inline_message_id: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub reply_markup: Option<InlineKeyboardMarkup>,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct SendVenueParams {
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub business_connection_id: Option<String>,
-
     pub chat_id: ChatId,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub message_thread_id: Option<i32>,
-
     pub latitude: f64,
-
     pub longitude: f64,
-
     pub title: String,
-
     pub address: String,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub foursquare_id: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub foursquare_type: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub google_place_id: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub google_place_type: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub disable_notification: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub protect_content: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub message_effect_id: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub reply_parameters: Option<ReplyParameters>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub reply_markup: Option<ReplyMarkup>,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SendContactParams {
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub business_connection_id: Option<String>,
-
     pub chat_id: ChatId,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub message_thread_id: Option<i32>,
-
     pub phone_number: String,
-
     pub first_name: String,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub last_name: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub vcard: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub disable_notification: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub protect_content: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub message_effect_id: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub reply_parameters: Option<ReplyParameters>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub reply_markup: Option<ReplyMarkup>,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SendPollParams {
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub business_connection_id: Option<String>,
-
     pub chat_id: ChatId,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub message_thread_id: Option<i32>,
-
     pub question: String,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub question_parse_mode: Option<ParseMode>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub question_entities: Option<Vec<MessageEntity>>,
-
     pub options: Vec<InputPollOption>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub is_anonymous: Option<bool>,
+
     #[serde(rename = "type")]
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub type_field: Option<PollType>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub allows_multiple_answers: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub correct_option_id: Option<u8>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub explanation: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub explanation_parse_mode: Option<ParseMode>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub explanation_entities: Option<Vec<MessageEntity>>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub open_period: Option<u32>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub close_date: Option<u64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub is_closed: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub disable_notification: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub protect_content: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub message_effect_id: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub reply_parameters: Option<ReplyParameters>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub reply_markup: Option<ReplyMarkup>,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SendDiceParams {
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub business_connection_id: Option<String>,
-
     pub chat_id: ChatId,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub message_thread_id: Option<i32>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub emoji: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub disable_notification: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub protect_content: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub message_effect_id: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub reply_parameters: Option<ReplyParameters>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub reply_markup: Option<ReplyMarkup>,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SendChatActionParams {
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub business_connection_id: Option<String>,
-
     pub chat_id: ChatId,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub message_thread_id: Option<i32>,
-
     pub action: ChatAction,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SetMessageReactionParams {
     pub chat_id: ChatId,
-
     pub message_id: i32,
-
     pub reaction: Vec<ReactionType>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub is_big: Option<bool>,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 pub struct GetUserProfilePhotosParams {
     pub user_id: u64,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub offset: Option<u32>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub limit: Option<u32>,
 }
 
@@ -1128,97 +678,56 @@ pub struct GetFileParams {
     pub file_id: String,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct BanChatMemberParams {
     pub chat_id: ChatId,
-
     pub user_id: u64,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub until_date: Option<u64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub revoke_messages: Option<bool>,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct UnbanChatMemberParams {
     pub chat_id: ChatId,
-
     pub user_id: u64,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub only_if_banned: Option<bool>,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct RestrictChatMemberParams {
     pub chat_id: ChatId,
-
     pub user_id: u64,
-
     pub permissions: ChatPermissions,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub use_independent_chat_permissions: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub until_date: Option<u64>,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct PromoteChatMemberParams {
     pub chat_id: ChatId,
-
     pub user_id: u64,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub is_anonymous: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub can_manage_chat: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub can_post_messages: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub can_edit_messages: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub can_delete_messages: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub can_post_stories: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub can_edit_stories: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub can_delete_stories: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub can_manage_video_chats: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub can_restrict_members: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub can_promote_members: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub can_change_info: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub can_invite_users: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub can_pin_messages: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub can_manage_topics: Option<bool>,
 }
 
@@ -1226,9 +735,7 @@ pub struct PromoteChatMemberParams {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SetChatAdministratorCustomTitleParams {
     pub chat_id: ChatId,
-
     pub user_id: u64,
-
     pub custom_title: String,
 }
 
@@ -1236,7 +743,6 @@ pub struct SetChatAdministratorCustomTitleParams {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct BanChatSenderChatParams {
     pub chat_id: ChatId,
-
     pub sender_chat_id: i64,
 }
 
@@ -1244,18 +750,15 @@ pub struct BanChatSenderChatParams {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct UnbanChatSenderChatParams {
     pub chat_id: ChatId,
-
     pub sender_chat_id: i64,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SetChatPermissionsParams {
     pub chat_id: ChatId,
-
     pub permissions: ChatPermissions,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub use_independent_chat_permissions: Option<bool>,
 }
 
@@ -1265,65 +768,45 @@ pub struct ExportChatInviteLinkParams {
     pub chat_id: ChatId,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct CreateChatInviteLinkParams {
     pub chat_id: ChatId,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub expire_date: Option<u64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub member_limit: Option<u32>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub creates_join_request: Option<bool>,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct EditChatInviteLinkParams {
     pub chat_id: ChatId,
-
     pub invite_link: String,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub expire_date: Option<u64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub member_limit: Option<u32>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub creates_join_request: Option<bool>,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct CreateChatSubscriptionInviteLinkParams {
     pub chat_id: ChatId,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
-
     pub subscription_period: u32,
-
     pub subscription_price: u16,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct EditChatSubscriptionInviteLinkParams {
     pub chat_id: ChatId,
-
     pub invite_link: String,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
 }
 
@@ -1331,7 +814,6 @@ pub struct EditChatSubscriptionInviteLinkParams {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct RevokeChatInviteLinkParams {
     pub chat_id: ChatId,
-
     pub invite_link: String,
 }
 
@@ -1339,7 +821,6 @@ pub struct RevokeChatInviteLinkParams {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ApproveChatJoinRequestParams {
     pub chat_id: ChatId,
-
     pub user_id: u64,
 }
 
@@ -1347,7 +828,6 @@ pub struct ApproveChatJoinRequestParams {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct DeclineChatJoinRequestParams {
     pub chat_id: ChatId,
-
     pub user_id: u64,
 }
 
@@ -1355,7 +835,6 @@ pub struct DeclineChatJoinRequestParams {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SetChatPhotoParams {
     pub chat_id: ChatId,
-
     pub photo: InputFile,
 }
 
@@ -1369,42 +848,33 @@ pub struct DeleteChatPhotoParams {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SetChatTitleParams {
     pub chat_id: ChatId,
-
     pub title: String,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SetChatDescriptionParams {
     pub chat_id: ChatId,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct PinChatMessageParams {
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub business_connection_id: Option<String>,
-
     pub chat_id: ChatId,
-
     pub message_id: i32,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub disable_notification: Option<bool>,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct UnpinChatMessageParams {
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub business_connection_id: Option<String>,
-
     pub chat_id: ChatId,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub message_id: Option<i32>,
 }
 
@@ -1442,7 +912,6 @@ pub struct GetChatMemberCountParams {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct GetChatMemberParams {
     pub chat_id: ChatId,
-
     pub user_id: u64,
 }
 
@@ -1450,7 +919,6 @@ pub struct GetChatMemberParams {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SetChatStickerSetParams {
     pub chat_id: ChatId,
-
     pub sticker_set_name: String,
 }
 
@@ -1460,31 +928,23 @@ pub struct DeleteChatStickerSetParams {
     pub chat_id: ChatId,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct CreateForumTopicParams {
     pub chat_id: ChatId,
-
     pub name: String,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub icon_color: Option<u32>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub icon_custom_emoji_id: Option<String>,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct EditForumTopicParams {
     pub chat_id: ChatId,
-
     pub message_thread_id: i32,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub icon_custom_emoji_id: Option<String>,
 }
 
@@ -1492,7 +952,6 @@ pub struct EditForumTopicParams {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct CloseForumTopicParams {
     pub chat_id: ChatId,
-
     pub message_thread_id: i32,
 }
 
@@ -1500,7 +959,6 @@ pub struct CloseForumTopicParams {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ReopenForumTopicParams {
     pub chat_id: ChatId,
-
     pub message_thread_id: i32,
 }
 
@@ -1508,7 +966,6 @@ pub struct ReopenForumTopicParams {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct DeleteForumTopicParams {
     pub chat_id: ChatId,
-
     pub message_thread_id: i32,
 }
 
@@ -1516,7 +973,6 @@ pub struct DeleteForumTopicParams {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct UnpinAllForumTopicMessagesParams {
     pub chat_id: ChatId,
-
     pub message_thread_id: i32,
 }
 
@@ -1524,7 +980,6 @@ pub struct UnpinAllForumTopicMessagesParams {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct EditGeneralForumTopicParams {
     pub chat_id: ChatId,
-
     pub name: String,
 }
 
@@ -1552,21 +1007,14 @@ pub struct UnhideGeneralForumTopicParams {
     pub chat_id: ChatId,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct AnswerCallbackQueryParams {
     pub callback_query_id: String,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub text: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub show_alert: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub url: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub cache_time: Option<u32>,
 }
 
@@ -1574,7 +1022,6 @@ pub struct AnswerCallbackQueryParams {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct GetUserChatBoostsParams {
     pub chat_id: ChatId,
-
     pub user_id: u64,
 }
 
@@ -1584,201 +1031,136 @@ pub struct GetBusinessConnectionParams {
     pub business_connection_id: String,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SetMyCommandsParams {
     pub commands: Vec<BotCommand>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub scope: Option<BotCommandScope>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub language_code: Option<String>,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SetMyNameParams {
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub language_code: Option<String>,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct GetMyNameParams {
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub language_code: Option<String>,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SetMyDescriptionParams {
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub language_code: Option<String>,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct GetMyDescriptionParams {
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub language_code: Option<String>,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SetMyShortDescriptionParams {
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub short_description: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub language_code: Option<String>,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct GetMyShortDescriptionParams {
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub language_code: Option<String>,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct GetMyCommandsParams {
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub scope: Option<BotCommandScope>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub language_code: Option<String>,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct DeleteMyCommandsParams {
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub scope: Option<BotCommandScope>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub language_code: Option<String>,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct EditMessageTextParams {
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub business_connection_id: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub chat_id: Option<ChatId>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub message_id: Option<i32>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub inline_message_id: Option<String>,
-
     pub text: String,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub parse_mode: Option<ParseMode>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub entities: Option<Vec<MessageEntity>>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub link_preview_options: Option<LinkPreviewOptions>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub reply_markup: Option<InlineKeyboardMarkup>,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct EditMessageCaptionParams {
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub business_connection_id: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub chat_id: Option<ChatId>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub message_id: Option<i32>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub inline_message_id: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub caption: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub parse_mode: Option<ParseMode>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub caption_entities: Option<Vec<MessageEntity>>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub show_caption_above_media: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub reply_markup: Option<InlineKeyboardMarkup>,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct EditMessageMediaParams {
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub business_connection_id: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub chat_id: Option<ChatId>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub message_id: Option<i32>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub inline_message_id: Option<String>,
-
     pub media: InputMedia,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub reply_markup: Option<InlineKeyboardMarkup>,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct EditMessageReplyMarkupParams {
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub business_connection_id: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub chat_id: Option<ChatId>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub message_id: Option<i32>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub inline_message_id: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub reply_markup: Option<InlineKeyboardMarkup>,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct StopPollParams {
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub business_connection_id: Option<String>,
-
     pub chat_id: ChatId,
-
     pub message_id: i32,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub reply_markup: Option<InlineKeyboardMarkup>,
 }
 
@@ -1786,7 +1168,6 @@ pub struct StopPollParams {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct DeleteMessageParams {
     pub chat_id: ChatId,
-
     pub message_id: i32,
 }
 
@@ -1794,39 +1175,22 @@ pub struct DeleteMessageParams {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct DeleteMessagesParams {
     pub chat_id: ChatId,
-
     pub message_ids: Vec<i32>,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SendStickerParams {
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub business_connection_id: Option<String>,
-
     pub chat_id: ChatId,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub message_thread_id: Option<i32>,
-
     pub sticker: FileUpload,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub emoji: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub disable_notification: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub protect_content: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub message_effect_id: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub reply_parameters: Option<ReplyParameters>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub reply_markup: Option<ReplyMarkup>,
 }
 
@@ -1840,27 +1204,19 @@ pub struct GetStickerSetParams {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct UploadStickerFileParams {
     pub user_id: u64,
-
     pub sticker: InputFile,
-
     pub sticker_format: StickerFormat,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct CreateNewStickerSetParams {
     pub user_id: u64,
-
     pub name: String,
-
     pub title: String,
-
     pub stickers: Vec<InputSticker>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub sticker_type: Option<StickerType>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub needs_repainting: Option<bool>,
 }
 
@@ -1874,9 +1230,7 @@ pub struct GetCustomEmojiStickersParams {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct AddStickerToSetParams {
     pub user_id: u64,
-
     pub name: String,
-
     pub sticker: InputSticker,
 }
 
@@ -1884,7 +1238,6 @@ pub struct AddStickerToSetParams {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SetStickerPositionInSetParams {
     pub sticker: String,
-
     pub position: u32,
 }
 
@@ -1898,11 +1251,8 @@ pub struct DeleteStickerFromSetParams {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct ReplaceStickerInSetParams {
     pub user_id: u64,
-
     pub name: String,
-
     pub old_sticker: String,
-
     pub sticker: InputSticker,
 }
 
@@ -1910,25 +1260,22 @@ pub struct ReplaceStickerInSetParams {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SetStickerEmojiListParams {
     pub sticker: String,
-
     pub emoji_list: Vec<String>,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SetStickerKeywordsParams {
     pub sticker: String,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub keywords: Option<Vec<String>>,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct SetStickerMaskPositionParams {
     pub sticker: String,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub mask_position: Option<MaskPosition>,
 }
 
@@ -1936,29 +1283,24 @@ pub struct SetStickerMaskPositionParams {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SetStickerSetTitleParams {
     pub name: String,
-
     pub title: String,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SetStickerSetThumbnailParams {
     pub name: String,
-
     pub user_id: u64,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub thumbnail: Option<FileUpload>,
-
     pub format: StickerFormat,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SetCustomEmojiStickerSetThumbnailParams {
     pub name: String,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub custom_emoji_id: Option<String>,
 }
 
@@ -1968,201 +1310,103 @@ pub struct DeleteStickerSetParams {
     pub name: String,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct AnswerInlineQueryParams {
     pub inline_query_id: String,
-
     pub results: Vec<InlineQueryResult>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub cache_time: Option<u32>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub is_personal: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub next_offset: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub button: Option<InlineQueryResultsButton>,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct InlineQueryResultsButton {
     pub text: String,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub web_app: Option<WebAppInfo>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub start_parameter: Option<String>,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SendInvoiceParams {
     pub chat_id: ChatId,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub message_thread_id: Option<i32>,
-
     pub title: String,
-
     pub description: String,
-
     pub payload: String,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub provider_token: Option<String>,
-
     pub currency: String,
-
     pub prices: Vec<LabeledPrice>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub max_tip_amount: Option<u32>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub suggested_tip_amounts: Option<Vec<u32>>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub start_parameter: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub provider_data: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub photo_url: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub photo_size: Option<u32>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub photo_width: Option<u32>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub photo_height: Option<u32>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub need_name: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub need_phone_number: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub need_email: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub need_shipping_address: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub send_phone_number_to_provider: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub send_email_to_provider: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub is_flexible: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub disable_notification: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub protect_content: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub message_effect_id: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub reply_parameters: Option<ReplyParameters>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub reply_markup: Option<InlineKeyboardMarkup>,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct CreateInvoiceLinkParams {
     pub title: String,
-
     pub description: String,
-
     pub payload: String,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub provider_token: Option<String>,
-
     pub currency: String,
-
     pub prices: Vec<LabeledPrice>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub max_tip_amount: Option<u32>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub suggested_tip_amounts: Option<Vec<u32>>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub provider_data: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub photo_url: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub photo_size: Option<u32>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub photo_width: Option<u32>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub photo_height: Option<u32>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub need_name: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub need_phone_number: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub need_email: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub need_shipping_address: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub send_phone_number_to_provider: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub send_email_to_provider: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub is_flexible: Option<bool>,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct AnswerShippingQueryParams {
     pub shipping_query_id: String,
-
     pub ok: bool,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub shipping_options: Option<Vec<ShippingOption>>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub error_message: Option<String>,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct AnswerPreCheckoutQueryParams {
     pub pre_checkout_query_id: String,
-
     pub ok: bool,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub error_message: Option<String>,
 }
 
@@ -2178,7 +1422,6 @@ pub struct GetStarTransactionsParams {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct RefundStarPaymentParams {
     pub user_id: u64,
-
     pub telegram_payment_charge_id: String,
 }
 
@@ -2186,252 +1429,152 @@ pub struct RefundStarPaymentParams {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SetPassportDataErrorsParams {
     pub user_id: u64,
-
     pub errors: Vec<PassportElementError>,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SendGameParams {
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub business_connection_id: Option<String>,
-
     pub chat_id: i64,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub message_thread_id: Option<i32>,
-
     pub game_short_name: String,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub disable_notification: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub protect_content: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub message_effect_id: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub reply_parameters: Option<ReplyParameters>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub reply_markup: Option<InlineKeyboardMarkup>,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SetGameScoreParams {
     pub user_id: u64,
-
     pub score: i32,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub force: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub disable_edit_message: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub chat_id: Option<i64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub message_id: Option<i32>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub inline_message_id: Option<String>,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct GetGameHighScoresParams {
     pub user_id: u64,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub chat_id: Option<i64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub message_id: Option<i32>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub inline_message_id: Option<String>,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct InputMediaPhoto {
     pub media: FileUpload,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub caption: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub parse_mode: Option<ParseMode>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub caption_entities: Option<Vec<MessageEntity>>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub show_caption_above_media: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub has_spoiler: Option<bool>,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct InputMediaVideo {
     pub media: FileUpload,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub thumbnail: Option<FileUpload>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub caption: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub parse_mode: Option<ParseMode>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub caption_entities: Option<Vec<MessageEntity>>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub show_caption_above_media: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub width: Option<u32>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub height: Option<u32>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub duration: Option<u32>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub supports_streaming: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub has_spoiler: Option<bool>,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct InputMediaAnimation {
     pub media: FileUpload,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub thumbnail: Option<FileUpload>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub caption: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub parse_mode: Option<ParseMode>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub caption_entities: Option<Vec<MessageEntity>>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub show_caption_above_media: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub width: Option<u32>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub height: Option<u32>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub duration: Option<u32>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub has_spoiler: Option<bool>,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct InputMediaAudio {
     pub media: FileUpload,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub thumbnail: Option<FileUpload>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub caption: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub parse_mode: Option<ParseMode>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub caption_entities: Option<Vec<MessageEntity>>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub duration: Option<u32>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub performer: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub title: Option<String>,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct InputMediaDocument {
     pub media: FileUpload,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub thumbnail: Option<FileUpload>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub caption: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub parse_mode: Option<ParseMode>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub caption_entities: Option<Vec<MessageEntity>>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub disable_content_type_detection: Option<bool>,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SetMyDefaultAdministratorRightsParams {
     pub rights: ChatAdministratorRights,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub for_channels: Option<bool>,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct GetMyDefaultAdministratorRightsParams {
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub for_channels: Option<bool>,
 }
+
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct AnswerWebAppQueryParams {
     pub web_app_query_id: String,
-
     pub result: InlineQueryResult,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SetChatMenuButtonParams {
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub chat_id: Option<i64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub menu_button: Option<MenuButton>,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct GetChatMenuButtonParams {
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub chat_id: Option<i64>,
 }
 
@@ -2441,26 +1584,15 @@ pub struct UnpinAllGeneralForumTopicMessagesParams {
     pub chat_id: ChatId,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ReplyParameters {
     pub message_id: i32,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub chat_id: Option<ChatId>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub allow_sending_without_reply: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub quote: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub quote_parse_mode: Option<ParseMode>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub quote_entities: Option<Vec<MessageEntity>>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub quote_position: Option<u32>,
 }

--- a/src/api_params.rs
+++ b/src/api_params.rs
@@ -5,7 +5,7 @@ use std::path::PathBuf;
 use macro_rules_attribute::apply;
 use serde::{Deserialize, Serialize};
 
-use crate::macros::serdebuilder;
+use crate::macros::apistruct;
 use crate::objects::{
     AllowedUpdate, BotCommand, ChatAdministratorRights, ChatPermissions, ForceReply,
     InlineKeyboardMarkup, InlineQueryResultArticle, InlineQueryResultAudio,
@@ -200,32 +200,32 @@ pub enum BotCommandScope {
     ChatMember(BotCommandScopeChatMember),
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct BotCommandScopeChat {
     pub chat_id: ChatId,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct BotCommandScopeChatAdministrators {
     pub chat_id: ChatId,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct BotCommandScopeChatMember {
     pub chat_id: ChatId,
     pub user_id: u64,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct InputFile {
     pub path: PathBuf,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct GetUpdatesParams {
     pub offset: Option<i64>,
@@ -234,7 +234,7 @@ pub struct GetUpdatesParams {
     pub allowed_updates: Option<Vec<AllowedUpdate>>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct SetWebhookParams {
     pub url: String,
@@ -246,13 +246,13 @@ pub struct SetWebhookParams {
     pub secret_token: Option<String>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Copy, Eq)]
 pub struct DeleteWebhookParams {
     pub drop_pending_updates: Option<bool>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct SendMessageParams {
     pub business_connection_id: Option<String>,
@@ -269,7 +269,7 @@ pub struct SendMessageParams {
     pub reply_markup: Option<ReplyMarkup>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct ForwardMessageParams {
     pub chat_id: ChatId,
@@ -280,7 +280,7 @@ pub struct ForwardMessageParams {
     pub message_id: i32,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct ForwardMessagesParams {
     pub chat_id: ChatId,
@@ -291,7 +291,7 @@ pub struct ForwardMessagesParams {
     pub protect_content: Option<bool>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct CopyMessageParams {
     pub chat_id: ChatId,
@@ -308,7 +308,7 @@ pub struct CopyMessageParams {
     pub reply_markup: Option<ReplyMarkup>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct CopyMessagesParams {
     pub chat_id: ChatId,
@@ -320,7 +320,7 @@ pub struct CopyMessagesParams {
     pub remove_caption: Option<bool>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct SendPhotoParams {
     pub business_connection_id: Option<String>,
@@ -339,7 +339,7 @@ pub struct SendPhotoParams {
     pub reply_markup: Option<ReplyMarkup>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct SendAudioParams {
     pub business_connection_id: Option<String>,
@@ -360,7 +360,7 @@ pub struct SendAudioParams {
     pub reply_markup: Option<ReplyMarkup>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct SendDocumentParams {
     pub business_connection_id: Option<String>,
@@ -379,7 +379,7 @@ pub struct SendDocumentParams {
     pub reply_markup: Option<ReplyMarkup>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct SendVideoParams {
     pub business_connection_id: Option<String>,
@@ -403,7 +403,7 @@ pub struct SendVideoParams {
     pub reply_markup: Option<ReplyMarkup>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct SendAnimationParams {
     pub business_connection_id: Option<String>,
@@ -426,7 +426,7 @@ pub struct SendAnimationParams {
     pub reply_markup: Option<ReplyMarkup>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct SendVoiceParams {
     pub business_connection_id: Option<String>,
@@ -444,7 +444,7 @@ pub struct SendVoiceParams {
     pub reply_markup: Option<ReplyMarkup>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct SendVideoNoteParams {
     pub business_connection_id: Option<String>,
@@ -461,7 +461,7 @@ pub struct SendVideoNoteParams {
     pub reply_markup: Option<ReplyMarkup>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct SendPaidMediaParams {
     pub business_connection_id: Option<String>,
@@ -479,7 +479,7 @@ pub struct SendPaidMediaParams {
     pub reply_markup: Option<ReplyMarkup>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct SendMediaGroupParams {
     pub business_connection_id: Option<String>,
@@ -492,7 +492,7 @@ pub struct SendMediaGroupParams {
     pub reply_parameters: Option<ReplyParameters>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 pub struct SendLocationParams {
     pub business_connection_id: Option<String>,
     pub chat_id: ChatId,
@@ -510,7 +510,7 @@ pub struct SendLocationParams {
     pub reply_markup: Option<ReplyMarkup>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 pub struct EditMessageLiveLocationParams {
     pub business_connection_id: Option<String>,
     pub chat_id: Option<ChatId>,
@@ -525,7 +525,7 @@ pub struct EditMessageLiveLocationParams {
     pub reply_markup: Option<InlineKeyboardMarkup>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct StopMessageLiveLocationParams {
     pub business_connection_id: Option<String>,
@@ -535,7 +535,7 @@ pub struct StopMessageLiveLocationParams {
     pub reply_markup: Option<InlineKeyboardMarkup>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 pub struct SendVenueParams {
     pub business_connection_id: Option<String>,
     pub chat_id: ChatId,
@@ -555,7 +555,7 @@ pub struct SendVenueParams {
     pub reply_markup: Option<ReplyMarkup>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct SendContactParams {
     pub business_connection_id: Option<String>,
@@ -572,7 +572,7 @@ pub struct SendContactParams {
     pub reply_markup: Option<ReplyMarkup>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct SendPollParams {
     pub business_connection_id: Option<String>,
@@ -601,7 +601,7 @@ pub struct SendPollParams {
     pub reply_markup: Option<ReplyMarkup>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct SendDiceParams {
     pub business_connection_id: Option<String>,
@@ -615,7 +615,7 @@ pub struct SendDiceParams {
     pub reply_markup: Option<ReplyMarkup>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct SendChatActionParams {
     pub business_connection_id: Option<String>,
@@ -624,7 +624,7 @@ pub struct SendChatActionParams {
     pub action: ChatAction,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct SetMessageReactionParams {
     pub chat_id: ChatId,
@@ -633,7 +633,7 @@ pub struct SetMessageReactionParams {
     pub is_big: Option<bool>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Copy, Eq)]
 pub struct GetUserProfilePhotosParams {
     pub user_id: u64,
@@ -641,13 +641,13 @@ pub struct GetUserProfilePhotosParams {
     pub limit: Option<u32>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct GetFileParams {
     pub file_id: String,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct BanChatMemberParams {
     pub chat_id: ChatId,
@@ -656,7 +656,7 @@ pub struct BanChatMemberParams {
     pub revoke_messages: Option<bool>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct UnbanChatMemberParams {
     pub chat_id: ChatId,
@@ -664,7 +664,7 @@ pub struct UnbanChatMemberParams {
     pub only_if_banned: Option<bool>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct RestrictChatMemberParams {
     pub chat_id: ChatId,
@@ -674,7 +674,7 @@ pub struct RestrictChatMemberParams {
     pub until_date: Option<u64>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct PromoteChatMemberParams {
     pub chat_id: ChatId,
@@ -696,7 +696,7 @@ pub struct PromoteChatMemberParams {
     pub can_manage_topics: Option<bool>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct SetChatAdministratorCustomTitleParams {
     pub chat_id: ChatId,
@@ -704,21 +704,21 @@ pub struct SetChatAdministratorCustomTitleParams {
     pub custom_title: String,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct BanChatSenderChatParams {
     pub chat_id: ChatId,
     pub sender_chat_id: i64,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct UnbanChatSenderChatParams {
     pub chat_id: ChatId,
     pub sender_chat_id: i64,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct SetChatPermissionsParams {
     pub chat_id: ChatId,
@@ -726,13 +726,13 @@ pub struct SetChatPermissionsParams {
     pub use_independent_chat_permissions: Option<bool>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct ExportChatInviteLinkParams {
     pub chat_id: ChatId,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct CreateChatInviteLinkParams {
     pub chat_id: ChatId,
@@ -742,7 +742,7 @@ pub struct CreateChatInviteLinkParams {
     pub creates_join_request: Option<bool>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct EditChatInviteLinkParams {
     pub chat_id: ChatId,
@@ -753,7 +753,7 @@ pub struct EditChatInviteLinkParams {
     pub creates_join_request: Option<bool>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct CreateChatSubscriptionInviteLinkParams {
     pub chat_id: ChatId,
@@ -762,7 +762,7 @@ pub struct CreateChatSubscriptionInviteLinkParams {
     pub subscription_price: u16,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct EditChatSubscriptionInviteLinkParams {
     pub chat_id: ChatId,
@@ -770,55 +770,55 @@ pub struct EditChatSubscriptionInviteLinkParams {
     pub name: Option<String>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct RevokeChatInviteLinkParams {
     pub chat_id: ChatId,
     pub invite_link: String,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct ApproveChatJoinRequestParams {
     pub chat_id: ChatId,
     pub user_id: u64,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct DeclineChatJoinRequestParams {
     pub chat_id: ChatId,
     pub user_id: u64,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct SetChatPhotoParams {
     pub chat_id: ChatId,
     pub photo: InputFile,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct DeleteChatPhotoParams {
     pub chat_id: ChatId,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct SetChatTitleParams {
     pub chat_id: ChatId,
     pub title: String,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct SetChatDescriptionParams {
     pub chat_id: ChatId,
     pub description: Option<String>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct PinChatMessageParams {
     pub business_connection_id: Option<String>,
@@ -827,7 +827,7 @@ pub struct PinChatMessageParams {
     pub disable_notification: Option<bool>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct UnpinChatMessageParams {
     pub business_connection_id: Option<String>,
@@ -835,57 +835,57 @@ pub struct UnpinChatMessageParams {
     pub message_id: Option<i32>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct UnpinAllChatMessagesParams {
     pub chat_id: ChatId,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct LeaveChatParams {
     pub chat_id: ChatId,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct GetChatParams {
     pub chat_id: ChatId,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct GetChatAdministratorsParams {
     pub chat_id: ChatId,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct GetChatMemberCountParams {
     pub chat_id: ChatId,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct GetChatMemberParams {
     pub chat_id: ChatId,
     pub user_id: u64,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct SetChatStickerSetParams {
     pub chat_id: ChatId,
     pub sticker_set_name: String,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct DeleteChatStickerSetParams {
     pub chat_id: ChatId,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct CreateForumTopicParams {
     pub chat_id: ChatId,
@@ -894,7 +894,7 @@ pub struct CreateForumTopicParams {
     pub icon_custom_emoji_id: Option<String>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct EditForumTopicParams {
     pub chat_id: ChatId,
@@ -903,66 +903,66 @@ pub struct EditForumTopicParams {
     pub icon_custom_emoji_id: Option<String>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct CloseForumTopicParams {
     pub chat_id: ChatId,
     pub message_thread_id: i32,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct ReopenForumTopicParams {
     pub chat_id: ChatId,
     pub message_thread_id: i32,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct DeleteForumTopicParams {
     pub chat_id: ChatId,
     pub message_thread_id: i32,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct UnpinAllForumTopicMessagesParams {
     pub chat_id: ChatId,
     pub message_thread_id: i32,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct EditGeneralForumTopicParams {
     pub chat_id: ChatId,
     pub name: String,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct CloseGeneralForumTopicParams {
     pub chat_id: ChatId,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct ReopenGeneralForumTopicParams {
     pub chat_id: ChatId,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct HideGeneralForumTopicParams {
     pub chat_id: ChatId,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct UnhideGeneralForumTopicParams {
     pub chat_id: ChatId,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct AnswerCallbackQueryParams {
     pub callback_query_id: String,
@@ -972,20 +972,20 @@ pub struct AnswerCallbackQueryParams {
     pub cache_time: Option<u32>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct GetUserChatBoostsParams {
     pub chat_id: ChatId,
     pub user_id: u64,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct GetBusinessConnectionParams {
     pub business_connection_id: String,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct SetMyCommandsParams {
     pub commands: Vec<BotCommand>,
@@ -993,60 +993,60 @@ pub struct SetMyCommandsParams {
     pub language_code: Option<String>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct SetMyNameParams {
     pub name: Option<String>,
     pub language_code: Option<String>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct GetMyNameParams {
     pub language_code: Option<String>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct SetMyDescriptionParams {
     pub description: Option<String>,
     pub language_code: Option<String>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct GetMyDescriptionParams {
     pub language_code: Option<String>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct SetMyShortDescriptionParams {
     pub short_description: Option<String>,
     pub language_code: Option<String>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct GetMyShortDescriptionParams {
     pub language_code: Option<String>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct GetMyCommandsParams {
     pub scope: Option<BotCommandScope>,
     pub language_code: Option<String>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct DeleteMyCommandsParams {
     pub scope: Option<BotCommandScope>,
     pub language_code: Option<String>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct EditMessageTextParams {
     pub business_connection_id: Option<String>,
@@ -1060,7 +1060,7 @@ pub struct EditMessageTextParams {
     pub reply_markup: Option<InlineKeyboardMarkup>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct EditMessageCaptionParams {
     pub business_connection_id: Option<String>,
@@ -1074,7 +1074,7 @@ pub struct EditMessageCaptionParams {
     pub reply_markup: Option<InlineKeyboardMarkup>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct EditMessageMediaParams {
     pub business_connection_id: Option<String>,
@@ -1085,7 +1085,7 @@ pub struct EditMessageMediaParams {
     pub reply_markup: Option<InlineKeyboardMarkup>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct EditMessageReplyMarkupParams {
     pub business_connection_id: Option<String>,
@@ -1095,7 +1095,7 @@ pub struct EditMessageReplyMarkupParams {
     pub reply_markup: Option<InlineKeyboardMarkup>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct StopPollParams {
     pub business_connection_id: Option<String>,
@@ -1104,21 +1104,21 @@ pub struct StopPollParams {
     pub reply_markup: Option<InlineKeyboardMarkup>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct DeleteMessageParams {
     pub chat_id: ChatId,
     pub message_id: i32,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct DeleteMessagesParams {
     pub chat_id: ChatId,
     pub message_ids: Vec<i32>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct SendStickerParams {
     pub business_connection_id: Option<String>,
@@ -1133,13 +1133,13 @@ pub struct SendStickerParams {
     pub reply_markup: Option<ReplyMarkup>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct GetStickerSetParams {
     pub name: String,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct UploadStickerFileParams {
     pub user_id: u64,
@@ -1147,7 +1147,7 @@ pub struct UploadStickerFileParams {
     pub sticker_format: StickerFormat,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 pub struct CreateNewStickerSetParams {
     pub user_id: u64,
     pub name: String,
@@ -1157,33 +1157,33 @@ pub struct CreateNewStickerSetParams {
     pub needs_repainting: Option<bool>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct GetCustomEmojiStickersParams {
     pub custom_emoji_ids: Vec<String>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 pub struct AddStickerToSetParams {
     pub user_id: u64,
     pub name: String,
     pub sticker: InputSticker,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct SetStickerPositionInSetParams {
     pub sticker: String,
     pub position: u32,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct DeleteStickerFromSetParams {
     pub sticker: String,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 pub struct ReplaceStickerInSetParams {
     pub user_id: u64,
     pub name: String,
@@ -1191,34 +1191,34 @@ pub struct ReplaceStickerInSetParams {
     pub sticker: InputSticker,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct SetStickerEmojiListParams {
     pub sticker: String,
     pub emoji_list: Vec<String>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct SetStickerKeywordsParams {
     pub sticker: String,
     pub keywords: Option<Vec<String>>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 pub struct SetStickerMaskPositionParams {
     pub sticker: String,
     pub mask_position: Option<MaskPosition>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct SetStickerSetTitleParams {
     pub name: String,
     pub title: String,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct SetStickerSetThumbnailParams {
     pub name: String,
@@ -1227,20 +1227,20 @@ pub struct SetStickerSetThumbnailParams {
     pub format: StickerFormat,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct SetCustomEmojiStickerSetThumbnailParams {
     pub name: String,
     pub custom_emoji_id: Option<String>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct DeleteStickerSetParams {
     pub name: String,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 pub struct AnswerInlineQueryParams {
     pub inline_query_id: String,
     pub results: Vec<InlineQueryResult>,
@@ -1250,7 +1250,7 @@ pub struct AnswerInlineQueryParams {
     pub button: Option<InlineQueryResultsButton>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct InlineQueryResultsButton {
     pub text: String,
@@ -1258,7 +1258,7 @@ pub struct InlineQueryResultsButton {
     pub start_parameter: Option<String>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct SendInvoiceParams {
     pub chat_id: ChatId,
@@ -1291,7 +1291,7 @@ pub struct SendInvoiceParams {
     pub reply_markup: Option<InlineKeyboardMarkup>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct CreateInvoiceLinkParams {
     pub title: String,
@@ -1316,7 +1316,7 @@ pub struct CreateInvoiceLinkParams {
     pub is_flexible: Option<bool>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct AnswerShippingQueryParams {
     pub shipping_query_id: String,
@@ -1325,7 +1325,7 @@ pub struct AnswerShippingQueryParams {
     pub error_message: Option<String>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct AnswerPreCheckoutQueryParams {
     pub pre_checkout_query_id: String,
@@ -1333,7 +1333,7 @@ pub struct AnswerPreCheckoutQueryParams {
     pub error_message: Option<String>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct GetStarTransactionsParams {
     offset: u32,
@@ -1341,21 +1341,21 @@ pub struct GetStarTransactionsParams {
     limit: u32,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct RefundStarPaymentParams {
     pub user_id: u64,
     pub telegram_payment_charge_id: String,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct SetPassportDataErrorsParams {
     pub user_id: u64,
     pub errors: Vec<PassportElementError>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct SendGameParams {
     pub business_connection_id: Option<String>,
@@ -1369,7 +1369,7 @@ pub struct SendGameParams {
     pub reply_markup: Option<InlineKeyboardMarkup>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct SetGameScoreParams {
     pub user_id: u64,
@@ -1381,7 +1381,7 @@ pub struct SetGameScoreParams {
     pub inline_message_id: Option<String>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct GetGameHighScoresParams {
     pub user_id: u64,
@@ -1390,7 +1390,7 @@ pub struct GetGameHighScoresParams {
     pub inline_message_id: Option<String>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct InputMediaPhoto {
     pub media: FileUpload,
@@ -1401,7 +1401,7 @@ pub struct InputMediaPhoto {
     pub has_spoiler: Option<bool>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct InputMediaVideo {
     pub media: FileUpload,
@@ -1417,7 +1417,7 @@ pub struct InputMediaVideo {
     pub has_spoiler: Option<bool>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct InputMediaAnimation {
     pub media: FileUpload,
@@ -1432,7 +1432,7 @@ pub struct InputMediaAnimation {
     pub has_spoiler: Option<bool>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct InputMediaAudio {
     pub media: FileUpload,
@@ -1445,7 +1445,7 @@ pub struct InputMediaAudio {
     pub title: Option<String>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct InputMediaDocument {
     pub media: FileUpload,
@@ -1456,45 +1456,45 @@ pub struct InputMediaDocument {
     pub disable_content_type_detection: Option<bool>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct SetMyDefaultAdministratorRightsParams {
     pub rights: ChatAdministratorRights,
     pub for_channels: Option<bool>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct GetMyDefaultAdministratorRightsParams {
     pub for_channels: Option<bool>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 pub struct AnswerWebAppQueryParams {
     pub web_app_query_id: String,
     pub result: InlineQueryResult,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct SetChatMenuButtonParams {
     pub chat_id: Option<i64>,
     pub menu_button: Option<MenuButton>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct GetChatMenuButtonParams {
     pub chat_id: Option<i64>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct UnpinAllGeneralForumTopicMessagesParams {
     pub chat_id: ChatId,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct ReplyParameters {
     pub message_id: i32,

--- a/src/api_params.rs
+++ b/src/api_params.rs
@@ -201,32 +201,32 @@ pub enum BotCommandScope {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct BotCommandScopeChat {
     pub chat_id: ChatId,
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct BotCommandScopeChatAdministrators {
     pub chat_id: ChatId,
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct BotCommandScopeChatMember {
     pub chat_id: ChatId,
     pub user_id: u64,
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct InputFile {
     pub path: PathBuf,
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct GetUpdatesParams {
     pub offset: Option<i64>,
     pub limit: Option<u32>,
@@ -235,7 +235,7 @@ pub struct GetUpdatesParams {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct SetWebhookParams {
     pub url: String,
     pub certificate: Option<InputFile>,
@@ -247,13 +247,13 @@ pub struct SetWebhookParams {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Copy, Eq)]
 pub struct DeleteWebhookParams {
     pub drop_pending_updates: Option<bool>,
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct SendMessageParams {
     pub business_connection_id: Option<String>,
     pub chat_id: ChatId,
@@ -270,7 +270,7 @@ pub struct SendMessageParams {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct ForwardMessageParams {
     pub chat_id: ChatId,
     pub message_thread_id: Option<i32>,
@@ -281,7 +281,7 @@ pub struct ForwardMessageParams {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct ForwardMessagesParams {
     pub chat_id: ChatId,
     pub message_thread_id: Option<i32>,
@@ -292,7 +292,7 @@ pub struct ForwardMessagesParams {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct CopyMessageParams {
     pub chat_id: ChatId,
     pub message_thread_id: Option<i32>,
@@ -309,7 +309,7 @@ pub struct CopyMessageParams {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct CopyMessagesParams {
     pub chat_id: ChatId,
     pub message_thread_id: Option<i32>,
@@ -321,7 +321,7 @@ pub struct CopyMessagesParams {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct SendPhotoParams {
     pub business_connection_id: Option<String>,
     pub chat_id: ChatId,
@@ -340,7 +340,7 @@ pub struct SendPhotoParams {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct SendAudioParams {
     pub business_connection_id: Option<String>,
     pub chat_id: ChatId,
@@ -361,7 +361,7 @@ pub struct SendAudioParams {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct SendDocumentParams {
     pub business_connection_id: Option<String>,
     pub chat_id: ChatId,
@@ -380,7 +380,7 @@ pub struct SendDocumentParams {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct SendVideoParams {
     pub business_connection_id: Option<String>,
     pub chat_id: ChatId,
@@ -404,7 +404,7 @@ pub struct SendVideoParams {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct SendAnimationParams {
     pub business_connection_id: Option<String>,
     pub chat_id: ChatId,
@@ -427,7 +427,7 @@ pub struct SendAnimationParams {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct SendVoiceParams {
     pub business_connection_id: Option<String>,
     pub chat_id: ChatId,
@@ -445,7 +445,7 @@ pub struct SendVoiceParams {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct SendVideoNoteParams {
     pub business_connection_id: Option<String>,
     pub chat_id: ChatId,
@@ -462,7 +462,7 @@ pub struct SendVideoNoteParams {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct SendPaidMediaParams {
     pub business_connection_id: Option<String>,
     pub chat_id: ChatId,
@@ -480,7 +480,7 @@ pub struct SendPaidMediaParams {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct SendMediaGroupParams {
     pub business_connection_id: Option<String>,
     pub chat_id: ChatId,
@@ -493,7 +493,6 @@ pub struct SendMediaGroupParams {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq)]
 pub struct SendLocationParams {
     pub business_connection_id: Option<String>,
     pub chat_id: ChatId,
@@ -512,7 +511,6 @@ pub struct SendLocationParams {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq)]
 pub struct EditMessageLiveLocationParams {
     pub business_connection_id: Option<String>,
     pub chat_id: Option<ChatId>,
@@ -528,7 +526,7 @@ pub struct EditMessageLiveLocationParams {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct StopMessageLiveLocationParams {
     pub business_connection_id: Option<String>,
     pub chat_id: Option<ChatId>,
@@ -538,7 +536,6 @@ pub struct StopMessageLiveLocationParams {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq)]
 pub struct SendVenueParams {
     pub business_connection_id: Option<String>,
     pub chat_id: ChatId,
@@ -559,7 +556,7 @@ pub struct SendVenueParams {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct SendContactParams {
     pub business_connection_id: Option<String>,
     pub chat_id: ChatId,
@@ -576,7 +573,7 @@ pub struct SendContactParams {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct SendPollParams {
     pub business_connection_id: Option<String>,
     pub chat_id: ChatId,
@@ -605,7 +602,7 @@ pub struct SendPollParams {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct SendDiceParams {
     pub business_connection_id: Option<String>,
     pub chat_id: ChatId,
@@ -619,7 +616,7 @@ pub struct SendDiceParams {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct SendChatActionParams {
     pub business_connection_id: Option<String>,
     pub chat_id: ChatId,
@@ -628,7 +625,7 @@ pub struct SendChatActionParams {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct SetMessageReactionParams {
     pub chat_id: ChatId,
     pub message_id: i32,
@@ -637,7 +634,7 @@ pub struct SetMessageReactionParams {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Copy, Eq)]
 pub struct GetUserProfilePhotosParams {
     pub user_id: u64,
     pub offset: Option<u32>,
@@ -645,13 +642,13 @@ pub struct GetUserProfilePhotosParams {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct GetFileParams {
     pub file_id: String,
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct BanChatMemberParams {
     pub chat_id: ChatId,
     pub user_id: u64,
@@ -660,7 +657,7 @@ pub struct BanChatMemberParams {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct UnbanChatMemberParams {
     pub chat_id: ChatId,
     pub user_id: u64,
@@ -668,7 +665,7 @@ pub struct UnbanChatMemberParams {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct RestrictChatMemberParams {
     pub chat_id: ChatId,
     pub user_id: u64,
@@ -678,7 +675,7 @@ pub struct RestrictChatMemberParams {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct PromoteChatMemberParams {
     pub chat_id: ChatId,
     pub user_id: u64,
@@ -700,7 +697,7 @@ pub struct PromoteChatMemberParams {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct SetChatAdministratorCustomTitleParams {
     pub chat_id: ChatId,
     pub user_id: u64,
@@ -708,21 +705,21 @@ pub struct SetChatAdministratorCustomTitleParams {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct BanChatSenderChatParams {
     pub chat_id: ChatId,
     pub sender_chat_id: i64,
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct UnbanChatSenderChatParams {
     pub chat_id: ChatId,
     pub sender_chat_id: i64,
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct SetChatPermissionsParams {
     pub chat_id: ChatId,
     pub permissions: ChatPermissions,
@@ -730,13 +727,13 @@ pub struct SetChatPermissionsParams {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct ExportChatInviteLinkParams {
     pub chat_id: ChatId,
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct CreateChatInviteLinkParams {
     pub chat_id: ChatId,
     pub name: Option<String>,
@@ -746,7 +743,7 @@ pub struct CreateChatInviteLinkParams {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct EditChatInviteLinkParams {
     pub chat_id: ChatId,
     pub invite_link: String,
@@ -757,7 +754,7 @@ pub struct EditChatInviteLinkParams {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct CreateChatSubscriptionInviteLinkParams {
     pub chat_id: ChatId,
     pub name: Option<String>,
@@ -766,7 +763,7 @@ pub struct CreateChatSubscriptionInviteLinkParams {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct EditChatSubscriptionInviteLinkParams {
     pub chat_id: ChatId,
     pub invite_link: String,
@@ -774,55 +771,55 @@ pub struct EditChatSubscriptionInviteLinkParams {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct RevokeChatInviteLinkParams {
     pub chat_id: ChatId,
     pub invite_link: String,
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct ApproveChatJoinRequestParams {
     pub chat_id: ChatId,
     pub user_id: u64,
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct DeclineChatJoinRequestParams {
     pub chat_id: ChatId,
     pub user_id: u64,
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct SetChatPhotoParams {
     pub chat_id: ChatId,
     pub photo: InputFile,
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct DeleteChatPhotoParams {
     pub chat_id: ChatId,
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct SetChatTitleParams {
     pub chat_id: ChatId,
     pub title: String,
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct SetChatDescriptionParams {
     pub chat_id: ChatId,
     pub description: Option<String>,
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct PinChatMessageParams {
     pub business_connection_id: Option<String>,
     pub chat_id: ChatId,
@@ -831,7 +828,7 @@ pub struct PinChatMessageParams {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct UnpinChatMessageParams {
     pub business_connection_id: Option<String>,
     pub chat_id: ChatId,
@@ -839,57 +836,57 @@ pub struct UnpinChatMessageParams {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct UnpinAllChatMessagesParams {
     pub chat_id: ChatId,
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct LeaveChatParams {
     pub chat_id: ChatId,
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct GetChatParams {
     pub chat_id: ChatId,
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct GetChatAdministratorsParams {
     pub chat_id: ChatId,
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct GetChatMemberCountParams {
     pub chat_id: ChatId,
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct GetChatMemberParams {
     pub chat_id: ChatId,
     pub user_id: u64,
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct SetChatStickerSetParams {
     pub chat_id: ChatId,
     pub sticker_set_name: String,
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct DeleteChatStickerSetParams {
     pub chat_id: ChatId,
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct CreateForumTopicParams {
     pub chat_id: ChatId,
     pub name: String,
@@ -898,7 +895,7 @@ pub struct CreateForumTopicParams {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct EditForumTopicParams {
     pub chat_id: ChatId,
     pub message_thread_id: i32,
@@ -907,66 +904,66 @@ pub struct EditForumTopicParams {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct CloseForumTopicParams {
     pub chat_id: ChatId,
     pub message_thread_id: i32,
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct ReopenForumTopicParams {
     pub chat_id: ChatId,
     pub message_thread_id: i32,
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct DeleteForumTopicParams {
     pub chat_id: ChatId,
     pub message_thread_id: i32,
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct UnpinAllForumTopicMessagesParams {
     pub chat_id: ChatId,
     pub message_thread_id: i32,
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct EditGeneralForumTopicParams {
     pub chat_id: ChatId,
     pub name: String,
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct CloseGeneralForumTopicParams {
     pub chat_id: ChatId,
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct ReopenGeneralForumTopicParams {
     pub chat_id: ChatId,
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct HideGeneralForumTopicParams {
     pub chat_id: ChatId,
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct UnhideGeneralForumTopicParams {
     pub chat_id: ChatId,
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct AnswerCallbackQueryParams {
     pub callback_query_id: String,
     pub text: Option<String>,
@@ -976,20 +973,20 @@ pub struct AnswerCallbackQueryParams {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct GetUserChatBoostsParams {
     pub chat_id: ChatId,
     pub user_id: u64,
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct GetBusinessConnectionParams {
     pub business_connection_id: String,
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct SetMyCommandsParams {
     pub commands: Vec<BotCommand>,
     pub scope: Option<BotCommandScope>,
@@ -997,60 +994,60 @@ pub struct SetMyCommandsParams {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct SetMyNameParams {
     pub name: Option<String>,
     pub language_code: Option<String>,
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct GetMyNameParams {
     pub language_code: Option<String>,
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct SetMyDescriptionParams {
     pub description: Option<String>,
     pub language_code: Option<String>,
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct GetMyDescriptionParams {
     pub language_code: Option<String>,
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct SetMyShortDescriptionParams {
     pub short_description: Option<String>,
     pub language_code: Option<String>,
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct GetMyShortDescriptionParams {
     pub language_code: Option<String>,
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct GetMyCommandsParams {
     pub scope: Option<BotCommandScope>,
     pub language_code: Option<String>,
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct DeleteMyCommandsParams {
     pub scope: Option<BotCommandScope>,
     pub language_code: Option<String>,
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct EditMessageTextParams {
     pub business_connection_id: Option<String>,
     pub chat_id: Option<ChatId>,
@@ -1064,7 +1061,7 @@ pub struct EditMessageTextParams {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct EditMessageCaptionParams {
     pub business_connection_id: Option<String>,
     pub chat_id: Option<ChatId>,
@@ -1078,7 +1075,7 @@ pub struct EditMessageCaptionParams {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct EditMessageMediaParams {
     pub business_connection_id: Option<String>,
     pub chat_id: Option<ChatId>,
@@ -1089,7 +1086,7 @@ pub struct EditMessageMediaParams {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct EditMessageReplyMarkupParams {
     pub business_connection_id: Option<String>,
     pub chat_id: Option<ChatId>,
@@ -1099,7 +1096,7 @@ pub struct EditMessageReplyMarkupParams {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct StopPollParams {
     pub business_connection_id: Option<String>,
     pub chat_id: ChatId,
@@ -1108,21 +1105,21 @@ pub struct StopPollParams {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct DeleteMessageParams {
     pub chat_id: ChatId,
     pub message_id: i32,
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct DeleteMessagesParams {
     pub chat_id: ChatId,
     pub message_ids: Vec<i32>,
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct SendStickerParams {
     pub business_connection_id: Option<String>,
     pub chat_id: ChatId,
@@ -1137,13 +1134,13 @@ pub struct SendStickerParams {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct GetStickerSetParams {
     pub name: String,
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct UploadStickerFileParams {
     pub user_id: u64,
     pub sticker: InputFile,
@@ -1151,7 +1148,6 @@ pub struct UploadStickerFileParams {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq)]
 pub struct CreateNewStickerSetParams {
     pub user_id: u64,
     pub name: String,
@@ -1162,13 +1158,12 @@ pub struct CreateNewStickerSetParams {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct GetCustomEmojiStickersParams {
     pub custom_emoji_ids: Vec<String>,
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq)]
 pub struct AddStickerToSetParams {
     pub user_id: u64,
     pub name: String,
@@ -1176,20 +1171,19 @@ pub struct AddStickerToSetParams {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct SetStickerPositionInSetParams {
     pub sticker: String,
     pub position: u32,
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct DeleteStickerFromSetParams {
     pub sticker: String,
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq)]
 pub struct ReplaceStickerInSetParams {
     pub user_id: u64,
     pub name: String,
@@ -1198,35 +1192,34 @@ pub struct ReplaceStickerInSetParams {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct SetStickerEmojiListParams {
     pub sticker: String,
     pub emoji_list: Vec<String>,
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct SetStickerKeywordsParams {
     pub sticker: String,
     pub keywords: Option<Vec<String>>,
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq)]
 pub struct SetStickerMaskPositionParams {
     pub sticker: String,
     pub mask_position: Option<MaskPosition>,
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct SetStickerSetTitleParams {
     pub name: String,
     pub title: String,
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct SetStickerSetThumbnailParams {
     pub name: String,
     pub user_id: u64,
@@ -1235,20 +1228,19 @@ pub struct SetStickerSetThumbnailParams {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct SetCustomEmojiStickerSetThumbnailParams {
     pub name: String,
     pub custom_emoji_id: Option<String>,
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct DeleteStickerSetParams {
     pub name: String,
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq)]
 pub struct AnswerInlineQueryParams {
     pub inline_query_id: String,
     pub results: Vec<InlineQueryResult>,
@@ -1259,7 +1251,7 @@ pub struct AnswerInlineQueryParams {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct InlineQueryResultsButton {
     pub text: String,
     pub web_app: Option<WebAppInfo>,
@@ -1267,7 +1259,7 @@ pub struct InlineQueryResultsButton {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct SendInvoiceParams {
     pub chat_id: ChatId,
     pub message_thread_id: Option<i32>,
@@ -1300,7 +1292,7 @@ pub struct SendInvoiceParams {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct CreateInvoiceLinkParams {
     pub title: String,
     pub description: String,
@@ -1325,7 +1317,7 @@ pub struct CreateInvoiceLinkParams {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct AnswerShippingQueryParams {
     pub shipping_query_id: String,
     pub ok: bool,
@@ -1334,7 +1326,7 @@ pub struct AnswerShippingQueryParams {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct AnswerPreCheckoutQueryParams {
     pub pre_checkout_query_id: String,
     pub ok: bool,
@@ -1342,7 +1334,7 @@ pub struct AnswerPreCheckoutQueryParams {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct GetStarTransactionsParams {
     offset: u32,
 
@@ -1350,21 +1342,21 @@ pub struct GetStarTransactionsParams {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct RefundStarPaymentParams {
     pub user_id: u64,
     pub telegram_payment_charge_id: String,
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct SetPassportDataErrorsParams {
     pub user_id: u64,
     pub errors: Vec<PassportElementError>,
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct SendGameParams {
     pub business_connection_id: Option<String>,
     pub chat_id: i64,
@@ -1378,7 +1370,7 @@ pub struct SendGameParams {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct SetGameScoreParams {
     pub user_id: u64,
     pub score: i32,
@@ -1390,7 +1382,7 @@ pub struct SetGameScoreParams {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct GetGameHighScoresParams {
     pub user_id: u64,
     pub chat_id: Option<i64>,
@@ -1399,7 +1391,7 @@ pub struct GetGameHighScoresParams {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct InputMediaPhoto {
     pub media: FileUpload,
     pub caption: Option<String>,
@@ -1410,7 +1402,7 @@ pub struct InputMediaPhoto {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct InputMediaVideo {
     pub media: FileUpload,
     pub thumbnail: Option<FileUpload>,
@@ -1426,7 +1418,7 @@ pub struct InputMediaVideo {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct InputMediaAnimation {
     pub media: FileUpload,
     pub thumbnail: Option<FileUpload>,
@@ -1441,7 +1433,7 @@ pub struct InputMediaAnimation {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct InputMediaAudio {
     pub media: FileUpload,
     pub thumbnail: Option<FileUpload>,
@@ -1454,7 +1446,7 @@ pub struct InputMediaAudio {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct InputMediaDocument {
     pub media: FileUpload,
     pub thumbnail: Option<FileUpload>,
@@ -1465,46 +1457,45 @@ pub struct InputMediaDocument {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct SetMyDefaultAdministratorRightsParams {
     pub rights: ChatAdministratorRights,
     pub for_channels: Option<bool>,
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct GetMyDefaultAdministratorRightsParams {
     pub for_channels: Option<bool>,
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq)]
 pub struct AnswerWebAppQueryParams {
     pub web_app_query_id: String,
     pub result: InlineQueryResult,
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct SetChatMenuButtonParams {
     pub chat_id: Option<i64>,
     pub menu_button: Option<MenuButton>,
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct GetChatMenuButtonParams {
     pub chat_id: Option<i64>,
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct UnpinAllGeneralForumTopicMessagesParams {
     pub chat_id: ChatId,
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct ReplyParameters {
     pub message_id: i32,
     pub chat_id: Option<ChatId>,

--- a/src/api_params.rs
+++ b/src/api_params.rs
@@ -4,9 +4,8 @@ use std::path::PathBuf;
 
 use macro_rules_attribute::apply;
 use serde::{Deserialize, Serialize};
-use serde_with::skip_serializing_none;
 
-use crate::macros::builder;
+use crate::macros::serdebuilder;
 use crate::objects::{
     AllowedUpdate, BotCommand, ChatAdministratorRights, ChatPermissions, ForceReply,
     InlineKeyboardMarkup, InlineQueryResultArticle, InlineQueryResultAudio,
@@ -201,34 +200,33 @@ pub enum BotCommandScope {
     ChatMember(BotCommandScopeChatMember),
 }
 
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BotCommandScopeChat {
     pub chat_id: ChatId,
 }
 
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BotCommandScopeChatAdministrators {
     pub chat_id: ChatId,
 }
 
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BotCommandScopeChatMember {
     pub chat_id: ChatId,
     pub user_id: u64,
 }
 
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct InputFile {
     pub path: PathBuf,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct GetUpdatesParams {
     pub offset: Option<i64>,
     pub limit: Option<u32>,
@@ -236,9 +234,8 @@ pub struct GetUpdatesParams {
     pub allowed_updates: Option<Vec<AllowedUpdate>>,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SetWebhookParams {
     pub url: String,
     pub certificate: Option<InputFile>,
@@ -249,16 +246,14 @@ pub struct SetWebhookParams {
     pub secret_token: Option<String>,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct DeleteWebhookParams {
     pub drop_pending_updates: Option<bool>,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SendMessageParams {
     pub business_connection_id: Option<String>,
     pub chat_id: ChatId,
@@ -274,9 +269,8 @@ pub struct SendMessageParams {
     pub reply_markup: Option<ReplyMarkup>,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ForwardMessageParams {
     pub chat_id: ChatId,
     pub message_thread_id: Option<i32>,
@@ -286,9 +280,8 @@ pub struct ForwardMessageParams {
     pub message_id: i32,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ForwardMessagesParams {
     pub chat_id: ChatId,
     pub message_thread_id: Option<i32>,
@@ -298,9 +291,8 @@ pub struct ForwardMessagesParams {
     pub protect_content: Option<bool>,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CopyMessageParams {
     pub chat_id: ChatId,
     pub message_thread_id: Option<i32>,
@@ -316,9 +308,8 @@ pub struct CopyMessageParams {
     pub reply_markup: Option<ReplyMarkup>,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CopyMessagesParams {
     pub chat_id: ChatId,
     pub message_thread_id: Option<i32>,
@@ -329,9 +320,8 @@ pub struct CopyMessagesParams {
     pub remove_caption: Option<bool>,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SendPhotoParams {
     pub business_connection_id: Option<String>,
     pub chat_id: ChatId,
@@ -349,9 +339,8 @@ pub struct SendPhotoParams {
     pub reply_markup: Option<ReplyMarkup>,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SendAudioParams {
     pub business_connection_id: Option<String>,
     pub chat_id: ChatId,
@@ -371,9 +360,8 @@ pub struct SendAudioParams {
     pub reply_markup: Option<ReplyMarkup>,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SendDocumentParams {
     pub business_connection_id: Option<String>,
     pub chat_id: ChatId,
@@ -391,9 +379,8 @@ pub struct SendDocumentParams {
     pub reply_markup: Option<ReplyMarkup>,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SendVideoParams {
     pub business_connection_id: Option<String>,
     pub chat_id: ChatId,
@@ -416,9 +403,8 @@ pub struct SendVideoParams {
     pub reply_markup: Option<ReplyMarkup>,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SendAnimationParams {
     pub business_connection_id: Option<String>,
     pub chat_id: ChatId,
@@ -440,9 +426,8 @@ pub struct SendAnimationParams {
     pub reply_markup: Option<ReplyMarkup>,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SendVoiceParams {
     pub business_connection_id: Option<String>,
     pub chat_id: ChatId,
@@ -459,9 +444,8 @@ pub struct SendVoiceParams {
     pub reply_markup: Option<ReplyMarkup>,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SendVideoNoteParams {
     pub business_connection_id: Option<String>,
     pub chat_id: ChatId,
@@ -477,9 +461,8 @@ pub struct SendVideoNoteParams {
     pub reply_markup: Option<ReplyMarkup>,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SendPaidMediaParams {
     pub business_connection_id: Option<String>,
     pub chat_id: ChatId,
@@ -496,9 +479,8 @@ pub struct SendPaidMediaParams {
     pub reply_markup: Option<ReplyMarkup>,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SendMediaGroupParams {
     pub business_connection_id: Option<String>,
     pub chat_id: ChatId,
@@ -510,9 +492,8 @@ pub struct SendMediaGroupParams {
     pub reply_parameters: Option<ReplyParameters>,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct SendLocationParams {
     pub business_connection_id: Option<String>,
     pub chat_id: ChatId,
@@ -530,9 +511,8 @@ pub struct SendLocationParams {
     pub reply_markup: Option<ReplyMarkup>,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct EditMessageLiveLocationParams {
     pub business_connection_id: Option<String>,
     pub chat_id: Option<ChatId>,
@@ -547,9 +527,8 @@ pub struct EditMessageLiveLocationParams {
     pub reply_markup: Option<InlineKeyboardMarkup>,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct StopMessageLiveLocationParams {
     pub business_connection_id: Option<String>,
     pub chat_id: Option<ChatId>,
@@ -558,9 +537,8 @@ pub struct StopMessageLiveLocationParams {
     pub reply_markup: Option<InlineKeyboardMarkup>,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct SendVenueParams {
     pub business_connection_id: Option<String>,
     pub chat_id: ChatId,
@@ -580,9 +558,8 @@ pub struct SendVenueParams {
     pub reply_markup: Option<ReplyMarkup>,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SendContactParams {
     pub business_connection_id: Option<String>,
     pub chat_id: ChatId,
@@ -598,9 +575,8 @@ pub struct SendContactParams {
     pub reply_markup: Option<ReplyMarkup>,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SendPollParams {
     pub business_connection_id: Option<String>,
     pub chat_id: ChatId,
@@ -628,9 +604,8 @@ pub struct SendPollParams {
     pub reply_markup: Option<ReplyMarkup>,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SendDiceParams {
     pub business_connection_id: Option<String>,
     pub chat_id: ChatId,
@@ -643,9 +618,8 @@ pub struct SendDiceParams {
     pub reply_markup: Option<ReplyMarkup>,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SendChatActionParams {
     pub business_connection_id: Option<String>,
     pub chat_id: ChatId,
@@ -653,9 +627,8 @@ pub struct SendChatActionParams {
     pub action: ChatAction,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SetMessageReactionParams {
     pub chat_id: ChatId,
     pub message_id: i32,
@@ -663,24 +636,22 @@ pub struct SetMessageReactionParams {
     pub is_big: Option<bool>,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GetUserProfilePhotosParams {
     pub user_id: u64,
     pub offset: Option<u32>,
     pub limit: Option<u32>,
 }
 
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct GetFileParams {
     pub file_id: String,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BanChatMemberParams {
     pub chat_id: ChatId,
     pub user_id: u64,
@@ -688,18 +659,16 @@ pub struct BanChatMemberParams {
     pub revoke_messages: Option<bool>,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct UnbanChatMemberParams {
     pub chat_id: ChatId,
     pub user_id: u64,
     pub only_if_banned: Option<bool>,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RestrictChatMemberParams {
     pub chat_id: ChatId,
     pub user_id: u64,
@@ -708,9 +677,8 @@ pub struct RestrictChatMemberParams {
     pub until_date: Option<u64>,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PromoteChatMemberParams {
     pub chat_id: ChatId,
     pub user_id: u64,
@@ -731,46 +699,44 @@ pub struct PromoteChatMemberParams {
     pub can_manage_topics: Option<bool>,
 }
 
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SetChatAdministratorCustomTitleParams {
     pub chat_id: ChatId,
     pub user_id: u64,
     pub custom_title: String,
 }
 
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BanChatSenderChatParams {
     pub chat_id: ChatId,
     pub sender_chat_id: i64,
 }
 
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct UnbanChatSenderChatParams {
     pub chat_id: ChatId,
     pub sender_chat_id: i64,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SetChatPermissionsParams {
     pub chat_id: ChatId,
     pub permissions: ChatPermissions,
     pub use_independent_chat_permissions: Option<bool>,
 }
 
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ExportChatInviteLinkParams {
     pub chat_id: ChatId,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CreateChatInviteLinkParams {
     pub chat_id: ChatId,
     pub name: Option<String>,
@@ -779,9 +745,8 @@ pub struct CreateChatInviteLinkParams {
     pub creates_join_request: Option<bool>,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct EditChatInviteLinkParams {
     pub chat_id: ChatId,
     pub invite_link: String,
@@ -791,9 +756,8 @@ pub struct EditChatInviteLinkParams {
     pub creates_join_request: Option<bool>,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CreateChatSubscriptionInviteLinkParams {
     pub chat_id: ChatId,
     pub name: Option<String>,
@@ -801,67 +765,64 @@ pub struct CreateChatSubscriptionInviteLinkParams {
     pub subscription_price: u16,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct EditChatSubscriptionInviteLinkParams {
     pub chat_id: ChatId,
     pub invite_link: String,
     pub name: Option<String>,
 }
 
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RevokeChatInviteLinkParams {
     pub chat_id: ChatId,
     pub invite_link: String,
 }
 
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ApproveChatJoinRequestParams {
     pub chat_id: ChatId,
     pub user_id: u64,
 }
 
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DeclineChatJoinRequestParams {
     pub chat_id: ChatId,
     pub user_id: u64,
 }
 
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SetChatPhotoParams {
     pub chat_id: ChatId,
     pub photo: InputFile,
 }
 
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DeleteChatPhotoParams {
     pub chat_id: ChatId,
 }
 
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SetChatTitleParams {
     pub chat_id: ChatId,
     pub title: String,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SetChatDescriptionParams {
     pub chat_id: ChatId,
     pub description: Option<String>,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PinChatMessageParams {
     pub business_connection_id: Option<String>,
     pub chat_id: ChatId,
@@ -869,68 +830,66 @@ pub struct PinChatMessageParams {
     pub disable_notification: Option<bool>,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct UnpinChatMessageParams {
     pub business_connection_id: Option<String>,
     pub chat_id: ChatId,
     pub message_id: Option<i32>,
 }
 
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct UnpinAllChatMessagesParams {
     pub chat_id: ChatId,
 }
 
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LeaveChatParams {
     pub chat_id: ChatId,
 }
 
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct GetChatParams {
     pub chat_id: ChatId,
 }
 
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct GetChatAdministratorsParams {
     pub chat_id: ChatId,
 }
 
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct GetChatMemberCountParams {
     pub chat_id: ChatId,
 }
 
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct GetChatMemberParams {
     pub chat_id: ChatId,
     pub user_id: u64,
 }
 
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SetChatStickerSetParams {
     pub chat_id: ChatId,
     pub sticker_set_name: String,
 }
 
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DeleteChatStickerSetParams {
     pub chat_id: ChatId,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CreateForumTopicParams {
     pub chat_id: ChatId,
     pub name: String,
@@ -938,9 +897,8 @@ pub struct CreateForumTopicParams {
     pub icon_custom_emoji_id: Option<String>,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct EditForumTopicParams {
     pub chat_id: ChatId,
     pub message_thread_id: i32,
@@ -948,68 +906,67 @@ pub struct EditForumTopicParams {
     pub icon_custom_emoji_id: Option<String>,
 }
 
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CloseForumTopicParams {
     pub chat_id: ChatId,
     pub message_thread_id: i32,
 }
 
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ReopenForumTopicParams {
     pub chat_id: ChatId,
     pub message_thread_id: i32,
 }
 
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DeleteForumTopicParams {
     pub chat_id: ChatId,
     pub message_thread_id: i32,
 }
 
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct UnpinAllForumTopicMessagesParams {
     pub chat_id: ChatId,
     pub message_thread_id: i32,
 }
 
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct EditGeneralForumTopicParams {
     pub chat_id: ChatId,
     pub name: String,
 }
 
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CloseGeneralForumTopicParams {
     pub chat_id: ChatId,
 }
 
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ReopenGeneralForumTopicParams {
     pub chat_id: ChatId,
 }
 
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct HideGeneralForumTopicParams {
     pub chat_id: ChatId,
 }
 
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct UnhideGeneralForumTopicParams {
     pub chat_id: ChatId,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AnswerCallbackQueryParams {
     pub callback_query_id: String,
     pub text: Option<String>,
@@ -1018,92 +975,82 @@ pub struct AnswerCallbackQueryParams {
     pub cache_time: Option<u32>,
 }
 
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct GetUserChatBoostsParams {
     pub chat_id: ChatId,
     pub user_id: u64,
 }
 
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct GetBusinessConnectionParams {
     pub business_connection_id: String,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SetMyCommandsParams {
     pub commands: Vec<BotCommand>,
     pub scope: Option<BotCommandScope>,
     pub language_code: Option<String>,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SetMyNameParams {
     pub name: Option<String>,
     pub language_code: Option<String>,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct GetMyNameParams {
     pub language_code: Option<String>,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SetMyDescriptionParams {
     pub description: Option<String>,
     pub language_code: Option<String>,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct GetMyDescriptionParams {
     pub language_code: Option<String>,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SetMyShortDescriptionParams {
     pub short_description: Option<String>,
     pub language_code: Option<String>,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct GetMyShortDescriptionParams {
     pub language_code: Option<String>,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct GetMyCommandsParams {
     pub scope: Option<BotCommandScope>,
     pub language_code: Option<String>,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DeleteMyCommandsParams {
     pub scope: Option<BotCommandScope>,
     pub language_code: Option<String>,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct EditMessageTextParams {
     pub business_connection_id: Option<String>,
     pub chat_id: Option<ChatId>,
@@ -1116,9 +1063,8 @@ pub struct EditMessageTextParams {
     pub reply_markup: Option<InlineKeyboardMarkup>,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct EditMessageCaptionParams {
     pub business_connection_id: Option<String>,
     pub chat_id: Option<ChatId>,
@@ -1131,9 +1077,8 @@ pub struct EditMessageCaptionParams {
     pub reply_markup: Option<InlineKeyboardMarkup>,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct EditMessageMediaParams {
     pub business_connection_id: Option<String>,
     pub chat_id: Option<ChatId>,
@@ -1143,9 +1088,8 @@ pub struct EditMessageMediaParams {
     pub reply_markup: Option<InlineKeyboardMarkup>,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct EditMessageReplyMarkupParams {
     pub business_connection_id: Option<String>,
     pub chat_id: Option<ChatId>,
@@ -1154,9 +1098,8 @@ pub struct EditMessageReplyMarkupParams {
     pub reply_markup: Option<InlineKeyboardMarkup>,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct StopPollParams {
     pub business_connection_id: Option<String>,
     pub chat_id: ChatId,
@@ -1164,23 +1107,22 @@ pub struct StopPollParams {
     pub reply_markup: Option<InlineKeyboardMarkup>,
 }
 
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DeleteMessageParams {
     pub chat_id: ChatId,
     pub message_id: i32,
 }
 
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DeleteMessagesParams {
     pub chat_id: ChatId,
     pub message_ids: Vec<i32>,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SendStickerParams {
     pub business_connection_id: Option<String>,
     pub chat_id: ChatId,
@@ -1194,23 +1136,22 @@ pub struct SendStickerParams {
     pub reply_markup: Option<ReplyMarkup>,
 }
 
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct GetStickerSetParams {
     pub name: String,
 }
 
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct UploadStickerFileParams {
     pub user_id: u64,
     pub sticker: InputFile,
     pub sticker_format: StickerFormat,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct CreateNewStickerSetParams {
     pub user_id: u64,
     pub name: String,
@@ -1220,35 +1161,35 @@ pub struct CreateNewStickerSetParams {
     pub needs_repainting: Option<bool>,
 }
 
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct GetCustomEmojiStickersParams {
     pub custom_emoji_ids: Vec<String>,
 }
 
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct AddStickerToSetParams {
     pub user_id: u64,
     pub name: String,
     pub sticker: InputSticker,
 }
 
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SetStickerPositionInSetParams {
     pub sticker: String,
     pub position: u32,
 }
 
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DeleteStickerFromSetParams {
     pub sticker: String,
 }
 
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct ReplaceStickerInSetParams {
     pub user_id: u64,
     pub name: String,
@@ -1256,39 +1197,36 @@ pub struct ReplaceStickerInSetParams {
     pub sticker: InputSticker,
 }
 
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SetStickerEmojiListParams {
     pub sticker: String,
     pub emoji_list: Vec<String>,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SetStickerKeywordsParams {
     pub sticker: String,
     pub keywords: Option<Vec<String>>,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct SetStickerMaskPositionParams {
     pub sticker: String,
     pub mask_position: Option<MaskPosition>,
 }
 
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SetStickerSetTitleParams {
     pub name: String,
     pub title: String,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SetStickerSetThumbnailParams {
     pub name: String,
     pub user_id: u64,
@@ -1296,23 +1234,21 @@ pub struct SetStickerSetThumbnailParams {
     pub format: StickerFormat,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SetCustomEmojiStickerSetThumbnailParams {
     pub name: String,
     pub custom_emoji_id: Option<String>,
 }
 
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DeleteStickerSetParams {
     pub name: String,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct AnswerInlineQueryParams {
     pub inline_query_id: String,
     pub results: Vec<InlineQueryResult>,
@@ -1322,18 +1258,16 @@ pub struct AnswerInlineQueryParams {
     pub button: Option<InlineQueryResultsButton>,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct InlineQueryResultsButton {
     pub text: String,
     pub web_app: Option<WebAppInfo>,
     pub start_parameter: Option<String>,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SendInvoiceParams {
     pub chat_id: ChatId,
     pub message_thread_id: Option<i32>,
@@ -1365,9 +1299,8 @@ pub struct SendInvoiceParams {
     pub reply_markup: Option<InlineKeyboardMarkup>,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CreateInvoiceLinkParams {
     pub title: String,
     pub description: String,
@@ -1391,9 +1324,8 @@ pub struct CreateInvoiceLinkParams {
     pub is_flexible: Option<bool>,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AnswerShippingQueryParams {
     pub shipping_query_id: String,
     pub ok: bool,
@@ -1401,40 +1333,38 @@ pub struct AnswerShippingQueryParams {
     pub error_message: Option<String>,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AnswerPreCheckoutQueryParams {
     pub pre_checkout_query_id: String,
     pub ok: bool,
     pub error_message: Option<String>,
 }
 
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct GetStarTransactionsParams {
     offset: u32,
 
     limit: u32,
 }
 
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RefundStarPaymentParams {
     pub user_id: u64,
     pub telegram_payment_charge_id: String,
 }
 
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SetPassportDataErrorsParams {
     pub user_id: u64,
     pub errors: Vec<PassportElementError>,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SendGameParams {
     pub business_connection_id: Option<String>,
     pub chat_id: i64,
@@ -1447,9 +1377,8 @@ pub struct SendGameParams {
     pub reply_markup: Option<InlineKeyboardMarkup>,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SetGameScoreParams {
     pub user_id: u64,
     pub score: i32,
@@ -1460,9 +1389,8 @@ pub struct SetGameScoreParams {
     pub inline_message_id: Option<String>,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct GetGameHighScoresParams {
     pub user_id: u64,
     pub chat_id: Option<i64>,
@@ -1470,9 +1398,8 @@ pub struct GetGameHighScoresParams {
     pub inline_message_id: Option<String>,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct InputMediaPhoto {
     pub media: FileUpload,
     pub caption: Option<String>,
@@ -1482,9 +1409,8 @@ pub struct InputMediaPhoto {
     pub has_spoiler: Option<bool>,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct InputMediaVideo {
     pub media: FileUpload,
     pub thumbnail: Option<FileUpload>,
@@ -1499,9 +1425,8 @@ pub struct InputMediaVideo {
     pub has_spoiler: Option<bool>,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct InputMediaAnimation {
     pub media: FileUpload,
     pub thumbnail: Option<FileUpload>,
@@ -1515,9 +1440,8 @@ pub struct InputMediaAnimation {
     pub has_spoiler: Option<bool>,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct InputMediaAudio {
     pub media: FileUpload,
     pub thumbnail: Option<FileUpload>,
@@ -1529,9 +1453,8 @@ pub struct InputMediaAudio {
     pub title: Option<String>,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct InputMediaDocument {
     pub media: FileUpload,
     pub thumbnail: Option<FileUpload>,
@@ -1541,52 +1464,47 @@ pub struct InputMediaDocument {
     pub disable_content_type_detection: Option<bool>,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SetMyDefaultAdministratorRightsParams {
     pub rights: ChatAdministratorRights,
     pub for_channels: Option<bool>,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct GetMyDefaultAdministratorRightsParams {
     pub for_channels: Option<bool>,
 }
 
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct AnswerWebAppQueryParams {
     pub web_app_query_id: String,
     pub result: InlineQueryResult,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SetChatMenuButtonParams {
     pub chat_id: Option<i64>,
     pub menu_button: Option<MenuButton>,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct GetChatMenuButtonParams {
     pub chat_id: Option<i64>,
 }
 
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct UnpinAllGeneralForumTopicMessagesParams {
     pub chat_id: ChatId,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ReplyParameters {
     pub message_id: i32,
     pub chat_id: Option<ChatId>,

--- a/src/api_params.rs
+++ b/src/api_params.rs
@@ -2,10 +2,9 @@
 
 use std::path::PathBuf;
 
-use macro_rules_attribute::apply;
 use serde::{Deserialize, Serialize};
 
-use crate::macros::apistruct;
+use crate::macros::{apistruct, apply};
 use crate::objects::{
     AllowedUpdate, BotCommand, ChatAdministratorRights, ChatPermissions, ForceReply,
     InlineKeyboardMarkup, InlineQueryResultArticle, InlineQueryResultAudio,

--- a/src/api_params.rs
+++ b/src/api_params.rs
@@ -180,7 +180,7 @@ pub enum ChatAction {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(tag = "type", rename_all = "lowercase")]
+#[serde(tag = "type", rename_all = "snake_case")]
 pub enum Media {
     Audio(InputMediaAudio),
     Document(InputMediaDocument),

--- a/src/api_params.rs
+++ b/src/api_params.rs
@@ -582,7 +582,6 @@ pub struct SendPollParams {
     pub question_entities: Option<Vec<MessageEntity>>,
     pub options: Vec<InputPollOption>,
     pub is_anonymous: Option<bool>,
-
     #[serde(rename = "type")]
     pub type_field: Option<PollType>,
     pub allows_multiple_answers: Option<bool>,

--- a/src/api_params.rs
+++ b/src/api_params.rs
@@ -97,40 +97,27 @@ pub enum InlineQueryResult {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(tag = "type")]
+#[serde(tag = "type", rename_all = "snake_case")]
 pub enum InputMedia {
-    #[serde(rename = "animation")]
     Animation(InputMediaAnimation),
-    #[serde(rename = "document")]
     Document(InputMediaDocument),
-    #[serde(rename = "audio")]
     Audio(InputMediaAudio),
-    #[serde(rename = "photo")]
     Photo(InputMediaPhoto),
-    #[serde(rename = "video")]
     Video(InputMediaVideo),
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(tag = "source")]
+#[serde(tag = "source", rename_all = "snake_case")]
 pub enum PassportElementError {
     #[serde(rename = "data")]
     DataField(PassportElementErrorDataField),
-    #[serde(rename = "front_side")]
     FrontSide(PassportElementErrorFrontSide),
-    #[serde(rename = "reverse_side")]
     ReverseSide(PassportElementErrorReverseSide),
-    #[serde(rename = "selfie")]
     Selfie(PassportElementErrorSelfie),
-    #[serde(rename = "file")]
     File(PassportElementErrorFile),
-    #[serde(rename = "files")]
     Files(PassportElementErrorFiles),
-    #[serde(rename = "translation_file")]
     TranslationFile(PassportElementErrorTranslationFile),
-    #[serde(rename = "translation_files")]
     TranslationFiles(PassportElementErrorTranslationFiles),
-    #[serde(rename = "unspecified")]
     Unspecified(PassportElementErrorUnspecified),
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,7 @@ mod client_ureq;
 mod error;
 #[cfg(any(feature = "http-client", feature = "async-http-client"))]
 mod json;
+mod macros;
 pub mod objects;
 mod parse_mode;
 pub mod response;
@@ -34,8 +35,6 @@ pub mod response;
 mod trait_async;
 #[cfg(feature = "telegram-trait")]
 mod trait_sync;
-
-mod macros;
 
 /// Default Bot API URL
 pub const BASE_API_URL: &str = "https://api.telegram.org/bot";

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,3 +1,5 @@
+pub use macro_rules_attribute::apply;
+
 macro_rules_attribute::attribute_alias! {
     // Enable [`bon::builder`] `into` for specific types to reduce boilerplate for the callers.
     #[apply(apistruct!)] =

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,9 +1,8 @@
 macro_rules_attribute::attribute_alias! {
     // Enable [`bon::builder`] `into` for specific types to reduce boilerplate for the callers.
-    // Keep [`PartialEq`] and [`Clone`] out of it as [`Copy`] / [`Eq`] might also exist.
     #[apply(serdebuilder!)] =
         #[::serde_with::skip_serializing_none]
-        #[derive(::bon::Builder, ::serde::Serialize, ::serde::Deserialize)]
+        #[derive(Clone, Debug, PartialEq, ::bon::Builder, ::serde::Serialize, ::serde::Deserialize)]
         #[builder(
             on(String, into),
             on(ChatId, into),

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,10 +1,9 @@
 macro_rules_attribute::attribute_alias! {
-    // Shared configuration for all builder derives. Make sure to add them to
-    // all API types.
-    //
-    // We enable `into` for specific types to reduce boilerplate for the callers.
-    #[apply(builder!)] =
-        #[derive(::bon::Builder)]
+    // Enable [`bon::builder`] `into` for specific types to reduce boilerplate for the callers.
+    // Keep [`PartialEq`] and [`Clone`] out of it as [`Copy`] / [`Eq`] might also exist.
+    #[apply(serdebuilder!)] =
+        #[::serde_with::skip_serializing_none]
+        #[derive(::bon::Builder, ::serde::Serialize, ::serde::Deserialize)]
         #[builder(
             on(String, into),
             on(ChatId, into),

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,6 +1,6 @@
 macro_rules_attribute::attribute_alias! {
     // Enable [`bon::builder`] `into` for specific types to reduce boilerplate for the callers.
-    #[apply(serdebuilder!)] =
+    #[apply(apistruct!)] =
         #[::serde_with::skip_serializing_none]
         #[derive(Clone, Debug, PartialEq, ::bon::Builder, ::serde::Serialize, ::serde::Deserialize)]
         #[builder(

--- a/src/objects.rs
+++ b/src/objects.rs
@@ -1339,7 +1339,6 @@ pub struct Story {
 pub struct StickerSet {
     pub name: String,
     pub title: String,
-    #[serde(rename = "sticker_type")]
     pub sticker_type: StickerType,
     #[doc(hidden)]
     #[deprecated(since = "0.19.2", note = "Please use `sticker_type` instead")]

--- a/src/objects.rs
+++ b/src/objects.rs
@@ -4,6 +4,7 @@
 
 use macro_rules_attribute::apply;
 use serde::{Deserialize, Serialize};
+use serde_with::skip_serializing_none;
 
 use crate::api_params::FileUpload;
 use crate::macros::builder;
@@ -195,75 +196,47 @@ pub enum BackgroundFill {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct MenuButtonWebApp {
     pub text: String,
-
     pub web_app: WebAppInfo,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ChatMemberOwner {
     pub user: User,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub custom_title: Option<String>,
-
     pub is_anonymous: bool,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ChatMemberAdministrator {
     pub user: User,
-
     pub can_be_edited: bool,
-
     pub is_anonymous: bool,
-
     pub can_manage_chat: bool,
-
     pub can_delete_messages: bool,
-
     pub can_manage_video_chats: bool,
-
     pub can_restrict_members: bool,
-
     pub can_promote_members: bool,
-
     pub can_change_info: bool,
-
     pub can_invite_users: bool,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub can_post_messages: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub can_edit_messages: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub can_pin_messages: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub can_post_stories: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub can_edit_stories: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub can_delete_stories: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub can_manage_topics: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub custom_title: Option<String>,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ChatMemberMember {
     pub user: User,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub until_date: Option<u64>,
 }
 
@@ -271,37 +244,21 @@ pub struct ChatMemberMember {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ChatMemberRestricted {
     pub user: User,
-
     pub is_member: bool,
-
     pub can_send_messages: bool,
-
     pub can_send_audios: bool,
-
     pub can_send_documents: bool,
-
     pub can_send_photos: bool,
-
     pub can_send_videos: bool,
-
     pub can_send_video_notes: bool,
-
     pub can_send_voice_notes: bool,
-
     pub can_send_polls: bool,
-
     pub can_send_other_messages: bool,
-
     pub can_add_web_page_previews: bool,
-
     pub can_change_info: bool,
-
     pub can_invite_users: bool,
-
     pub can_pin_messages: bool,
-
     pub can_manage_topics: bool,
-
     pub until_date: u64,
 }
 
@@ -310,11 +267,11 @@ pub struct ChatMemberRestricted {
 pub struct ChatMemberLeft {
     pub user: User,
 }
+
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ChatMemberBanned {
     pub user: User,
-
     pub until_date: u64,
 }
 
@@ -390,31 +347,18 @@ pub enum UpdateContent {
     PurchasedPaidMedia(PaidMediaPurchased),
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct WebhookInfo {
     pub url: String,
-
     pub has_custom_certificate: bool,
-
     pub pending_update_count: u32,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub ip_address: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub last_error_date: Option<u64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub last_error_message: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub last_synchronization_error_date: Option<u64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub max_connections: Option<u16>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub allowed_updates: Option<Vec<AllowedUpdate>>,
 }
 
@@ -445,46 +389,26 @@ pub enum AllowedUpdate {
     RemovedChatBoost,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct User {
     pub id: u64,
-
     pub is_bot: bool,
-
     pub first_name: String,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub last_name: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub username: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub language_code: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub is_premium: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub added_to_attachment_menu: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub can_join_groups: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub can_read_all_group_messages: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub supports_inline_queries: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub can_connect_to_business: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub has_main_web_app: Option<bool>,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Chat {
@@ -492,23 +416,14 @@ pub struct Chat {
 
     #[serde(rename = "type")]
     pub type_field: ChatType,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub title: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub username: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub first_name: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub last_name: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub is_forum: Option<bool>,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct ChatFullInfo {
@@ -516,387 +431,138 @@ pub struct ChatFullInfo {
 
     #[serde(rename = "type")]
     pub type_field: ChatType,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub title: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub username: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub first_name: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub last_name: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub is_forum: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub photo: Option<ChatPhoto>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub active_usernames: Option<Vec<String>>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub birthdate: Option<Birthdate>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub business_intro: Option<BusinessIntro>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub business_location: Option<BusinessLocation>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub business_opening_hours: Option<BusinessOpeningHours>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub personal_chat: Option<Box<Chat>>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub available_reactions: Option<Vec<ReactionType>>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub accent_color_id: Option<u16>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub max_reaction_count: Option<u16>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub background_custom_emoji_id: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub profile_accent_color_id: Option<u16>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub profile_background_custom_emoji_id: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub emoji_status_custom_emoji_id: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub emoji_status_expiration_date: Option<u32>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub bio: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub has_private_forwards: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub has_restricted_voice_and_video_messages: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub join_to_send_messages: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub join_by_request: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub invite_link: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub pinned_message: Option<Box<Message>>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub permissions: Option<ChatPermissions>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub can_send_paid_media: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub slow_mode_delay: Option<u16>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub unrestrict_boost_count: Option<u32>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub message_auto_delete_time: Option<u32>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub has_aggressive_anti_spam_enabled: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub has_hidden_members: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub has_protected_content: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub has_visible_history: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub sticker_set_name: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub can_set_sticker_set: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub custom_emoji_sticker_set_name: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub linked_chat_id: Option<i64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub location: Option<ChatLocation>,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct Message {
     pub message_id: i32,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub message_thread_id: Option<i32>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub from: Option<Box<User>>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub sender_chat: Option<Box<Chat>>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub sender_boost_count: Option<u32>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub sender_business_bot: Option<Box<User>>,
-
     pub date: u64,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub business_connection_id: Option<String>,
-
     pub chat: Box<Chat>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub forward_origin: Option<Box<MessageOrigin>>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub is_topic_message: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub is_automatic_forward: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub reply_to_message: Option<Box<Message>>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub external_reply: Option<Box<ExternalReplyInfo>>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub quote: Option<Box<TextQuote>>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub reply_to_story: Option<Box<Story>>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub via_bot: Option<Box<User>>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub edit_date: Option<u64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub has_protected_content: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub is_from_offline: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub media_group_id: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub author_signature: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub text: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub entities: Option<Vec<MessageEntity>>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub link_preview_options: Option<LinkPreviewOptions>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub effect_id: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub animation: Option<Box<Animation>>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub audio: Option<Box<Audio>>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub document: Option<Box<Document>>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub paid_media: Option<Box<PaidMediaInfo>>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub photo: Option<Vec<PhotoSize>>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub sticker: Option<Box<Sticker>>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub story: Option<Box<Story>>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub video: Option<Box<Video>>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub video_note: Option<Box<VideoNote>>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub voice: Option<Box<Voice>>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub caption: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub caption_entities: Option<Vec<MessageEntity>>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub show_caption_above_media: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub has_media_spoiler: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub contact: Option<Box<Contact>>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub dice: Option<Box<Dice>>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub game: Option<Box<Game>>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub poll: Option<Box<Poll>>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub venue: Option<Box<Venue>>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub location: Option<Box<Location>>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub new_chat_members: Option<Vec<User>>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub left_chat_member: Option<Box<User>>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub new_chat_title: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub new_chat_photo: Option<Vec<PhotoSize>>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub delete_chat_photo: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub group_chat_created: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub supergroup_chat_created: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub channel_chat_created: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub message_auto_delete_timer_changed: Option<Box<MessageAutoDeleteTimerChanged>>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub migrate_to_chat_id: Option<i64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub migrate_from_chat_id: Option<i64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub pinned_message: Option<Box<MaybeInaccessibleMessage>>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub invoice: Option<Box<Invoice>>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub successful_payment: Option<Box<SuccessfulPayment>>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub refunded_payment: Option<Box<RefundedPayment>>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub users_shared: Option<Box<UsersShared>>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub chat_shared: Option<Box<ChatShared>>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub connected_website: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub write_access_allowed: Option<WriteAccessAllowed>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub passport_data: Option<Box<PassportData>>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub proximity_alert_triggered: Option<Box<ProximityAlertTriggered>>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub boost_added: Option<Box<ChatBoostAdded>>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub chat_background_set: Option<Box<ChatBackground>>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub forum_topic_created: Option<Box<ForumTopicCreated>>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub forum_topic_edited: Option<Box<ForumTopicEdited>>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub forum_topic_closed: Option<Box<ForumTopicClosed>>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub forum_topic_reopened: Option<Box<ForumTopicReopened>>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub general_forum_topic_hidden: Option<Box<GeneralForumTopicHidden>>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub general_forum_topic_unhidden: Option<Box<GeneralForumTopicUnhidden>>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub giveaway_created: Option<GiveawayCreated>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub giveaway: Option<Giveaway>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub giveaway_winners: Option<GiveawayWinners>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub giveaway_completed: Option<GiveawayCompleted>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub video_chat_started: Option<Box<VideoChatStarted>>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub video_chat_ended: Option<Box<VideoChatEnded>>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub video_chat_scheduled: Option<Box<VideoChatScheduled>>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub video_chat_participants_invited: Option<Box<VideoChatParticipantsInvited>>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub web_app_data: Option<Box<WebAppData>>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub reply_markup: Option<Box<InlineKeyboardMarkup>>,
 }
 
@@ -906,116 +572,57 @@ pub struct MessageId {
     pub message_id: i32,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct MessageEntity {
     #[serde(rename = "type")]
     pub type_field: MessageEntityType,
-
     pub offset: u16,
-
     pub length: u16,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub url: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub user: Option<User>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub language: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub custom_emoji_id: Option<String>,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct TextQuote {
     pub text: String,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub entities: Option<Vec<MessageEntity>>,
-
     pub position: u32,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub is_manual: Option<bool>,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct ExternalReplyInfo {
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub origin: Option<MessageOrigin>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub chat: Option<Chat>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub message_id: Option<i32>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub link_preview_options: Option<LinkPreviewOptions>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub animation: Option<Animation>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub audio: Option<Audio>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub document: Option<Document>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub paid_media: Option<PaidMediaInfo>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub photo: Option<Vec<PhotoSize>>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub sticker: Option<Sticker>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub story: Option<Story>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub video: Option<Video>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub video_note: Option<VideoNote>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub voice: Option<Voice>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub has_media_spoiler: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub contact: Option<Contact>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub dice: Option<Dice>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub game: Option<Game>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub giveaway: Option<Giveaway>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub giveaway_winners: Option<GiveawayWinners>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub invoice: Option<Invoice>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub location: Option<Location>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub poll: Option<Poll>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub venue: Option<Venue>,
 }
 
@@ -1042,212 +649,135 @@ pub struct MessageOriginHiddenUser {
     pub sender_user_name: String,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct MessageOriginChat {
     pub date: u64,
-
     pub sender_chat: Chat,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub author_signature: Option<String>,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct MessageOriginChannel {
     pub date: u64,
-
     pub chat: Chat,
-
     pub message_id: i32,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub author_signature: Option<String>,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct LinkPreviewOptions {
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub is_disabled: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub url: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub prefer_small_media: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub prefer_large_media: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub show_above_text: Option<bool>,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct PhotoSize {
     pub file_id: String,
-
     pub file_unique_id: String,
-
     pub width: u32,
-
     pub height: u32,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub file_size: Option<u64>,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Animation {
     pub file_id: String,
-
     pub file_unique_id: String,
-
     pub width: u32,
-
     pub height: u32,
-
     pub duration: u32,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub thumbnail: Option<PhotoSize>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub file_name: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub mime_type: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub file_size: Option<u64>,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Audio {
     pub file_id: String,
-
     pub file_unique_id: String,
-
     pub duration: u32,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub performer: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub title: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub file_name: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub mime_type: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub file_size: Option<u64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub thumbnail: Option<PhotoSize>,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Document {
     pub file_id: String,
-
     pub file_unique_id: String,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub thumbnail: Option<PhotoSize>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub file_name: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub mime_type: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub file_size: Option<u64>,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Video {
     pub file_id: String,
-
     pub file_unique_id: String,
-
     pub width: u32,
-
     pub height: u32,
-
     pub duration: u32,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub thumbnail: Option<PhotoSize>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub file_name: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub mime_type: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub file_size: Option<u64>,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct VideoNote {
     pub file_id: String,
-
     pub file_unique_id: String,
-
     pub length: u32,
-
     pub duration: u32,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub thumbnail: Option<PhotoSize>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub file_size: Option<u64>,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Voice {
     pub file_id: String,
-
     pub file_unique_id: String,
-
     pub duration: u32,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub mime_type: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub file_size: Option<u64>,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Contact {
     pub phone_number: String,
-
     pub first_name: String,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub last_name: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub user_id: Option<u64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub vcard: Option<String>,
 }
 
@@ -1255,125 +785,81 @@ pub struct Contact {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Dice {
     pub emoji: String,
-
     pub value: u8,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct PollOption {
     pub text: String,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub text_entities: Option<Vec<MessageEntity>>,
-
     pub voter_count: u32,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct InputPollOption {
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub text: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub text_parse_mode: Option<ParseMode>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub text_entities: Option<Vec<MessageEntity>>,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct PollAnswer {
     pub poll_id: String,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub voter_chat: Option<Chat>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub user: Option<Box<User>>,
-
     pub option_ids: Vec<u8>,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Poll {
     pub id: String,
-
     pub question: String,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub question_entities: Option<Vec<MessageEntity>>,
-
     pub options: Vec<PollOption>,
-
     pub total_voter_count: u32,
-
     pub is_closed: bool,
-
     pub is_anonymous: bool,
+
     #[serde(rename = "type")]
     pub type_field: PollType,
-
     pub allows_multiple_answers: bool,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub correct_option_id: Option<u8>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub explanation: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub explanation_entities: Option<Vec<MessageEntity>>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub open_period: Option<u32>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub close_date: Option<u64>,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]
 pub struct Location {
     pub longitude: f64,
-
     pub latitude: f64,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub horizontal_accuracy: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub live_period: Option<u32>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub heading: Option<u16>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub proximity_alert_radius: Option<u32>,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct Venue {
     pub location: Location,
-
     pub title: String,
-
     pub address: String,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub foursquare_id: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub foursquare_type: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub google_place_id: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub google_place_type: Option<String>,
 }
 
@@ -1381,9 +867,7 @@ pub struct Venue {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ProximityAlertTriggered {
     pub traveler: User,
-
     pub watcher: User,
-
     pub distance: u32,
 }
 
@@ -1409,9 +893,7 @@ pub struct BackgroundFillSolid {
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 pub struct BackgroundFillGradient {
     pub top_color: u32,
-
     pub bottom_color: u32,
-
     pub rotation_angle: u16,
 }
 
@@ -1425,37 +907,27 @@ pub struct BackgroundFillFreeformGradient {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct BackgroundTypeFill {
     pub fill: BackgroundFill,
-
     pub dark_theme_dimming: u8,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct BackgroundTypeWallpaper {
     pub document: Document,
-
     pub dark_theme_dimming: u8,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub is_blurred: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub is_moving: Option<bool>,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct BackgroundTypePattern {
     pub document: Document,
-
     pub fill: BackgroundFill,
-
     pub intensity: u8,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub is_inverted: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub is_moving: Option<bool>,
 }
 
@@ -1465,14 +937,12 @@ pub struct BackgroundTypeChatTheme {
     pub theme_name: String,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ForumTopicCreated {
     pub name: String,
-
     pub icon_color: u32,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub icon_custom_emoji_id: Option<String>,
 }
 
@@ -1480,13 +950,11 @@ pub struct ForumTopicCreated {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ForumTopicClosed {}
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ForumTopicEdited {
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub icon_custom_emoji_id: Option<String>,
 }
 
@@ -1502,21 +970,14 @@ pub struct GeneralForumTopicHidden {}
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct GeneralForumTopicUnhidden {}
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SharedUser {
     pub user_id: u64,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub first_name: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub last_name: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub username: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub photo: Option<Vec<PhotoSize>>,
 }
 
@@ -1524,37 +985,26 @@ pub struct SharedUser {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct UsersShared {
     pub request_id: i32,
-
     pub users: Vec<SharedUser>,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ChatShared {
     pub request_id: i32,
-
     pub chat_id: i64,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub title: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub username: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub photo: Option<Vec<PhotoSize>>,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct WriteAccessAllowed {
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub from_request: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub web_app_name: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub from_attachment_menu: Option<bool>,
 }
 
@@ -1564,10 +1014,10 @@ pub struct VideoChatEnded {
     pub duration: u32,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct VideoChatParticipantsInvited {
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub users: Option<Vec<User>>,
 }
 
@@ -1575,142 +1025,87 @@ pub struct VideoChatParticipantsInvited {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct UserProfilePhotos {
     pub total_count: u32,
-
     pub photos: Vec<Vec<PhotoSize>>,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct File {
     pub file_id: String,
-
     pub file_unique_id: String,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub file_size: Option<u64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub file_path: Option<String>,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ReplyKeyboardMarkup {
     pub keyboard: Vec<Vec<KeyboardButton>>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub is_persistent: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub resize_keyboard: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub one_time_keyboard: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub input_field_placeholder: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub selective: Option<bool>,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct KeyboardButton {
     pub text: String,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub request_users: Option<KeyboardButtonRequestUsers>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub request_chat: Option<KeyboardButtonRequestChat>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub request_contact: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub request_location: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub request_poll: Option<KeyboardButtonPollType>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub web_app: Option<WebAppInfo>,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct KeyboardButtonRequestUsers {
     pub request_id: i32,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub user_is_bot: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub user_is_premium: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub max_quantity: Option<u32>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub request_name: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub request_username: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub request_photo: Option<bool>,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct KeyboardButtonRequestChat {
     pub request_id: i32,
-
     pub chat_is_channel: bool,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub chat_is_forum: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub chat_has_username: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub chat_is_created: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub user_administrator_rights: Option<ChatAdministratorRights>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub bot_administrator_rights: Option<ChatAdministratorRights>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub bot_is_member: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub request_title: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub request_username: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub request_photo: Option<bool>,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 pub struct KeyboardButtonPollType {
     #[serde(rename = "type")]
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub type_field: Option<PollType>,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ReplyKeyboardRemove {
     pub remove_keyboard: bool,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub selective: Option<bool>,
 }
 
@@ -1720,104 +1115,62 @@ pub struct InlineKeyboardMarkup {
     pub inline_keyboard: Vec<Vec<InlineKeyboardButton>>,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct InlineKeyboardButton {
     pub text: String,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub url: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub login_url: Option<LoginUrl>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub callback_data: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub web_app: Option<WebAppInfo>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub switch_inline_query: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub switch_inline_query_current_chat: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub switch_inline_query_chosen_chat: Option<SwitchInlineQueryChosenChat>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub callback_game: Option<CallbackGame>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub pay: Option<bool>,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct LoginUrl {
     pub url: String,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub forward_text: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub bot_username: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub request_write_access: Option<bool>,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SwitchInlineQueryChosenChat {
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub query: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub allow_user_chats: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub allow_bot_chats: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub allow_group_chats: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub allow_channel_chats: Option<bool>,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct CallbackQuery {
     pub id: String,
-
     pub from: User,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub message: Option<MaybeInaccessibleMessage>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub inline_message_id: Option<String>,
-
     pub chat_instance: String,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub data: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub game_short_name: Option<String>,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ForceReply {
     pub force_reply: bool,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub input_field_placeholder: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub selective: Option<bool>,
 }
 
@@ -1825,124 +1178,69 @@ pub struct ForceReply {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ChatPhoto {
     pub small_file_id: String,
-
     pub small_file_unique_id: String,
-
     pub big_file_id: String,
-
     pub big_file_unique_id: String,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ChatInviteLink {
     pub invite_link: String,
-
     pub creator: User,
-
     pub creates_join_request: bool,
-
     pub is_primary: bool,
-
     pub is_revoked: bool,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub expire_date: Option<u64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub member_limit: Option<u32>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub pending_join_request_count: Option<u32>,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ChatMemberUpdated {
     pub chat: Chat,
-
     pub from: User,
-
     pub date: u64,
-
     pub old_chat_member: ChatMember,
-
     pub new_chat_member: ChatMember,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub invite_link: Option<ChatInviteLink>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub via_join_request: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub via_chat_folder_invite_link: Option<bool>,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ChatJoinRequest {
     pub chat: Chat,
-
     pub from: User,
-
     pub user_chat_id: u64,
-
     pub date: u64,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub bio: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub invite_link: Option<ChatInviteLink>,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ChatPermissions {
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub can_send_messages: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub can_send_audios: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub can_send_documents: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub can_send_photos: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub can_send_videos: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub can_send_video_notes: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub can_send_voice_notes: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub can_send_polls: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub can_send_other_messages: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub can_add_web_page_previews: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub can_change_info: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub can_invite_users: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub can_pin_messages: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub can_manage_topics: Option<bool>,
 }
 
@@ -1950,31 +1248,24 @@ pub struct ChatPermissions {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Birthdate {
     pub day: u8,
-
     pub month: u8,
-
     pub year: u16,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct BusinessIntro {
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub title: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub message: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub sticker: Option<Sticker>,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct BusinessLocation {
     pub address: String,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub location: Option<Location>,
 }
 
@@ -1982,7 +1273,6 @@ pub struct BusinessLocation {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct BusinessOpeningHoursInterval {
     pub opening_minute: u16,
-
     pub closing_minute: u16,
 }
 
@@ -1990,7 +1280,6 @@ pub struct BusinessOpeningHoursInterval {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct BusinessOpeningHours {
     pub time_zone_name: String,
-
     pub opening_hours: Vec<BusinessOpeningHoursInterval>,
 }
 
@@ -1998,7 +1287,6 @@ pub struct BusinessOpeningHours {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct ChatLocation {
     pub location: Location,
-
     pub address: String,
 }
 
@@ -2031,27 +1319,19 @@ pub struct ReactionTypePaid {}
 pub struct ReactionCount {
     #[serde(rename = "type")]
     pub type_field: ReactionType,
-
     pub total_count: i32,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct MessageReactionUpdated {
     pub chat: Chat,
-
     pub message_id: i32,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub user: Option<User>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub actor_chat: Option<Chat>,
-
     pub date: u64,
-
     pub old_reaction: Vec<ReactionType>,
-
     pub new_reaction: Vec<ReactionType>,
 }
 
@@ -2059,24 +1339,18 @@ pub struct MessageReactionUpdated {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct MessageReactionCountUpdated {
     pub chat: Chat,
-
     pub message_id: i32,
-
     pub date: u64,
-
     pub reactions: Vec<ReactionCount>,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
 pub struct ForumTopic {
     pub message_thread_id: i32,
-
     pub name: String,
-
     pub icon_color: u32,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub icon_custom_emoji_id: Option<String>,
 }
 
@@ -2084,74 +1358,48 @@ pub struct ForumTopic {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct BotCommand {
     pub command: String,
-
     pub description: String,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ResponseParameters {
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub migrate_to_chat_id: Option<i64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub retry_after: Option<u16>,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct Sticker {
     pub file_id: String,
-
     pub file_unique_id: String,
 
     #[serde(rename = "type")]
     pub sticker_type: StickerType,
-
     pub width: u32,
-
     pub height: u32,
-
     pub is_animated: bool,
-
     pub is_video: bool,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub thumbnail: Option<PhotoSize>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub emoji: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub set_name: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub premium_animation: Option<File>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub mask_position: Option<MaskPosition>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub custom_emoji_id: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub needs_repainting: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub file_size: Option<u64>,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct InputSticker {
     pub sticker: FileUpload,
     pub format: StickerFormat,
     pub emoji_list: Vec<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub mask_position: Option<MaskPosition>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub keywords: Option<Vec<String>>,
 }
 
@@ -2162,11 +1410,11 @@ pub struct Story {
     pub id: u64,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct StickerSet {
     pub name: String,
-
     pub title: String,
 
     #[serde(rename = "sticker_type")]
@@ -2175,10 +1423,7 @@ pub struct StickerSet {
     #[doc(hidden)]
     #[deprecated(since = "0.19.2", note = "Please use `sticker_type` instead")]
     pub contains_masks: bool,
-
     pub stickers: Vec<Sticker>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub thumbnail: Option<PhotoSize>,
 }
 
@@ -2186,809 +1431,427 @@ pub struct StickerSet {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct MaskPosition {
     pub point: String,
-
     pub x_shift: f64,
-
     pub y_shift: f64,
-
     pub scale: f64,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct InlineQuery {
     pub id: String,
-
     pub from: User,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub location: Option<Location>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub chat_type: Option<String>,
-
     pub query: String,
-
     pub offset: String,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct InlineQueryResultArticle {
     pub id: String,
-
     pub title: String,
-
     pub input_message_content: InputMessageContent,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub reply_markup: Option<InlineKeyboardMarkup>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub url: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub hide_url: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub thumbnail_url: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub thumbnail_width: Option<u32>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub thumbnail_height: Option<u32>,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct InlineQueryResultPhoto {
     pub id: String,
-
     pub photo_url: String,
-
     pub thumbnail_url: String,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub photo_width: Option<u32>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub photo_height: Option<u32>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub title: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub caption: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub parse_mode: Option<ParseMode>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub caption_entities: Option<Vec<MessageEntity>>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub show_caption_above_media: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub reply_markup: Option<InlineKeyboardMarkup>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub input_message_content: Option<InputMessageContent>,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct InlineQueryResultGif {
     pub id: String,
-
     pub gif_url: String,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub gif_width: Option<u32>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub gif_height: Option<u32>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub gif_duration: Option<u32>,
-
     pub thumbnail_url: String,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub thumbnail_mime_type: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub title: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub caption: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub parse_mode: Option<ParseMode>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub caption_entities: Option<Vec<MessageEntity>>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub show_caption_above_media: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub reply_markup: Option<InlineKeyboardMarkup>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub input_message_content: Option<InputMessageContent>,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct InlineQueryResultMpeg4Gif {
     pub id: String,
-
     pub mpeg4_url: String,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub mpeg4_width: Option<u32>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub mpeg4_height: Option<u32>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub mpeg4_duration: Option<u32>,
-
     pub thumbnail_url: String,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub thumbnail_mime_type: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub title: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub caption: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub parse_mode: Option<ParseMode>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub caption_entities: Option<Vec<MessageEntity>>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub show_caption_above_media: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub reply_markup: Option<InlineKeyboardMarkup>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub input_message_content: Option<InputMessageContent>,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct InlineQueryResultVideo {
     pub id: String,
-
     pub video_url: String,
-
     pub mime_type: String,
-
     pub thumbnail_url: String,
-
     pub title: String,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub caption: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub parse_mode: Option<ParseMode>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub caption_entities: Option<Vec<MessageEntity>>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub video_width: Option<u32>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub video_height: Option<u32>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub video_duration: Option<u32>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub show_caption_above_media: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub reply_markup: Option<InlineKeyboardMarkup>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub input_message_content: Option<InputMessageContent>,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct InlineQueryResultAudio {
     pub id: String,
-
     pub audio_url: String,
-
     pub title: String,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub caption: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub parse_mode: Option<ParseMode>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub caption_entities: Option<Vec<MessageEntity>>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub performer: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub audio_duration: Option<u32>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub reply_markup: Option<InlineKeyboardMarkup>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub input_message_content: Option<InputMessageContent>,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct InlineQueryResultVoice {
     pub id: String,
-
     pub voice_url: String,
-
     pub title: String,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub caption: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub parse_mode: Option<ParseMode>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub caption_entities: Option<Vec<MessageEntity>>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub voice_duration: Option<u32>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub reply_markup: Option<InlineKeyboardMarkup>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub input_message_content: Option<InputMessageContent>,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct InlineQueryResultDocument {
     pub id: String,
-
     pub title: String,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub caption: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub parse_mode: Option<ParseMode>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub caption_entities: Option<Vec<MessageEntity>>,
-
     pub document_url: String,
-
     pub mime_type: String,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub reply_markup: Option<InlineKeyboardMarkup>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub input_message_content: Option<InputMessageContent>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub thumbnail_url: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub thumbnail_width: Option<u32>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub thumbnail_height: Option<u32>,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct InlineQueryResultLocation {
     pub id: String,
-
     pub latitude: f64,
-
     pub longitude: f64,
-
     pub title: String,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub horizontal_accuracy: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub live_period: Option<u32>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub heading: Option<u16>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub proximity_alert_radius: Option<u32>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub reply_markup: Option<InlineKeyboardMarkup>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub input_message_content: Option<InputMessageContent>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub thumbnail_url: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub thumbnail_width: Option<u32>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub thumbnail_height: Option<u32>,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct InlineQueryResultVenue {
     pub id: String,
-
     pub latitude: f64,
-
     pub longitude: f64,
-
     pub title: String,
-
     pub address: String,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub foursquare_id: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub foursquare_type: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub google_place_id: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub google_place_type: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub reply_markup: Option<InlineKeyboardMarkup>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub input_message_content: Option<InputMessageContent>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub thumbnail_url: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub thumbnail_width: Option<u32>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub thumbnail_height: Option<u32>,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct InlineQueryResultContact {
     pub id: String,
-
     pub phone_number: String,
-
     pub first_name: String,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub last_name: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub vcard: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub reply_markup: Option<InlineKeyboardMarkup>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub input_message_content: Option<InputMessageContent>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub thumbnail_url: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub thumbnail_width: Option<u32>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub thumbnail_height: Option<u32>,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct InlineQueryResultGame {
     pub id: String,
-
     pub game_short_name: String,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub reply_markup: Option<InlineKeyboardMarkup>,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct InlineQueryResultCachedPhoto {
     pub id: String,
-
     pub photo_file_id: String,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub title: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub caption: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub parse_mode: Option<ParseMode>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub caption_entities: Option<Vec<MessageEntity>>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub show_caption_above_media: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub reply_markup: Option<InlineKeyboardMarkup>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub input_message_content: Option<InputMessageContent>,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct InlineQueryResultCachedGif {
     pub id: String,
-
     pub gif_file_id: String,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub title: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub caption: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub parse_mode: Option<ParseMode>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub caption_entities: Option<Vec<MessageEntity>>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub show_caption_above_media: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub reply_markup: Option<InlineKeyboardMarkup>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub input_message_content: Option<InputMessageContent>,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct InlineQueryResultCachedMpeg4Gif {
     pub id: String,
-
     pub mpeg4_file_id: String,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub title: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub caption: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub parse_mode: Option<ParseMode>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub caption_entities: Option<Vec<MessageEntity>>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub show_caption_above_media: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub reply_markup: Option<InlineKeyboardMarkup>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub input_message_content: Option<InputMessageContent>,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct InlineQueryResultCachedSticker {
     pub id: String,
-
     pub sticker_file_id: String,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub reply_markup: Option<InlineKeyboardMarkup>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub input_message_content: Option<InputMessageContent>,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct InlineQueryResultCachedDocument {
     pub id: String,
-
     pub title: String,
-
     pub document_file_id: String,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub caption: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub parse_mode: Option<ParseMode>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub caption_entities: Option<Vec<MessageEntity>>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub reply_markup: Option<InlineKeyboardMarkup>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub input_message_content: Option<InputMessageContent>,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct InlineQueryResultCachedVideo {
     pub id: String,
-
     pub video_file_id: String,
-
     pub title: String,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub caption: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub parse_mode: Option<ParseMode>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub caption_entities: Option<Vec<MessageEntity>>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub show_caption_above_media: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub reply_markup: Option<InlineKeyboardMarkup>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub input_message_content: Option<InputMessageContent>,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct InlineQueryResultCachedVoice {
     pub id: String,
-
     pub voice_file_id: String,
-
     pub title: String,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub caption: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub parse_mode: Option<ParseMode>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub caption_entities: Option<Vec<MessageEntity>>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub reply_markup: Option<InlineKeyboardMarkup>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub input_message_content: Option<InputMessageContent>,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct InlineQueryResultCachedAudio {
     pub id: String,
-
     pub audio_file_id: String,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub caption: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub parse_mode: Option<ParseMode>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub caption_entities: Option<Vec<MessageEntity>>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub reply_markup: Option<InlineKeyboardMarkup>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub input_message_content: Option<InputMessageContent>,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct InputTextMessageContent {
     pub message_text: String,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub parse_mode: Option<ParseMode>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub entities: Option<Vec<MessageEntity>>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub link_preview_options: Option<LinkPreviewOptions>,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]
 pub struct InputLocationMessageContent {
     pub latitude: f64,
-
     pub longitude: f64,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub horizontal_accuracy: Option<f64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub live_period: Option<u32>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub heading: Option<u16>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub proximity_alert_radius: Option<u32>,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct InputInvoiceMessageContent {
     pub title: String,
-
     pub description: String,
-
     pub payload: String,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub provider_token: Option<String>,
-
     pub currency: String,
-
     pub prices: Vec<LabeledPrice>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub max_tip_amount: Option<u32>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub suggested_tip_amounts: Option<Vec<u32>>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub provider_data: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub photo_url: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub photo_size: Option<u32>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub photo_width: Option<u32>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub photo_height: Option<u32>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub need_name: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub need_phone_number: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub need_email: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub need_shipping_address: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub send_phone_number_to_provider: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub send_email_to_provider: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub is_flexible: Option<bool>,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct InputVenueMessageContent {
     pub latitude: f64,
-
     pub longitude: f64,
-
     pub title: String,
-
     pub address: String,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub foursquare_id: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub foursquare_type: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub google_place_id: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub google_place_type: Option<String>,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct InputContactMessageContent {
     pub phone_number: String,
-
     pub first_name: String,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub last_name: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub vcard: Option<String>,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct ChosenInlineResult {
     pub result_id: String,
-
     pub from: User,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub location: Option<Location>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub inline_message_id: Option<String>,
-
     pub query: String,
 }
 
@@ -2996,7 +1859,6 @@ pub struct ChosenInlineResult {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct LabeledPrice {
     pub label: String,
-
     pub amount: u32,
 }
 
@@ -3004,13 +1866,9 @@ pub struct LabeledPrice {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Invoice {
     pub title: String,
-
     pub description: String,
-
     pub start_parameter: String,
-
     pub currency: String,
-
     pub total_amount: u32,
 }
 
@@ -3018,7 +1876,6 @@ pub struct Invoice {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct PaidMediaInfo {
     pub star_count: u32,
-
     pub paid_media: Vec<PaidMedia>,
 }
 
@@ -3030,16 +1887,12 @@ pub enum PaidMedia {
     Video(PaidMediaVideo),
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct PaidMediaPreview {
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub width: Option<u32>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub height: Option<u32>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub duration: Option<u32>,
 }
 
@@ -3066,23 +1919,15 @@ pub struct InputPaidMediaPhoto {
     pub media: String,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct InputPaidMediaVideo {
     pub media: String,
-
     pub thumbnail: String,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub width: Option<u32>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub height: Option<u32>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub duration: Option<u32>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub supports_streaming: Option<bool>,
 }
 
@@ -3090,31 +1935,20 @@ pub struct InputPaidMediaVideo {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ShippingAddress {
     pub country_code: String,
-
     pub state: String,
-
     pub city: String,
-
     pub street_line1: String,
-
     pub street_line2: String,
-
     pub post_code: String,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct OrderInfo {
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub phone_number: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub email: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub shipping_address: Option<ShippingAddress>,
 }
 
@@ -3122,29 +1956,20 @@ pub struct OrderInfo {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ShippingOption {
     pub id: String,
-
     pub title: String,
-
     pub prices: Vec<LabeledPrice>,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SuccessfulPayment {
     pub currency: String,
-
     pub total_amount: u32,
-
     pub invoice_payload: String,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub shipping_option_id: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub order_info: Option<OrderInfo>,
-
     pub telegram_payment_charge_id: String,
-
     pub provider_payment_charge_id: String,
 }
 
@@ -3152,13 +1977,9 @@ pub struct SuccessfulPayment {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct RefundedPayment {
     pub currency: String,
-
     pub total_amount: u32,
-
     pub invoice_payload: String,
-
     pub telegram_payment_charge_id: String,
-
     pub provider_payment_charge_id: Option<String>,
 }
 
@@ -3166,31 +1987,21 @@ pub struct RefundedPayment {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ShippingQuery {
     pub id: String,
-
     pub from: User,
-
     pub invoice_payload: String,
-
     pub shipping_address: ShippingAddress,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct PreCheckoutQuery {
     pub id: String,
-
     pub from: User,
-
     pub currency: String,
-
     pub total_amount: u32,
-
     pub invoice_payload: String,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub shipping_option_id: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub order_info: Option<OrderInfo>,
 }
 
@@ -3198,7 +2009,6 @@ pub struct PreCheckoutQuery {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct PaidMediaPurchased {
     pub from: User,
-
     pub paid_media_payload: String,
 }
 
@@ -3206,7 +2016,6 @@ pub struct PaidMediaPurchased {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct PassportData {
     pub data: Vec<EncryptedPassportElement>,
-
     pub credentials: EncryptedCredentials,
 }
 
@@ -3214,44 +2023,25 @@ pub struct PassportData {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct PassportFile {
     pub file_id: String,
-
     pub file_unique_id: String,
-
     pub file_size: u64,
-
     pub file_date: u64,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct EncryptedPassportElement {
     #[serde(rename = "type")]
     pub type_field: EncryptedPassportElementType,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub data: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub phone_number: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub email: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub files: Option<Vec<PassportFile>>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub front_side: Option<PassportFile>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub reverse_side: Option<PassportFile>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub selfie: Option<PassportFile>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub translation: Option<Vec<PassportFile>>,
-
     pub hash: String,
 }
 
@@ -3259,9 +2049,7 @@ pub struct EncryptedPassportElement {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct EncryptedCredentials {
     pub data: String,
-
     pub hash: String,
-
     pub secret: String,
 }
 
@@ -3270,11 +2058,8 @@ pub struct EncryptedCredentials {
 pub struct PassportElementErrorDataField {
     #[serde(rename = "type")]
     pub type_field: PassportElementErrorDataFieldType,
-
     pub field_name: String,
-
     pub data_hash: String,
-
     pub message: String,
 }
 
@@ -3283,9 +2068,7 @@ pub struct PassportElementErrorDataField {
 pub struct PassportElementErrorFrontSide {
     #[serde(rename = "type")]
     pub type_field: PassportElementErrorFrontSideType,
-
     pub file_hash: String,
-
     pub message: String,
 }
 
@@ -3294,9 +2077,7 @@ pub struct PassportElementErrorFrontSide {
 pub struct PassportElementErrorReverseSide {
     #[serde(rename = "type")]
     pub type_field: PassportElementErrorReverseSideType,
-
     pub file_hash: String,
-
     pub message: String,
 }
 
@@ -3305,9 +2086,7 @@ pub struct PassportElementErrorReverseSide {
 pub struct PassportElementErrorSelfie {
     #[serde(rename = "type")]
     pub type_field: PassportElementErrorSelfieType,
-
     pub file_hash: String,
-
     pub message: String,
 }
 
@@ -3316,9 +2095,7 @@ pub struct PassportElementErrorSelfie {
 pub struct PassportElementErrorFile {
     #[serde(rename = "type")]
     pub type_field: PassportElementErrorFileType,
-
     pub file_hash: String,
-
     pub message: String,
 }
 
@@ -3327,9 +2104,7 @@ pub struct PassportElementErrorFile {
 pub struct PassportElementErrorFiles {
     #[serde(rename = "type")]
     pub type_field: PassportElementErrorFileType,
-
     pub file_hashes: Vec<String>,
-
     pub message: String,
 }
 
@@ -3338,9 +2113,7 @@ pub struct PassportElementErrorFiles {
 pub struct PassportElementErrorTranslationFile {
     #[serde(rename = "type")]
     pub type_field: PassportElementErrorTranslationFileType,
-
     pub file_hash: String,
-
     pub message: String,
 }
 
@@ -3349,9 +2122,7 @@ pub struct PassportElementErrorTranslationFile {
 pub struct PassportElementErrorTranslationFiles {
     #[serde(rename = "type")]
     pub type_field: PassportElementErrorTranslationFileType,
-
     pub file_hashes: Vec<String>,
-
     pub message: String,
 }
 
@@ -3360,28 +2131,19 @@ pub struct PassportElementErrorTranslationFiles {
 pub struct PassportElementErrorUnspecified {
     #[serde(rename = "type")]
     pub type_field: EncryptedPassportElementType,
-
     pub element_hash: String,
-
     pub message: String,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Game {
     pub title: String,
-
     pub description: String,
-
     pub photo: Vec<PhotoSize>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub text: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub text_entities: Option<Vec<MessageEntity>>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub animation: Option<Animation>,
 }
 
@@ -3389,135 +2151,78 @@ pub struct Game {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct GameHighScore {
     pub position: u32,
-
     pub user: User,
-
     pub score: i32,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct GiveawayCreated {
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub prize_star_count: Option<u32>,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Giveaway {
     pub chats: Vec<Chat>,
-
     pub winners_selection_date: u64,
-
     pub winner_count: u32,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub only_new_members: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub has_public_winners: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub prize_description: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub country_codes: Option<Vec<String>>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub prize_star_count: Option<u32>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub premium_subscription_month_count: Option<u32>,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct GiveawayWinners {
     pub chat: Chat,
-
     pub giveaway_message_id: i32,
-
     pub winners_selection_date: u64,
-
     pub winner_count: u32,
-
     pub winners: Vec<User>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub additional_chat_count: Option<u32>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub prize_star_count: Option<u32>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub premium_subscription_month_count: Option<u32>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub unclaimed_prize_count: Option<u32>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub only_new_members: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub was_refunded: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub prize_description: Option<String>,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct GiveawayCompleted {
     pub winner_count: u32,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub unclaimed_prize_count: Option<u32>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub giveaway_message: Option<Box<Message>>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub is_star_giveaway: Option<bool>,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ChatAdministratorRights {
     pub is_anonymous: bool,
-
     pub can_manage_chat: bool,
-
     pub can_delete_messages: bool,
-
     pub can_manage_video_chats: bool,
-
     pub can_restrict_members: bool,
-
     pub can_promote_members: bool,
-
     pub can_change_info: bool,
-
     pub can_invite_users: bool,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub can_post_messages: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub can_edit_messages: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub can_pin_messages: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub can_post_stories: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub can_edit_stories: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub can_delete_stories: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub can_manage_topics: Option<bool>,
 }
 
@@ -3537,7 +2242,6 @@ pub struct SentWebAppMessage {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct WebAppData {
     pub data: String,
-
     pub button_text: String,
 }
 
@@ -3561,18 +2265,13 @@ pub struct ChatBoostSourceGiftCode {
     pub user: User,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ChatBoostSourceGiveaway {
     pub giveaway_message_id: i32,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub user: Option<User>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub prize_star_count: Option<u32>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub is_unclaimed: Option<bool>,
 }
 
@@ -3580,11 +2279,8 @@ pub struct ChatBoostSourceGiveaway {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ChatBoost {
     pub boost_id: String,
-
     pub add_date: u64,
-
     pub expiration_date: u64,
-
     pub source: ChatBoostSource,
 }
 
@@ -3592,7 +2288,6 @@ pub struct ChatBoost {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ChatBoostUpdated {
     pub chat: Chat,
-
     pub boost: ChatBoost,
 }
 
@@ -3600,11 +2295,8 @@ pub struct ChatBoostUpdated {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ChatBoostRemoved {
     pub chat: Chat,
-
     pub boost_id: String,
-
     pub remove_date: u64,
-
     pub source: ChatBoostSource,
 }
 
@@ -3618,15 +2310,10 @@ pub struct UserChatBoosts {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct BusinessConnection {
     pub id: String,
-
     pub user: User,
-
     pub user_chat_id: u64,
-
     pub date: u64,
-
     pub can_reply: bool,
-
     pub is_enabled: bool,
 }
 
@@ -3634,9 +2321,7 @@ pub struct BusinessConnection {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct BusinessMessagesDeleted {
     pub business_connection_id: String,
-
     pub chat: Chat,
-
     pub message_ids: Vec<i32>,
 }
 
@@ -3651,9 +2336,7 @@ pub enum MaybeInaccessibleMessage {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct InaccessibleMessage {
     pub chat: Chat,
-
     pub message_id: i32,
-
     pub date: u64,
 }
 
@@ -3673,7 +2356,6 @@ pub struct RevenueWithdrawalStatePending {}
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct RevenueWithdrawalStateSucceeded {
     pub date: u64,
-
     pub url: String,
 }
 
@@ -3690,22 +2372,19 @@ pub enum TransactionPartner {
     Other(TransactionPartnerOther),
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct TransactionPartnerUser {
     pub user: User,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub invoice_payload: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub paid_media: Option<Vec<PaidMedia>>,
 }
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct TransactionPartnerFragment {
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub withdrawal_state: Option<RevenueWithdrawalState>,
 }
 
@@ -3717,19 +2396,14 @@ pub struct TransactionPartnerTelegramAds {}
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct TransactionPartnerOther {}
 
+#[skip_serializing_none]
 #[apply(builder!)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct StarTransaction {
     pub id: String,
-
     pub amount: u32,
-
     pub date: u64,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub source: Option<TransactionPartner>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub receiver: Option<TransactionPartner>,
 }
 

--- a/src/objects.rs
+++ b/src/objects.rs
@@ -2,11 +2,10 @@
 
 #![allow(deprecated)]
 
-use macro_rules_attribute::apply;
 use serde::{Deserialize, Serialize};
 
 use crate::api_params::FileUpload;
-use crate::macros::apistruct;
+use crate::macros::{apistruct, apply};
 use crate::ParseMode;
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]

--- a/src/objects.rs
+++ b/src/objects.rs
@@ -9,7 +9,7 @@ use crate::api_params::FileUpload;
 use crate::macros::serdebuilder;
 use crate::ParseMode;
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum StickerType {
     Regular,
@@ -25,7 +25,7 @@ pub enum StickerFormat {
     Video,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 #[serde(untagged)]
 pub enum InputMessageContent {
     Text(InputTextMessageContent),
@@ -35,7 +35,7 @@ pub enum InputMessageContent {
     Invoice(InputInvoiceMessageContent),
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(tag = "status", rename_all = "snake_case")]
 pub enum ChatMember {
     Creator(ChatMemberOwner),
@@ -46,7 +46,7 @@ pub enum ChatMember {
     Kicked(ChatMemberBanned),
 }
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum ChatType {
     Private,
@@ -166,7 +166,7 @@ pub enum PassportElementErrorTranslationFileType {
     TemporaryRegistration,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum MenuButton {
     Commands,
@@ -174,7 +174,7 @@ pub enum MenuButton {
     Default,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum ChatBackground {
     Fill(BackgroundTypeFill),
@@ -183,7 +183,7 @@ pub enum ChatBackground {
     ChatTheme(BackgroundTypeChatTheme),
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum BackgroundFill {
     Solid(BackgroundFillSolid),
@@ -315,7 +315,7 @@ pub struct Update {
     pub content: UpdateContent,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub enum UpdateContent {
     Message(Message),
@@ -360,7 +360,7 @@ pub struct WebhookInfo {
 /// Control which updates to receive.
 /// Specify an empty list to receive all update types except `ChatMember`.
 /// [Official documentation](https://core.telegram.org/bots/api#getupdates).
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, Hash)]
 #[serde(rename_all = "snake_case")]
 #[non_exhaustive]
 pub enum AllowedUpdate {
@@ -1227,7 +1227,7 @@ pub struct ChatLocation {
     pub address: String,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum ReactionType {
     Emoji(ReactionTypeEmoji),
@@ -1757,7 +1757,7 @@ pub struct PaidMediaInfo {
     pub paid_media: Vec<PaidMedia>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum PaidMedia {
     Preview(PaidMediaPreview),
@@ -1785,7 +1785,7 @@ pub struct PaidMediaVideo {
     pub video: Video,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum InputPaidMedia {
     Photo(InputPaidMediaPhoto),
@@ -2112,7 +2112,7 @@ pub struct WebAppData {
     pub button_text: String,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(tag = "source", rename_all = "snake_case")]
 pub enum ChatBoostSource {
     Premium(ChatBoostSourcePremium),
@@ -2191,7 +2191,7 @@ pub struct BusinessMessagesDeleted {
     pub message_ids: Vec<i32>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 #[serde(untagged)]
 pub enum MaybeInaccessibleMessage {
     Message(Message),
@@ -2206,7 +2206,7 @@ pub struct InaccessibleMessage {
     pub date: u64,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum RevenueWithdrawalState {
     Pending(RevenueWithdrawalStatePending),
@@ -2229,7 +2229,7 @@ pub struct RevenueWithdrawalStateSucceeded {
 #[derive(Eq)]
 pub struct RevenueWithdrawalStateFailed {}
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum TransactionPartner {
     User(TransactionPartnerUser),

--- a/src/objects.rs
+++ b/src/objects.rs
@@ -192,14 +192,14 @@ pub enum BackgroundFill {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct MenuButtonWebApp {
     pub text: String,
     pub web_app: WebAppInfo,
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct ChatMemberOwner {
     pub user: User,
     pub custom_title: Option<String>,
@@ -207,7 +207,7 @@ pub struct ChatMemberOwner {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct ChatMemberAdministrator {
     pub user: User,
     pub can_be_edited: bool,
@@ -230,14 +230,14 @@ pub struct ChatMemberAdministrator {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct ChatMemberMember {
     pub user: User,
     pub until_date: Option<u64>,
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct ChatMemberRestricted {
     pub user: User,
     pub is_member: bool,
@@ -259,46 +259,46 @@ pub struct ChatMemberRestricted {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct ChatMemberLeft {
     pub user: User,
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct ChatMemberBanned {
     pub user: User,
     pub until_date: u64,
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Copy, Eq)]
 pub struct VideoChatStarted {}
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Copy, Eq)]
 pub struct VideoChatScheduled {
     pub start_date: u64,
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Copy, Eq)]
 pub struct CallbackGame {}
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct BotDescription {
     pub description: String,
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct BotName {
     pub name: String,
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct BotShortDescription {
     pub short_description: String,
 }
@@ -306,7 +306,6 @@ pub struct BotShortDescription {
 /// Represents an incoming update from telegram.
 /// [Official documentation.](https://core.telegram.org/bots/api#update)
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq)]
 pub struct Update {
     pub update_id: u32,
 
@@ -345,7 +344,7 @@ pub enum UpdateContent {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct WebhookInfo {
     pub url: String,
     pub has_custom_certificate: bool,
@@ -386,7 +385,7 @@ pub enum AllowedUpdate {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct User {
     pub id: u64,
     pub is_bot: bool,
@@ -404,7 +403,7 @@ pub struct User {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct Chat {
     pub id: i64,
 
@@ -418,7 +417,6 @@ pub struct Chat {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq)]
 pub struct ChatFullInfo {
     pub id: i64,
 
@@ -469,7 +467,6 @@ pub struct ChatFullInfo {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq)]
 pub struct Message {
     pub message_id: i32,
     pub message_thread_id: Option<i32>,
@@ -559,13 +556,13 @@ pub struct Message {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Copy, Eq)]
 pub struct MessageId {
     pub message_id: i32,
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct MessageEntity {
     #[serde(rename = "type")]
     pub type_field: MessageEntityType,
@@ -578,7 +575,7 @@ pub struct MessageEntity {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct TextQuote {
     pub text: String,
     pub entities: Option<Vec<MessageEntity>>,
@@ -587,7 +584,6 @@ pub struct TextQuote {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Clone, Debug, PartialEq)]
 pub struct ExternalReplyInfo {
     pub origin: Option<MessageOrigin>,
     pub chat: Option<Chat>,
@@ -625,21 +621,21 @@ pub enum MessageOrigin {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct MessageOriginUser {
     pub date: u64,
     pub sender_user: User,
 }
 
 #[apply(serdebuilder!)]
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct MessageOriginHiddenUser {
     pub date: u64,
     pub sender_user_name: String,
 }
 
 #[apply(serdebuilder!)]
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct MessageOriginChat {
     pub date: u64,
     pub sender_chat: Chat,
@@ -647,7 +643,7 @@ pub struct MessageOriginChat {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct MessageOriginChannel {
     pub date: u64,
     pub chat: Chat,
@@ -656,7 +652,7 @@ pub struct MessageOriginChannel {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct LinkPreviewOptions {
     pub is_disabled: Option<bool>,
     pub url: Option<String>,
@@ -666,7 +662,7 @@ pub struct LinkPreviewOptions {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct PhotoSize {
     pub file_id: String,
     pub file_unique_id: String,
@@ -676,7 +672,7 @@ pub struct PhotoSize {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct Animation {
     pub file_id: String,
     pub file_unique_id: String,
@@ -690,7 +686,7 @@ pub struct Animation {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct Audio {
     pub file_id: String,
     pub file_unique_id: String,
@@ -704,7 +700,7 @@ pub struct Audio {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct Document {
     pub file_id: String,
     pub file_unique_id: String,
@@ -715,7 +711,7 @@ pub struct Document {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct Video {
     pub file_id: String,
     pub file_unique_id: String,
@@ -729,7 +725,7 @@ pub struct Video {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct VideoNote {
     pub file_id: String,
     pub file_unique_id: String,
@@ -740,7 +736,7 @@ pub struct VideoNote {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct Voice {
     pub file_id: String,
     pub file_unique_id: String,
@@ -750,7 +746,7 @@ pub struct Voice {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct Contact {
     pub phone_number: String,
     pub first_name: String,
@@ -760,14 +756,14 @@ pub struct Contact {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct Dice {
     pub emoji: String,
     pub value: u8,
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct PollOption {
     pub text: String,
     pub text_entities: Option<Vec<MessageEntity>>,
@@ -775,7 +771,7 @@ pub struct PollOption {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct InputPollOption {
     pub text: Option<String>,
     pub text_parse_mode: Option<ParseMode>,
@@ -783,7 +779,7 @@ pub struct InputPollOption {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct PollAnswer {
     pub poll_id: String,
     pub voter_chat: Option<Chat>,
@@ -792,7 +788,7 @@ pub struct PollAnswer {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct Poll {
     pub id: String,
     pub question: String,
@@ -813,7 +809,7 @@ pub struct Poll {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Copy)]
 pub struct Location {
     pub longitude: f64,
     pub latitude: f64,
@@ -824,7 +820,6 @@ pub struct Location {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq)]
 pub struct Venue {
     pub location: Location,
     pub title: String,
@@ -836,7 +831,7 @@ pub struct Venue {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct ProximityAlertTriggered {
     pub traveler: User,
     pub watcher: User,
@@ -844,25 +839,25 @@ pub struct ProximityAlertTriggered {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Copy, Eq)]
 pub struct MessageAutoDeleteTimerChanged {
     pub message_auto_delete_time: u32,
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Copy, Eq)]
 pub struct ChatBoostAdded {
     pub boost_count: u32,
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Copy, Eq)]
 pub struct BackgroundFillSolid {
     pub color: u32,
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Copy, Eq)]
 pub struct BackgroundFillGradient {
     pub top_color: u32,
     pub bottom_color: u32,
@@ -870,20 +865,20 @@ pub struct BackgroundFillGradient {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct BackgroundFillFreeformGradient {
     pub colors: Vec<u32>,
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct BackgroundTypeFill {
     pub fill: BackgroundFill,
     pub dark_theme_dimming: u8,
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct BackgroundTypeWallpaper {
     pub document: Document,
     pub dark_theme_dimming: u8,
@@ -892,7 +887,7 @@ pub struct BackgroundTypeWallpaper {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct BackgroundTypePattern {
     pub document: Document,
     pub fill: BackgroundFill,
@@ -902,13 +897,13 @@ pub struct BackgroundTypePattern {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct BackgroundTypeChatTheme {
     pub theme_name: String,
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct ForumTopicCreated {
     pub name: String,
     pub icon_color: u32,
@@ -916,30 +911,30 @@ pub struct ForumTopicCreated {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct ForumTopicClosed {}
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct ForumTopicEdited {
     pub name: Option<String>,
     pub icon_custom_emoji_id: Option<String>,
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct ForumTopicReopened {}
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct GeneralForumTopicHidden {}
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct GeneralForumTopicUnhidden {}
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct SharedUser {
     pub user_id: u64,
     pub first_name: Option<String>,
@@ -949,14 +944,14 @@ pub struct SharedUser {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct UsersShared {
     pub request_id: i32,
     pub users: Vec<SharedUser>,
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct ChatShared {
     pub request_id: i32,
     pub chat_id: i64,
@@ -966,7 +961,7 @@ pub struct ChatShared {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct WriteAccessAllowed {
     pub from_request: Option<bool>,
     pub web_app_name: Option<String>,
@@ -974,26 +969,26 @@ pub struct WriteAccessAllowed {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Copy, Eq)]
 pub struct VideoChatEnded {
     pub duration: u32,
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct VideoChatParticipantsInvited {
     pub users: Option<Vec<User>>,
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct UserProfilePhotos {
     pub total_count: u32,
     pub photos: Vec<Vec<PhotoSize>>,
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct File {
     pub file_id: String,
     pub file_unique_id: String,
@@ -1002,7 +997,7 @@ pub struct File {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct ReplyKeyboardMarkup {
     pub keyboard: Vec<Vec<KeyboardButton>>,
     pub is_persistent: Option<bool>,
@@ -1013,7 +1008,7 @@ pub struct ReplyKeyboardMarkup {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct KeyboardButton {
     pub text: String,
     pub request_users: Option<KeyboardButtonRequestUsers>,
@@ -1025,7 +1020,7 @@ pub struct KeyboardButton {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct KeyboardButtonRequestUsers {
     pub request_id: i32,
     pub user_is_bot: Option<bool>,
@@ -1037,7 +1032,7 @@ pub struct KeyboardButtonRequestUsers {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct KeyboardButtonRequestChat {
     pub request_id: i32,
     pub chat_is_channel: bool,
@@ -1053,27 +1048,27 @@ pub struct KeyboardButtonRequestChat {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Copy, Eq)]
 pub struct KeyboardButtonPollType {
     #[serde(rename = "type")]
     pub type_field: Option<PollType>,
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Copy, Eq)]
 pub struct ReplyKeyboardRemove {
     pub remove_keyboard: bool,
     pub selective: Option<bool>,
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct InlineKeyboardMarkup {
     pub inline_keyboard: Vec<Vec<InlineKeyboardButton>>,
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct InlineKeyboardButton {
     pub text: String,
     pub url: Option<String>,
@@ -1088,7 +1083,7 @@ pub struct InlineKeyboardButton {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct LoginUrl {
     pub url: String,
     pub forward_text: Option<String>,
@@ -1097,7 +1092,7 @@ pub struct LoginUrl {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct SwitchInlineQueryChosenChat {
     pub query: Option<String>,
     pub allow_user_chats: Option<bool>,
@@ -1107,7 +1102,6 @@ pub struct SwitchInlineQueryChosenChat {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq)]
 pub struct CallbackQuery {
     pub id: String,
     pub from: User,
@@ -1119,7 +1113,7 @@ pub struct CallbackQuery {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct ForceReply {
     pub force_reply: bool,
     pub input_field_placeholder: Option<String>,
@@ -1127,7 +1121,7 @@ pub struct ForceReply {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct ChatPhoto {
     pub small_file_id: String,
     pub small_file_unique_id: String,
@@ -1136,7 +1130,7 @@ pub struct ChatPhoto {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct ChatInviteLink {
     pub invite_link: String,
     pub creator: User,
@@ -1150,7 +1144,7 @@ pub struct ChatInviteLink {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct ChatMemberUpdated {
     pub chat: Chat,
     pub from: User,
@@ -1163,7 +1157,7 @@ pub struct ChatMemberUpdated {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct ChatJoinRequest {
     pub chat: Chat,
     pub from: User,
@@ -1174,7 +1168,7 @@ pub struct ChatJoinRequest {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Copy, Eq)]
 pub struct ChatPermissions {
     pub can_send_messages: Option<bool>,
     pub can_send_audios: Option<bool>,
@@ -1193,7 +1187,7 @@ pub struct ChatPermissions {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct Birthdate {
     pub day: u8,
     pub month: u8,
@@ -1201,7 +1195,6 @@ pub struct Birthdate {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq)]
 pub struct BusinessIntro {
     pub title: Option<String>,
     pub message: Option<String>,
@@ -1209,28 +1202,26 @@ pub struct BusinessIntro {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq)]
 pub struct BusinessLocation {
     pub address: String,
     pub location: Option<Location>,
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct BusinessOpeningHoursInterval {
     pub opening_minute: u16,
     pub closing_minute: u16,
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct BusinessOpeningHours {
     pub time_zone_name: String,
     pub opening_hours: Vec<BusinessOpeningHoursInterval>,
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq)]
 pub struct ChatLocation {
     pub location: Location,
     pub address: String,
@@ -1245,23 +1236,23 @@ pub enum ReactionType {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct ReactionTypeEmoji {
     pub emoji: String,
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct ReactionTypeCustomEmoji {
     pub custom_emoji_id: String,
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct ReactionTypePaid {}
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct ReactionCount {
     #[serde(rename = "type")]
     pub type_field: ReactionType,
@@ -1269,7 +1260,7 @@ pub struct ReactionCount {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct MessageReactionUpdated {
     pub chat: Chat,
     pub message_id: i32,
@@ -1281,7 +1272,7 @@ pub struct MessageReactionUpdated {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct MessageReactionCountUpdated {
     pub chat: Chat,
     pub message_id: i32,
@@ -1290,7 +1281,7 @@ pub struct MessageReactionCountUpdated {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Eq)]
 pub struct ForumTopic {
     pub message_thread_id: i32,
     pub name: String,
@@ -1299,21 +1290,20 @@ pub struct ForumTopic {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct BotCommand {
     pub command: String,
     pub description: String,
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Copy, Eq)]
 pub struct ResponseParameters {
     pub migrate_to_chat_id: Option<i64>,
     pub retry_after: Option<u16>,
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq)]
 pub struct Sticker {
     pub file_id: String,
     pub file_unique_id: String,
@@ -1335,7 +1325,6 @@ pub struct Sticker {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq)]
 pub struct InputSticker {
     pub sticker: FileUpload,
     pub format: StickerFormat,
@@ -1345,14 +1334,13 @@ pub struct InputSticker {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct Story {
     pub chat: Chat,
     pub id: u64,
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq)]
 pub struct StickerSet {
     pub name: String,
     pub title: String,
@@ -1368,7 +1356,6 @@ pub struct StickerSet {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq)]
 pub struct MaskPosition {
     pub point: String,
     pub x_shift: f64,
@@ -1377,7 +1364,6 @@ pub struct MaskPosition {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq)]
 pub struct InlineQuery {
     pub id: String,
     pub from: User,
@@ -1388,7 +1374,6 @@ pub struct InlineQuery {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq)]
 pub struct InlineQueryResultArticle {
     pub id: String,
     pub title: String,
@@ -1403,7 +1388,6 @@ pub struct InlineQueryResultArticle {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq)]
 pub struct InlineQueryResultPhoto {
     pub id: String,
     pub photo_url: String,
@@ -1421,7 +1405,6 @@ pub struct InlineQueryResultPhoto {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq)]
 pub struct InlineQueryResultGif {
     pub id: String,
     pub gif_url: String,
@@ -1440,7 +1423,6 @@ pub struct InlineQueryResultGif {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq)]
 pub struct InlineQueryResultMpeg4Gif {
     pub id: String,
     pub mpeg4_url: String,
@@ -1459,7 +1441,6 @@ pub struct InlineQueryResultMpeg4Gif {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq)]
 pub struct InlineQueryResultVideo {
     pub id: String,
     pub video_url: String,
@@ -1479,7 +1460,6 @@ pub struct InlineQueryResultVideo {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq)]
 pub struct InlineQueryResultAudio {
     pub id: String,
     pub audio_url: String,
@@ -1494,7 +1474,6 @@ pub struct InlineQueryResultAudio {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq)]
 pub struct InlineQueryResultVoice {
     pub id: String,
     pub voice_url: String,
@@ -1508,7 +1487,6 @@ pub struct InlineQueryResultVoice {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq)]
 pub struct InlineQueryResultDocument {
     pub id: String,
     pub title: String,
@@ -1526,7 +1504,6 @@ pub struct InlineQueryResultDocument {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq)]
 pub struct InlineQueryResultLocation {
     pub id: String,
     pub latitude: f64,
@@ -1544,7 +1521,6 @@ pub struct InlineQueryResultLocation {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq)]
 pub struct InlineQueryResultVenue {
     pub id: String,
     pub latitude: f64,
@@ -1563,7 +1539,6 @@ pub struct InlineQueryResultVenue {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq)]
 pub struct InlineQueryResultContact {
     pub id: String,
     pub phone_number: String,
@@ -1578,7 +1553,7 @@ pub struct InlineQueryResultContact {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct InlineQueryResultGame {
     pub id: String,
     pub game_short_name: String,
@@ -1586,7 +1561,6 @@ pub struct InlineQueryResultGame {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq)]
 pub struct InlineQueryResultCachedPhoto {
     pub id: String,
     pub photo_file_id: String,
@@ -1601,7 +1575,6 @@ pub struct InlineQueryResultCachedPhoto {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq)]
 pub struct InlineQueryResultCachedGif {
     pub id: String,
     pub gif_file_id: String,
@@ -1615,7 +1588,6 @@ pub struct InlineQueryResultCachedGif {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq)]
 pub struct InlineQueryResultCachedMpeg4Gif {
     pub id: String,
     pub mpeg4_file_id: String,
@@ -1629,7 +1601,6 @@ pub struct InlineQueryResultCachedMpeg4Gif {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq)]
 pub struct InlineQueryResultCachedSticker {
     pub id: String,
     pub sticker_file_id: String,
@@ -1638,7 +1609,6 @@ pub struct InlineQueryResultCachedSticker {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq)]
 pub struct InlineQueryResultCachedDocument {
     pub id: String,
     pub title: String,
@@ -1652,7 +1622,6 @@ pub struct InlineQueryResultCachedDocument {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq)]
 pub struct InlineQueryResultCachedVideo {
     pub id: String,
     pub video_file_id: String,
@@ -1667,7 +1636,6 @@ pub struct InlineQueryResultCachedVideo {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq)]
 pub struct InlineQueryResultCachedVoice {
     pub id: String,
     pub voice_file_id: String,
@@ -1680,7 +1648,6 @@ pub struct InlineQueryResultCachedVoice {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq)]
 pub struct InlineQueryResultCachedAudio {
     pub id: String,
     pub audio_file_id: String,
@@ -1692,7 +1659,7 @@ pub struct InlineQueryResultCachedAudio {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct InputTextMessageContent {
     pub message_text: String,
     pub parse_mode: Option<ParseMode>,
@@ -1701,7 +1668,7 @@ pub struct InputTextMessageContent {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Copy)]
 pub struct InputLocationMessageContent {
     pub latitude: f64,
     pub longitude: f64,
@@ -1712,7 +1679,7 @@ pub struct InputLocationMessageContent {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct InputInvoiceMessageContent {
     pub title: String,
     pub description: String,
@@ -1737,7 +1704,6 @@ pub struct InputInvoiceMessageContent {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq)]
 pub struct InputVenueMessageContent {
     pub latitude: f64,
     pub longitude: f64,
@@ -1750,7 +1716,7 @@ pub struct InputVenueMessageContent {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct InputContactMessageContent {
     pub phone_number: String,
     pub first_name: String,
@@ -1759,7 +1725,6 @@ pub struct InputContactMessageContent {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq)]
 pub struct ChosenInlineResult {
     pub result_id: String,
     pub from: User,
@@ -1769,14 +1734,14 @@ pub struct ChosenInlineResult {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct LabeledPrice {
     pub label: String,
     pub amount: u32,
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct Invoice {
     pub title: String,
     pub description: String,
@@ -1786,7 +1751,7 @@ pub struct Invoice {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct PaidMediaInfo {
     pub star_count: u32,
     pub paid_media: Vec<PaidMedia>,
@@ -1801,7 +1766,7 @@ pub enum PaidMedia {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct PaidMediaPreview {
     pub width: Option<u32>,
     pub height: Option<u32>,
@@ -1809,13 +1774,13 @@ pub struct PaidMediaPreview {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct PaidMediaPhoto {
     pub photo: Vec<PhotoSize>,
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct PaidMediaVideo {
     pub video: Video,
 }
@@ -1828,13 +1793,13 @@ pub enum InputPaidMedia {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct InputPaidMediaPhoto {
     pub media: String,
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct InputPaidMediaVideo {
     pub media: String,
     pub thumbnail: String,
@@ -1845,7 +1810,7 @@ pub struct InputPaidMediaVideo {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct ShippingAddress {
     pub country_code: String,
     pub state: String,
@@ -1856,7 +1821,7 @@ pub struct ShippingAddress {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct OrderInfo {
     pub name: Option<String>,
     pub phone_number: Option<String>,
@@ -1865,7 +1830,7 @@ pub struct OrderInfo {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct ShippingOption {
     pub id: String,
     pub title: String,
@@ -1873,7 +1838,7 @@ pub struct ShippingOption {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct SuccessfulPayment {
     pub currency: String,
     pub total_amount: u32,
@@ -1885,7 +1850,7 @@ pub struct SuccessfulPayment {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct RefundedPayment {
     pub currency: String,
     pub total_amount: u32,
@@ -1895,7 +1860,7 @@ pub struct RefundedPayment {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct ShippingQuery {
     pub id: String,
     pub from: User,
@@ -1904,7 +1869,7 @@ pub struct ShippingQuery {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct PreCheckoutQuery {
     pub id: String,
     pub from: User,
@@ -1916,21 +1881,21 @@ pub struct PreCheckoutQuery {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct PaidMediaPurchased {
     pub from: User,
     pub paid_media_payload: String,
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct PassportData {
     pub data: Vec<EncryptedPassportElement>,
     pub credentials: EncryptedCredentials,
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct PassportFile {
     pub file_id: String,
     pub file_unique_id: String,
@@ -1939,7 +1904,7 @@ pub struct PassportFile {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct EncryptedPassportElement {
     #[serde(rename = "type")]
     pub type_field: EncryptedPassportElementType,
@@ -1955,7 +1920,7 @@ pub struct EncryptedPassportElement {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct EncryptedCredentials {
     pub data: String,
     pub hash: String,
@@ -1963,7 +1928,7 @@ pub struct EncryptedCredentials {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct PassportElementErrorDataField {
     #[serde(rename = "type")]
     pub type_field: PassportElementErrorDataFieldType,
@@ -1973,7 +1938,7 @@ pub struct PassportElementErrorDataField {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct PassportElementErrorFrontSide {
     #[serde(rename = "type")]
     pub type_field: PassportElementErrorFrontSideType,
@@ -1982,7 +1947,7 @@ pub struct PassportElementErrorFrontSide {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct PassportElementErrorReverseSide {
     #[serde(rename = "type")]
     pub type_field: PassportElementErrorReverseSideType,
@@ -1991,7 +1956,7 @@ pub struct PassportElementErrorReverseSide {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct PassportElementErrorSelfie {
     #[serde(rename = "type")]
     pub type_field: PassportElementErrorSelfieType,
@@ -2000,7 +1965,7 @@ pub struct PassportElementErrorSelfie {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct PassportElementErrorFile {
     #[serde(rename = "type")]
     pub type_field: PassportElementErrorFileType,
@@ -2009,7 +1974,7 @@ pub struct PassportElementErrorFile {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct PassportElementErrorFiles {
     #[serde(rename = "type")]
     pub type_field: PassportElementErrorFileType,
@@ -2018,7 +1983,7 @@ pub struct PassportElementErrorFiles {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct PassportElementErrorTranslationFile {
     #[serde(rename = "type")]
     pub type_field: PassportElementErrorTranslationFileType,
@@ -2027,7 +1992,7 @@ pub struct PassportElementErrorTranslationFile {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct PassportElementErrorTranslationFiles {
     #[serde(rename = "type")]
     pub type_field: PassportElementErrorTranslationFileType,
@@ -2036,7 +2001,7 @@ pub struct PassportElementErrorTranslationFiles {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct PassportElementErrorUnspecified {
     #[serde(rename = "type")]
     pub type_field: EncryptedPassportElementType,
@@ -2045,7 +2010,7 @@ pub struct PassportElementErrorUnspecified {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct Game {
     pub title: String,
     pub description: String,
@@ -2056,7 +2021,7 @@ pub struct Game {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct GameHighScore {
     pub position: u32,
     pub user: User,
@@ -2064,13 +2029,13 @@ pub struct GameHighScore {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct GiveawayCreated {
     pub prize_star_count: Option<u32>,
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct Giveaway {
     pub chats: Vec<Chat>,
     pub winners_selection_date: u64,
@@ -2084,7 +2049,7 @@ pub struct Giveaway {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct GiveawayWinners {
     pub chat: Chat,
     pub giveaway_message_id: i32,
@@ -2101,7 +2066,6 @@ pub struct GiveawayWinners {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq)]
 pub struct GiveawayCompleted {
     pub winner_count: u32,
     pub unclaimed_prize_count: Option<u32>,
@@ -2110,7 +2074,7 @@ pub struct GiveawayCompleted {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Copy, Eq)]
 pub struct ChatAdministratorRights {
     pub is_anonymous: bool,
     pub can_manage_chat: bool,
@@ -2130,19 +2094,19 @@ pub struct ChatAdministratorRights {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct WebAppInfo {
     pub url: String,
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct SentWebAppMessage {
     pub inline_message_id: String,
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct WebAppData {
     pub data: String,
     pub button_text: String,
@@ -2157,19 +2121,19 @@ pub enum ChatBoostSource {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct ChatBoostSourcePremium {
     pub user: User,
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct ChatBoostSourceGiftCode {
     pub user: User,
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct ChatBoostSourceGiveaway {
     pub giveaway_message_id: i32,
     pub user: Option<User>,
@@ -2178,7 +2142,7 @@ pub struct ChatBoostSourceGiveaway {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct ChatBoost {
     pub boost_id: String,
     pub add_date: u64,
@@ -2187,14 +2151,14 @@ pub struct ChatBoost {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct ChatBoostUpdated {
     pub chat: Chat,
     pub boost: ChatBoost,
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct ChatBoostRemoved {
     pub chat: Chat,
     pub boost_id: String,
@@ -2203,13 +2167,13 @@ pub struct ChatBoostRemoved {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct UserChatBoosts {
     pub boosts: Vec<ChatBoost>,
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct BusinessConnection {
     pub id: String,
     pub user: User,
@@ -2220,7 +2184,7 @@ pub struct BusinessConnection {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct BusinessMessagesDeleted {
     pub business_connection_id: String,
     pub chat: Chat,
@@ -2235,7 +2199,7 @@ pub enum MaybeInaccessibleMessage {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct InaccessibleMessage {
     pub chat: Chat,
     pub message_id: i32,
@@ -2251,18 +2215,18 @@ pub enum RevenueWithdrawalState {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct RevenueWithdrawalStatePending {}
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct RevenueWithdrawalStateSucceeded {
     pub date: u64,
     pub url: String,
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct RevenueWithdrawalStateFailed {}
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -2275,7 +2239,7 @@ pub enum TransactionPartner {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct TransactionPartnerUser {
     pub user: User,
     pub invoice_payload: Option<String>,
@@ -2283,21 +2247,21 @@ pub struct TransactionPartnerUser {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct TransactionPartnerFragment {
     pub withdrawal_state: Option<RevenueWithdrawalState>,
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct TransactionPartnerTelegramAds {}
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct TransactionPartnerOther {}
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct StarTransaction {
     pub id: String,
     pub amount: u32,
@@ -2307,7 +2271,7 @@ pub struct StarTransaction {
 }
 
 #[apply(serdebuilder!)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Eq)]
 pub struct StarTransactions {
     pub transactions: Vec<StarTransaction>,
 }

--- a/src/objects.rs
+++ b/src/objects.rs
@@ -6,7 +6,7 @@ use macro_rules_attribute::apply;
 use serde::{Deserialize, Serialize};
 
 use crate::api_params::FileUpload;
-use crate::macros::serdebuilder;
+use crate::macros::apistruct;
 use crate::ParseMode;
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
@@ -191,14 +191,14 @@ pub enum BackgroundFill {
     FreeformGradient(BackgroundFillFreeformGradient),
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct MenuButtonWebApp {
     pub text: String,
     pub web_app: WebAppInfo,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct ChatMemberOwner {
     pub user: User,
@@ -206,7 +206,7 @@ pub struct ChatMemberOwner {
     pub is_anonymous: bool,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct ChatMemberAdministrator {
     pub user: User,
@@ -229,14 +229,14 @@ pub struct ChatMemberAdministrator {
     pub custom_title: Option<String>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct ChatMemberMember {
     pub user: User,
     pub until_date: Option<u64>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct ChatMemberRestricted {
     pub user: User,
@@ -258,46 +258,46 @@ pub struct ChatMemberRestricted {
     pub until_date: u64,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct ChatMemberLeft {
     pub user: User,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct ChatMemberBanned {
     pub user: User,
     pub until_date: u64,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Copy, Eq)]
 pub struct VideoChatStarted {}
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Copy, Eq)]
 pub struct VideoChatScheduled {
     pub start_date: u64,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Copy, Eq)]
 pub struct CallbackGame {}
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct BotDescription {
     pub description: String,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct BotName {
     pub name: String,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct BotShortDescription {
     pub short_description: String,
@@ -305,7 +305,7 @@ pub struct BotShortDescription {
 
 /// Represents an incoming update from telegram.
 /// [Official documentation.](https://core.telegram.org/bots/api#update)
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 pub struct Update {
     pub update_id: u32,
 
@@ -343,7 +343,7 @@ pub enum UpdateContent {
     PurchasedPaidMedia(PaidMediaPurchased),
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct WebhookInfo {
     pub url: String,
@@ -384,7 +384,7 @@ pub enum AllowedUpdate {
     RemovedChatBoost,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct User {
     pub id: u64,
@@ -402,7 +402,7 @@ pub struct User {
     pub has_main_web_app: Option<bool>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct Chat {
     pub id: i64,
@@ -416,7 +416,7 @@ pub struct Chat {
     pub is_forum: Option<bool>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 pub struct ChatFullInfo {
     pub id: i64,
 
@@ -466,7 +466,7 @@ pub struct ChatFullInfo {
     pub location: Option<ChatLocation>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 pub struct Message {
     pub message_id: i32,
     pub message_thread_id: Option<i32>,
@@ -555,13 +555,13 @@ pub struct Message {
     pub reply_markup: Option<Box<InlineKeyboardMarkup>>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Copy, Eq)]
 pub struct MessageId {
     pub message_id: i32,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct MessageEntity {
     #[serde(rename = "type")]
@@ -574,7 +574,7 @@ pub struct MessageEntity {
     pub custom_emoji_id: Option<String>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct TextQuote {
     pub text: String,
@@ -583,7 +583,7 @@ pub struct TextQuote {
     pub is_manual: Option<bool>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 pub struct ExternalReplyInfo {
     pub origin: Option<MessageOrigin>,
     pub chat: Option<Chat>,
@@ -620,21 +620,21 @@ pub enum MessageOrigin {
     Channel(MessageOriginChannel),
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct MessageOriginUser {
     pub date: u64,
     pub sender_user: User,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct MessageOriginHiddenUser {
     pub date: u64,
     pub sender_user_name: String,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct MessageOriginChat {
     pub date: u64,
@@ -642,7 +642,7 @@ pub struct MessageOriginChat {
     pub author_signature: Option<String>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct MessageOriginChannel {
     pub date: u64,
@@ -651,7 +651,7 @@ pub struct MessageOriginChannel {
     pub author_signature: Option<String>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct LinkPreviewOptions {
     pub is_disabled: Option<bool>,
@@ -661,7 +661,7 @@ pub struct LinkPreviewOptions {
     pub show_above_text: Option<bool>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct PhotoSize {
     pub file_id: String,
@@ -671,7 +671,7 @@ pub struct PhotoSize {
     pub file_size: Option<u64>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct Animation {
     pub file_id: String,
@@ -685,7 +685,7 @@ pub struct Animation {
     pub file_size: Option<u64>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct Audio {
     pub file_id: String,
@@ -699,7 +699,7 @@ pub struct Audio {
     pub thumbnail: Option<PhotoSize>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct Document {
     pub file_id: String,
@@ -710,7 +710,7 @@ pub struct Document {
     pub file_size: Option<u64>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct Video {
     pub file_id: String,
@@ -724,7 +724,7 @@ pub struct Video {
     pub file_size: Option<u64>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct VideoNote {
     pub file_id: String,
@@ -735,7 +735,7 @@ pub struct VideoNote {
     pub file_size: Option<u64>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct Voice {
     pub file_id: String,
@@ -745,7 +745,7 @@ pub struct Voice {
     pub file_size: Option<u64>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct Contact {
     pub phone_number: String,
@@ -755,14 +755,14 @@ pub struct Contact {
     pub vcard: Option<String>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct Dice {
     pub emoji: String,
     pub value: u8,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct PollOption {
     pub text: String,
@@ -770,7 +770,7 @@ pub struct PollOption {
     pub voter_count: u32,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct InputPollOption {
     pub text: Option<String>,
@@ -778,7 +778,7 @@ pub struct InputPollOption {
     pub text_entities: Option<Vec<MessageEntity>>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct PollAnswer {
     pub poll_id: String,
@@ -787,7 +787,7 @@ pub struct PollAnswer {
     pub option_ids: Vec<u8>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct Poll {
     pub id: String,
@@ -808,7 +808,7 @@ pub struct Poll {
     pub close_date: Option<u64>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Copy)]
 pub struct Location {
     pub longitude: f64,
@@ -819,7 +819,7 @@ pub struct Location {
     pub proximity_alert_radius: Option<u32>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 pub struct Venue {
     pub location: Location,
     pub title: String,
@@ -830,7 +830,7 @@ pub struct Venue {
     pub google_place_type: Option<String>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct ProximityAlertTriggered {
     pub traveler: User,
@@ -838,25 +838,25 @@ pub struct ProximityAlertTriggered {
     pub distance: u32,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Copy, Eq)]
 pub struct MessageAutoDeleteTimerChanged {
     pub message_auto_delete_time: u32,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Copy, Eq)]
 pub struct ChatBoostAdded {
     pub boost_count: u32,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Copy, Eq)]
 pub struct BackgroundFillSolid {
     pub color: u32,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Copy, Eq)]
 pub struct BackgroundFillGradient {
     pub top_color: u32,
@@ -864,20 +864,20 @@ pub struct BackgroundFillGradient {
     pub rotation_angle: u16,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct BackgroundFillFreeformGradient {
     pub colors: Vec<u32>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct BackgroundTypeFill {
     pub fill: BackgroundFill,
     pub dark_theme_dimming: u8,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct BackgroundTypeWallpaper {
     pub document: Document,
@@ -886,7 +886,7 @@ pub struct BackgroundTypeWallpaper {
     pub is_moving: Option<bool>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct BackgroundTypePattern {
     pub document: Document,
@@ -896,13 +896,13 @@ pub struct BackgroundTypePattern {
     pub is_moving: Option<bool>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct BackgroundTypeChatTheme {
     pub theme_name: String,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct ForumTopicCreated {
     pub name: String,
@@ -910,30 +910,30 @@ pub struct ForumTopicCreated {
     pub icon_custom_emoji_id: Option<String>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct ForumTopicClosed {}
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct ForumTopicEdited {
     pub name: Option<String>,
     pub icon_custom_emoji_id: Option<String>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct ForumTopicReopened {}
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct GeneralForumTopicHidden {}
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct GeneralForumTopicUnhidden {}
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct SharedUser {
     pub user_id: u64,
@@ -943,14 +943,14 @@ pub struct SharedUser {
     pub photo: Option<Vec<PhotoSize>>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct UsersShared {
     pub request_id: i32,
     pub users: Vec<SharedUser>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct ChatShared {
     pub request_id: i32,
@@ -960,7 +960,7 @@ pub struct ChatShared {
     pub photo: Option<Vec<PhotoSize>>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct WriteAccessAllowed {
     pub from_request: Option<bool>,
@@ -968,26 +968,26 @@ pub struct WriteAccessAllowed {
     pub from_attachment_menu: Option<bool>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Copy, Eq)]
 pub struct VideoChatEnded {
     pub duration: u32,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct VideoChatParticipantsInvited {
     pub users: Option<Vec<User>>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct UserProfilePhotos {
     pub total_count: u32,
     pub photos: Vec<Vec<PhotoSize>>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct File {
     pub file_id: String,
@@ -996,7 +996,7 @@ pub struct File {
     pub file_path: Option<String>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct ReplyKeyboardMarkup {
     pub keyboard: Vec<Vec<KeyboardButton>>,
@@ -1007,7 +1007,7 @@ pub struct ReplyKeyboardMarkup {
     pub selective: Option<bool>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct KeyboardButton {
     pub text: String,
@@ -1019,7 +1019,7 @@ pub struct KeyboardButton {
     pub web_app: Option<WebAppInfo>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct KeyboardButtonRequestUsers {
     pub request_id: i32,
@@ -1031,7 +1031,7 @@ pub struct KeyboardButtonRequestUsers {
     pub request_photo: Option<bool>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct KeyboardButtonRequestChat {
     pub request_id: i32,
@@ -1047,27 +1047,27 @@ pub struct KeyboardButtonRequestChat {
     pub request_photo: Option<bool>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Copy, Eq)]
 pub struct KeyboardButtonPollType {
     #[serde(rename = "type")]
     pub type_field: Option<PollType>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Copy, Eq)]
 pub struct ReplyKeyboardRemove {
     pub remove_keyboard: bool,
     pub selective: Option<bool>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct InlineKeyboardMarkup {
     pub inline_keyboard: Vec<Vec<InlineKeyboardButton>>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct InlineKeyboardButton {
     pub text: String,
@@ -1082,7 +1082,7 @@ pub struct InlineKeyboardButton {
     pub pay: Option<bool>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct LoginUrl {
     pub url: String,
@@ -1091,7 +1091,7 @@ pub struct LoginUrl {
     pub request_write_access: Option<bool>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct SwitchInlineQueryChosenChat {
     pub query: Option<String>,
@@ -1101,7 +1101,7 @@ pub struct SwitchInlineQueryChosenChat {
     pub allow_channel_chats: Option<bool>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 pub struct CallbackQuery {
     pub id: String,
     pub from: User,
@@ -1112,7 +1112,7 @@ pub struct CallbackQuery {
     pub game_short_name: Option<String>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct ForceReply {
     pub force_reply: bool,
@@ -1120,7 +1120,7 @@ pub struct ForceReply {
     pub selective: Option<bool>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct ChatPhoto {
     pub small_file_id: String,
@@ -1129,7 +1129,7 @@ pub struct ChatPhoto {
     pub big_file_unique_id: String,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct ChatInviteLink {
     pub invite_link: String,
@@ -1143,7 +1143,7 @@ pub struct ChatInviteLink {
     pub pending_join_request_count: Option<u32>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct ChatMemberUpdated {
     pub chat: Chat,
@@ -1156,7 +1156,7 @@ pub struct ChatMemberUpdated {
     pub via_chat_folder_invite_link: Option<bool>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct ChatJoinRequest {
     pub chat: Chat,
@@ -1167,7 +1167,7 @@ pub struct ChatJoinRequest {
     pub invite_link: Option<ChatInviteLink>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Copy, Eq)]
 pub struct ChatPermissions {
     pub can_send_messages: Option<bool>,
@@ -1186,7 +1186,7 @@ pub struct ChatPermissions {
     pub can_manage_topics: Option<bool>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct Birthdate {
     pub day: u8,
@@ -1194,34 +1194,34 @@ pub struct Birthdate {
     pub year: u16,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 pub struct BusinessIntro {
     pub title: Option<String>,
     pub message: Option<String>,
     pub sticker: Option<Sticker>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 pub struct BusinessLocation {
     pub address: String,
     pub location: Option<Location>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct BusinessOpeningHoursInterval {
     pub opening_minute: u16,
     pub closing_minute: u16,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct BusinessOpeningHours {
     pub time_zone_name: String,
     pub opening_hours: Vec<BusinessOpeningHoursInterval>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 pub struct ChatLocation {
     pub location: Location,
     pub address: String,
@@ -1235,23 +1235,23 @@ pub enum ReactionType {
     Paid(ReactionTypePaid),
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct ReactionTypeEmoji {
     pub emoji: String,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct ReactionTypeCustomEmoji {
     pub custom_emoji_id: String,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct ReactionTypePaid {}
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct ReactionCount {
     #[serde(rename = "type")]
@@ -1259,7 +1259,7 @@ pub struct ReactionCount {
     pub total_count: i32,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct MessageReactionUpdated {
     pub chat: Chat,
@@ -1271,7 +1271,7 @@ pub struct MessageReactionUpdated {
     pub new_reaction: Vec<ReactionType>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct MessageReactionCountUpdated {
     pub chat: Chat,
@@ -1280,7 +1280,7 @@ pub struct MessageReactionCountUpdated {
     pub reactions: Vec<ReactionCount>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct ForumTopic {
     pub message_thread_id: i32,
@@ -1289,21 +1289,21 @@ pub struct ForumTopic {
     pub icon_custom_emoji_id: Option<String>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct BotCommand {
     pub command: String,
     pub description: String,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Copy, Eq)]
 pub struct ResponseParameters {
     pub migrate_to_chat_id: Option<i64>,
     pub retry_after: Option<u16>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 pub struct Sticker {
     pub file_id: String,
     pub file_unique_id: String,
@@ -1324,7 +1324,7 @@ pub struct Sticker {
     pub file_size: Option<u64>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 pub struct InputSticker {
     pub sticker: FileUpload,
     pub format: StickerFormat,
@@ -1333,14 +1333,14 @@ pub struct InputSticker {
     pub keywords: Option<Vec<String>>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct Story {
     pub chat: Chat,
     pub id: u64,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 pub struct StickerSet {
     pub name: String,
     pub title: String,
@@ -1355,7 +1355,7 @@ pub struct StickerSet {
     pub thumbnail: Option<PhotoSize>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 pub struct MaskPosition {
     pub point: String,
     pub x_shift: f64,
@@ -1363,7 +1363,7 @@ pub struct MaskPosition {
     pub scale: f64,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 pub struct InlineQuery {
     pub id: String,
     pub from: User,
@@ -1373,7 +1373,7 @@ pub struct InlineQuery {
     pub offset: String,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 pub struct InlineQueryResultArticle {
     pub id: String,
     pub title: String,
@@ -1387,7 +1387,7 @@ pub struct InlineQueryResultArticle {
     pub thumbnail_height: Option<u32>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 pub struct InlineQueryResultPhoto {
     pub id: String,
     pub photo_url: String,
@@ -1404,7 +1404,7 @@ pub struct InlineQueryResultPhoto {
     pub input_message_content: Option<InputMessageContent>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 pub struct InlineQueryResultGif {
     pub id: String,
     pub gif_url: String,
@@ -1422,7 +1422,7 @@ pub struct InlineQueryResultGif {
     pub input_message_content: Option<InputMessageContent>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 pub struct InlineQueryResultMpeg4Gif {
     pub id: String,
     pub mpeg4_url: String,
@@ -1440,7 +1440,7 @@ pub struct InlineQueryResultMpeg4Gif {
     pub input_message_content: Option<InputMessageContent>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 pub struct InlineQueryResultVideo {
     pub id: String,
     pub video_url: String,
@@ -1459,7 +1459,7 @@ pub struct InlineQueryResultVideo {
     pub input_message_content: Option<InputMessageContent>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 pub struct InlineQueryResultAudio {
     pub id: String,
     pub audio_url: String,
@@ -1473,7 +1473,7 @@ pub struct InlineQueryResultAudio {
     pub input_message_content: Option<InputMessageContent>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 pub struct InlineQueryResultVoice {
     pub id: String,
     pub voice_url: String,
@@ -1486,7 +1486,7 @@ pub struct InlineQueryResultVoice {
     pub input_message_content: Option<InputMessageContent>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 pub struct InlineQueryResultDocument {
     pub id: String,
     pub title: String,
@@ -1503,7 +1503,7 @@ pub struct InlineQueryResultDocument {
     pub thumbnail_height: Option<u32>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 pub struct InlineQueryResultLocation {
     pub id: String,
     pub latitude: f64,
@@ -1520,7 +1520,7 @@ pub struct InlineQueryResultLocation {
     pub thumbnail_height: Option<u32>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 pub struct InlineQueryResultVenue {
     pub id: String,
     pub latitude: f64,
@@ -1538,7 +1538,7 @@ pub struct InlineQueryResultVenue {
     pub thumbnail_height: Option<u32>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 pub struct InlineQueryResultContact {
     pub id: String,
     pub phone_number: String,
@@ -1552,7 +1552,7 @@ pub struct InlineQueryResultContact {
     pub thumbnail_height: Option<u32>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct InlineQueryResultGame {
     pub id: String,
@@ -1560,7 +1560,7 @@ pub struct InlineQueryResultGame {
     pub reply_markup: Option<InlineKeyboardMarkup>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 pub struct InlineQueryResultCachedPhoto {
     pub id: String,
     pub photo_file_id: String,
@@ -1574,7 +1574,7 @@ pub struct InlineQueryResultCachedPhoto {
     pub input_message_content: Option<InputMessageContent>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 pub struct InlineQueryResultCachedGif {
     pub id: String,
     pub gif_file_id: String,
@@ -1587,7 +1587,7 @@ pub struct InlineQueryResultCachedGif {
     pub input_message_content: Option<InputMessageContent>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 pub struct InlineQueryResultCachedMpeg4Gif {
     pub id: String,
     pub mpeg4_file_id: String,
@@ -1600,7 +1600,7 @@ pub struct InlineQueryResultCachedMpeg4Gif {
     pub input_message_content: Option<InputMessageContent>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 pub struct InlineQueryResultCachedSticker {
     pub id: String,
     pub sticker_file_id: String,
@@ -1608,7 +1608,7 @@ pub struct InlineQueryResultCachedSticker {
     pub input_message_content: Option<InputMessageContent>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 pub struct InlineQueryResultCachedDocument {
     pub id: String,
     pub title: String,
@@ -1621,7 +1621,7 @@ pub struct InlineQueryResultCachedDocument {
     pub input_message_content: Option<InputMessageContent>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 pub struct InlineQueryResultCachedVideo {
     pub id: String,
     pub video_file_id: String,
@@ -1635,7 +1635,7 @@ pub struct InlineQueryResultCachedVideo {
     pub input_message_content: Option<InputMessageContent>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 pub struct InlineQueryResultCachedVoice {
     pub id: String,
     pub voice_file_id: String,
@@ -1647,7 +1647,7 @@ pub struct InlineQueryResultCachedVoice {
     pub input_message_content: Option<InputMessageContent>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 pub struct InlineQueryResultCachedAudio {
     pub id: String,
     pub audio_file_id: String,
@@ -1658,7 +1658,7 @@ pub struct InlineQueryResultCachedAudio {
     pub input_message_content: Option<InputMessageContent>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct InputTextMessageContent {
     pub message_text: String,
@@ -1667,7 +1667,7 @@ pub struct InputTextMessageContent {
     pub link_preview_options: Option<LinkPreviewOptions>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Copy)]
 pub struct InputLocationMessageContent {
     pub latitude: f64,
@@ -1678,7 +1678,7 @@ pub struct InputLocationMessageContent {
     pub proximity_alert_radius: Option<u32>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct InputInvoiceMessageContent {
     pub title: String,
@@ -1703,7 +1703,7 @@ pub struct InputInvoiceMessageContent {
     pub is_flexible: Option<bool>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 pub struct InputVenueMessageContent {
     pub latitude: f64,
     pub longitude: f64,
@@ -1715,7 +1715,7 @@ pub struct InputVenueMessageContent {
     pub google_place_type: Option<String>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct InputContactMessageContent {
     pub phone_number: String,
@@ -1724,7 +1724,7 @@ pub struct InputContactMessageContent {
     pub vcard: Option<String>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 pub struct ChosenInlineResult {
     pub result_id: String,
     pub from: User,
@@ -1733,14 +1733,14 @@ pub struct ChosenInlineResult {
     pub query: String,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct LabeledPrice {
     pub label: String,
     pub amount: u32,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct Invoice {
     pub title: String,
@@ -1750,7 +1750,7 @@ pub struct Invoice {
     pub total_amount: u32,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct PaidMediaInfo {
     pub star_count: u32,
@@ -1765,7 +1765,7 @@ pub enum PaidMedia {
     Video(PaidMediaVideo),
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct PaidMediaPreview {
     pub width: Option<u32>,
@@ -1773,13 +1773,13 @@ pub struct PaidMediaPreview {
     pub duration: Option<u32>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct PaidMediaPhoto {
     pub photo: Vec<PhotoSize>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct PaidMediaVideo {
     pub video: Video,
@@ -1792,13 +1792,13 @@ pub enum InputPaidMedia {
     Video(InputPaidMediaVideo),
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct InputPaidMediaPhoto {
     pub media: String,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct InputPaidMediaVideo {
     pub media: String,
@@ -1809,7 +1809,7 @@ pub struct InputPaidMediaVideo {
     pub supports_streaming: Option<bool>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct ShippingAddress {
     pub country_code: String,
@@ -1820,7 +1820,7 @@ pub struct ShippingAddress {
     pub post_code: String,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct OrderInfo {
     pub name: Option<String>,
@@ -1829,7 +1829,7 @@ pub struct OrderInfo {
     pub shipping_address: Option<ShippingAddress>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct ShippingOption {
     pub id: String,
@@ -1837,7 +1837,7 @@ pub struct ShippingOption {
     pub prices: Vec<LabeledPrice>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct SuccessfulPayment {
     pub currency: String,
@@ -1849,7 +1849,7 @@ pub struct SuccessfulPayment {
     pub provider_payment_charge_id: String,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct RefundedPayment {
     pub currency: String,
@@ -1859,7 +1859,7 @@ pub struct RefundedPayment {
     pub provider_payment_charge_id: Option<String>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct ShippingQuery {
     pub id: String,
@@ -1868,7 +1868,7 @@ pub struct ShippingQuery {
     pub shipping_address: ShippingAddress,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct PreCheckoutQuery {
     pub id: String,
@@ -1880,21 +1880,21 @@ pub struct PreCheckoutQuery {
     pub order_info: Option<OrderInfo>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct PaidMediaPurchased {
     pub from: User,
     pub paid_media_payload: String,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct PassportData {
     pub data: Vec<EncryptedPassportElement>,
     pub credentials: EncryptedCredentials,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct PassportFile {
     pub file_id: String,
@@ -1903,7 +1903,7 @@ pub struct PassportFile {
     pub file_date: u64,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct EncryptedPassportElement {
     #[serde(rename = "type")]
@@ -1919,7 +1919,7 @@ pub struct EncryptedPassportElement {
     pub hash: String,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct EncryptedCredentials {
     pub data: String,
@@ -1927,7 +1927,7 @@ pub struct EncryptedCredentials {
     pub secret: String,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct PassportElementErrorDataField {
     #[serde(rename = "type")]
@@ -1937,7 +1937,7 @@ pub struct PassportElementErrorDataField {
     pub message: String,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct PassportElementErrorFrontSide {
     #[serde(rename = "type")]
@@ -1946,7 +1946,7 @@ pub struct PassportElementErrorFrontSide {
     pub message: String,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct PassportElementErrorReverseSide {
     #[serde(rename = "type")]
@@ -1955,7 +1955,7 @@ pub struct PassportElementErrorReverseSide {
     pub message: String,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct PassportElementErrorSelfie {
     #[serde(rename = "type")]
@@ -1964,7 +1964,7 @@ pub struct PassportElementErrorSelfie {
     pub message: String,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct PassportElementErrorFile {
     #[serde(rename = "type")]
@@ -1973,7 +1973,7 @@ pub struct PassportElementErrorFile {
     pub message: String,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct PassportElementErrorFiles {
     #[serde(rename = "type")]
@@ -1982,7 +1982,7 @@ pub struct PassportElementErrorFiles {
     pub message: String,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct PassportElementErrorTranslationFile {
     #[serde(rename = "type")]
@@ -1991,7 +1991,7 @@ pub struct PassportElementErrorTranslationFile {
     pub message: String,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct PassportElementErrorTranslationFiles {
     #[serde(rename = "type")]
@@ -2000,7 +2000,7 @@ pub struct PassportElementErrorTranslationFiles {
     pub message: String,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct PassportElementErrorUnspecified {
     #[serde(rename = "type")]
@@ -2009,7 +2009,7 @@ pub struct PassportElementErrorUnspecified {
     pub message: String,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct Game {
     pub title: String,
@@ -2020,7 +2020,7 @@ pub struct Game {
     pub animation: Option<Animation>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct GameHighScore {
     pub position: u32,
@@ -2028,13 +2028,13 @@ pub struct GameHighScore {
     pub score: i32,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct GiveawayCreated {
     pub prize_star_count: Option<u32>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct Giveaway {
     pub chats: Vec<Chat>,
@@ -2048,7 +2048,7 @@ pub struct Giveaway {
     pub premium_subscription_month_count: Option<u32>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct GiveawayWinners {
     pub chat: Chat,
@@ -2065,7 +2065,7 @@ pub struct GiveawayWinners {
     pub prize_description: Option<String>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 pub struct GiveawayCompleted {
     pub winner_count: u32,
     pub unclaimed_prize_count: Option<u32>,
@@ -2073,7 +2073,7 @@ pub struct GiveawayCompleted {
     pub is_star_giveaway: Option<bool>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Copy, Eq)]
 pub struct ChatAdministratorRights {
     pub is_anonymous: bool,
@@ -2093,19 +2093,19 @@ pub struct ChatAdministratorRights {
     pub can_manage_topics: Option<bool>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct WebAppInfo {
     pub url: String,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct SentWebAppMessage {
     pub inline_message_id: String,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct WebAppData {
     pub data: String,
@@ -2120,19 +2120,19 @@ pub enum ChatBoostSource {
     Giveaway(ChatBoostSourceGiveaway),
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct ChatBoostSourcePremium {
     pub user: User,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct ChatBoostSourceGiftCode {
     pub user: User,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct ChatBoostSourceGiveaway {
     pub giveaway_message_id: i32,
@@ -2141,7 +2141,7 @@ pub struct ChatBoostSourceGiveaway {
     pub is_unclaimed: Option<bool>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct ChatBoost {
     pub boost_id: String,
@@ -2150,14 +2150,14 @@ pub struct ChatBoost {
     pub source: ChatBoostSource,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct ChatBoostUpdated {
     pub chat: Chat,
     pub boost: ChatBoost,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct ChatBoostRemoved {
     pub chat: Chat,
@@ -2166,13 +2166,13 @@ pub struct ChatBoostRemoved {
     pub source: ChatBoostSource,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct UserChatBoosts {
     pub boosts: Vec<ChatBoost>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct BusinessConnection {
     pub id: String,
@@ -2183,7 +2183,7 @@ pub struct BusinessConnection {
     pub is_enabled: bool,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct BusinessMessagesDeleted {
     pub business_connection_id: String,
@@ -2198,7 +2198,7 @@ pub enum MaybeInaccessibleMessage {
     InaccessibleMessage(InaccessibleMessage),
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct InaccessibleMessage {
     pub chat: Chat,
@@ -2214,18 +2214,18 @@ pub enum RevenueWithdrawalState {
     Failed(RevenueWithdrawalStateFailed),
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct RevenueWithdrawalStatePending {}
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct RevenueWithdrawalStateSucceeded {
     pub date: u64,
     pub url: String,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct RevenueWithdrawalStateFailed {}
 
@@ -2238,7 +2238,7 @@ pub enum TransactionPartner {
     Other(TransactionPartnerOther),
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct TransactionPartnerUser {
     pub user: User,
@@ -2246,21 +2246,21 @@ pub struct TransactionPartnerUser {
     pub paid_media: Option<Vec<PaidMedia>>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct TransactionPartnerFragment {
     pub withdrawal_state: Option<RevenueWithdrawalState>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct TransactionPartnerTelegramAds {}
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct TransactionPartnerOther {}
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct StarTransaction {
     pub id: String,
@@ -2270,7 +2270,7 @@ pub struct StarTransaction {
     pub receiver: Option<TransactionPartner>,
 }
 
-#[apply(serdebuilder!)]
+#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct StarTransactions {
     pub transactions: Vec<StarTransaction>,

--- a/src/objects.rs
+++ b/src/objects.rs
@@ -405,7 +405,6 @@ pub struct User {
 #[derive(Eq)]
 pub struct Chat {
     pub id: i64,
-
     #[serde(rename = "type")]
     pub type_field: ChatType,
     pub title: Option<String>,
@@ -418,7 +417,6 @@ pub struct Chat {
 #[apply(apistruct!)]
 pub struct ChatFullInfo {
     pub id: i64,
-
     #[serde(rename = "type")]
     pub type_field: ChatType,
     pub title: Option<String>,
@@ -796,7 +794,6 @@ pub struct Poll {
     pub total_voter_count: u32,
     pub is_closed: bool,
     pub is_anonymous: bool,
-
     #[serde(rename = "type")]
     pub type_field: PollType,
     pub allows_multiple_answers: bool,
@@ -1306,7 +1303,6 @@ pub struct ResponseParameters {
 pub struct Sticker {
     pub file_id: String,
     pub file_unique_id: String,
-
     #[serde(rename = "type")]
     pub sticker_type: StickerType,
     pub width: u32,
@@ -1343,10 +1339,8 @@ pub struct Story {
 pub struct StickerSet {
     pub name: String,
     pub title: String,
-
     #[serde(rename = "sticker_type")]
     pub sticker_type: StickerType,
-
     #[doc(hidden)]
     #[deprecated(since = "0.19.2", note = "Please use `sticker_type` instead")]
     pub contains_masks: bool,

--- a/src/objects.rs
+++ b/src/objects.rs
@@ -18,7 +18,7 @@ pub enum StickerType {
 }
 
 #[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(rename_all = "lowercase")]
+#[serde(rename_all = "snake_case")]
 pub enum StickerFormat {
     Static,
     Animated,
@@ -36,7 +36,7 @@ pub enum InputMessageContent {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(tag = "status", rename_all = "lowercase")]
+#[serde(tag = "status", rename_all = "snake_case")]
 pub enum ChatMember {
     Creator(ChatMemberOwner),
     Administrator(ChatMemberAdministrator),
@@ -47,7 +47,7 @@ pub enum ChatMember {
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(rename_all = "lowercase")]
+#[serde(rename_all = "snake_case")]
 pub enum ChatType {
     Private,
     Group,
@@ -82,7 +82,7 @@ pub enum MessageEntityType {
 }
 
 #[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(rename_all = "lowercase")]
+#[serde(rename_all = "snake_case")]
 pub enum PollType {
     Regular,
     Quiz,

--- a/src/objects.rs
+++ b/src/objects.rs
@@ -4,10 +4,9 @@
 
 use macro_rules_attribute::apply;
 use serde::{Deserialize, Serialize};
-use serde_with::skip_serializing_none;
 
 use crate::api_params::FileUpload;
-use crate::macros::builder;
+use crate::macros::serdebuilder;
 use crate::ParseMode;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -192,25 +191,23 @@ pub enum BackgroundFill {
     FreeformGradient(BackgroundFillFreeformGradient),
 }
 
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct MenuButtonWebApp {
     pub text: String,
     pub web_app: WebAppInfo,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ChatMemberOwner {
     pub user: User,
     pub custom_title: Option<String>,
     pub is_anonymous: bool,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ChatMemberAdministrator {
     pub user: User,
     pub can_be_edited: bool,
@@ -232,16 +229,15 @@ pub struct ChatMemberAdministrator {
     pub custom_title: Option<String>,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ChatMemberMember {
     pub user: User,
     pub until_date: Option<u64>,
 }
 
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ChatMemberRestricted {
     pub user: User,
     pub is_member: bool,
@@ -262,54 +258,55 @@ pub struct ChatMemberRestricted {
     pub until_date: u64,
 }
 
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ChatMemberLeft {
     pub user: User,
 }
 
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ChatMemberBanned {
     pub user: User,
     pub until_date: u64,
 }
 
-#[apply(builder!)]
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct VideoChatStarted {}
 
-#[apply(builder!)]
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct VideoChatScheduled {
     pub start_date: u64,
 }
 
-#[apply(builder!)]
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct CallbackGame {}
 
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BotDescription {
     pub description: String,
 }
 
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BotName {
     pub name: String,
 }
 
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BotShortDescription {
     pub short_description: String,
 }
 
 /// Represents an incoming update from telegram.
 /// [Official documentation.](https://core.telegram.org/bots/api#update)
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Update {
     pub update_id: u32,
 
@@ -347,9 +344,8 @@ pub enum UpdateContent {
     PurchasedPaidMedia(PaidMediaPurchased),
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct WebhookInfo {
     pub url: String,
     pub has_custom_certificate: bool,
@@ -389,9 +385,8 @@ pub enum AllowedUpdate {
     RemovedChatBoost,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct User {
     pub id: u64,
     pub is_bot: bool,
@@ -408,9 +403,8 @@ pub struct User {
     pub has_main_web_app: Option<bool>,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Chat {
     pub id: i64,
 
@@ -423,9 +417,8 @@ pub struct Chat {
     pub is_forum: Option<bool>,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct ChatFullInfo {
     pub id: i64,
 
@@ -475,9 +468,8 @@ pub struct ChatFullInfo {
     pub location: Option<ChatLocation>,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Message {
     pub message_id: i32,
     pub message_thread_id: Option<i32>,
@@ -566,15 +558,14 @@ pub struct Message {
     pub reply_markup: Option<Box<InlineKeyboardMarkup>>,
 }
 
-#[apply(builder!)]
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct MessageId {
     pub message_id: i32,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct MessageEntity {
     #[serde(rename = "type")]
     pub type_field: MessageEntityType,
@@ -586,9 +577,8 @@ pub struct MessageEntity {
     pub custom_emoji_id: Option<String>,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct TextQuote {
     pub text: String,
     pub entities: Option<Vec<MessageEntity>>,
@@ -596,9 +586,8 @@ pub struct TextQuote {
     pub is_manual: Option<bool>,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[apply(serdebuilder!)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct ExternalReplyInfo {
     pub origin: Option<MessageOrigin>,
     pub chat: Option<Chat>,
@@ -635,32 +624,30 @@ pub enum MessageOrigin {
     Channel(MessageOriginChannel),
 }
 
-#[apply(builder!)]
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct MessageOriginUser {
     pub date: u64,
     pub sender_user: User,
 }
 
-#[apply(builder!)]
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct MessageOriginHiddenUser {
     pub date: u64,
     pub sender_user_name: String,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct MessageOriginChat {
     pub date: u64,
     pub sender_chat: Chat,
     pub author_signature: Option<String>,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct MessageOriginChannel {
     pub date: u64,
     pub chat: Chat,
@@ -668,9 +655,8 @@ pub struct MessageOriginChannel {
     pub author_signature: Option<String>,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct LinkPreviewOptions {
     pub is_disabled: Option<bool>,
     pub url: Option<String>,
@@ -679,9 +665,8 @@ pub struct LinkPreviewOptions {
     pub show_above_text: Option<bool>,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PhotoSize {
     pub file_id: String,
     pub file_unique_id: String,
@@ -690,9 +675,8 @@ pub struct PhotoSize {
     pub file_size: Option<u64>,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Animation {
     pub file_id: String,
     pub file_unique_id: String,
@@ -705,9 +689,8 @@ pub struct Animation {
     pub file_size: Option<u64>,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Audio {
     pub file_id: String,
     pub file_unique_id: String,
@@ -720,9 +703,8 @@ pub struct Audio {
     pub thumbnail: Option<PhotoSize>,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Document {
     pub file_id: String,
     pub file_unique_id: String,
@@ -732,9 +714,8 @@ pub struct Document {
     pub file_size: Option<u64>,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Video {
     pub file_id: String,
     pub file_unique_id: String,
@@ -747,9 +728,8 @@ pub struct Video {
     pub file_size: Option<u64>,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct VideoNote {
     pub file_id: String,
     pub file_unique_id: String,
@@ -759,9 +739,8 @@ pub struct VideoNote {
     pub file_size: Option<u64>,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Voice {
     pub file_id: String,
     pub file_unique_id: String,
@@ -770,9 +749,8 @@ pub struct Voice {
     pub file_size: Option<u64>,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Contact {
     pub phone_number: String,
     pub first_name: String,
@@ -781,34 +759,31 @@ pub struct Contact {
     pub vcard: Option<String>,
 }
 
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Dice {
     pub emoji: String,
     pub value: u8,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PollOption {
     pub text: String,
     pub text_entities: Option<Vec<MessageEntity>>,
     pub voter_count: u32,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct InputPollOption {
     pub text: Option<String>,
     pub text_parse_mode: Option<ParseMode>,
     pub text_entities: Option<Vec<MessageEntity>>,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PollAnswer {
     pub poll_id: String,
     pub voter_chat: Option<Chat>,
@@ -816,9 +791,8 @@ pub struct PollAnswer {
     pub option_ids: Vec<u8>,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Poll {
     pub id: String,
     pub question: String,
@@ -838,9 +812,8 @@ pub struct Poll {
     pub close_date: Option<u64>,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Location {
     pub longitude: f64,
     pub latitude: f64,
@@ -850,9 +823,8 @@ pub struct Location {
     pub proximity_alert_radius: Option<u32>,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Venue {
     pub location: Location,
     pub title: String,
@@ -863,56 +835,55 @@ pub struct Venue {
     pub google_place_type: Option<String>,
 }
 
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ProximityAlertTriggered {
     pub traveler: User,
     pub watcher: User,
     pub distance: u32,
 }
 
-#[apply(builder!)]
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct MessageAutoDeleteTimerChanged {
     pub message_auto_delete_time: u32,
 }
 
-#[apply(builder!)]
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ChatBoostAdded {
     pub boost_count: u32,
 }
 
-#[apply(builder!)]
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct BackgroundFillSolid {
     pub color: u32,
 }
 
-#[apply(builder!)]
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct BackgroundFillGradient {
     pub top_color: u32,
     pub bottom_color: u32,
     pub rotation_angle: u16,
 }
 
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BackgroundFillFreeformGradient {
     pub colors: Vec<u32>,
 }
 
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BackgroundTypeFill {
     pub fill: BackgroundFill,
     pub dark_theme_dimming: u8,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BackgroundTypeWallpaper {
     pub document: Document,
     pub dark_theme_dimming: u8,
@@ -920,9 +891,8 @@ pub struct BackgroundTypeWallpaper {
     pub is_moving: Option<bool>,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BackgroundTypePattern {
     pub document: Document,
     pub fill: BackgroundFill,
@@ -931,48 +901,45 @@ pub struct BackgroundTypePattern {
     pub is_moving: Option<bool>,
 }
 
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BackgroundTypeChatTheme {
     pub theme_name: String,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ForumTopicCreated {
     pub name: String,
     pub icon_color: u32,
     pub icon_custom_emoji_id: Option<String>,
 }
 
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ForumTopicClosed {}
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ForumTopicEdited {
     pub name: Option<String>,
     pub icon_custom_emoji_id: Option<String>,
 }
 
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ForumTopicReopened {}
 
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct GeneralForumTopicHidden {}
 
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct GeneralForumTopicUnhidden {}
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SharedUser {
     pub user_id: u64,
     pub first_name: Option<String>,
@@ -981,16 +948,15 @@ pub struct SharedUser {
     pub photo: Option<Vec<PhotoSize>>,
 }
 
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct UsersShared {
     pub request_id: i32,
     pub users: Vec<SharedUser>,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ChatShared {
     pub request_id: i32,
     pub chat_id: i64,
@@ -999,38 +965,35 @@ pub struct ChatShared {
     pub photo: Option<Vec<PhotoSize>>,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct WriteAccessAllowed {
     pub from_request: Option<bool>,
     pub web_app_name: Option<String>,
     pub from_attachment_menu: Option<bool>,
 }
 
-#[apply(builder!)]
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct VideoChatEnded {
     pub duration: u32,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct VideoChatParticipantsInvited {
     pub users: Option<Vec<User>>,
 }
 
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct UserProfilePhotos {
     pub total_count: u32,
     pub photos: Vec<Vec<PhotoSize>>,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct File {
     pub file_id: String,
     pub file_unique_id: String,
@@ -1038,9 +1001,8 @@ pub struct File {
     pub file_path: Option<String>,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ReplyKeyboardMarkup {
     pub keyboard: Vec<Vec<KeyboardButton>>,
     pub is_persistent: Option<bool>,
@@ -1050,9 +1012,8 @@ pub struct ReplyKeyboardMarkup {
     pub selective: Option<bool>,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct KeyboardButton {
     pub text: String,
     pub request_users: Option<KeyboardButtonRequestUsers>,
@@ -1063,9 +1024,8 @@ pub struct KeyboardButton {
     pub web_app: Option<WebAppInfo>,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct KeyboardButtonRequestUsers {
     pub request_id: i32,
     pub user_is_bot: Option<bool>,
@@ -1076,9 +1036,8 @@ pub struct KeyboardButtonRequestUsers {
     pub request_photo: Option<bool>,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct KeyboardButtonRequestChat {
     pub request_id: i32,
     pub chat_is_channel: bool,
@@ -1093,31 +1052,28 @@ pub struct KeyboardButtonRequestChat {
     pub request_photo: Option<bool>,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct KeyboardButtonPollType {
     #[serde(rename = "type")]
     pub type_field: Option<PollType>,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ReplyKeyboardRemove {
     pub remove_keyboard: bool,
     pub selective: Option<bool>,
 }
 
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct InlineKeyboardMarkup {
     pub inline_keyboard: Vec<Vec<InlineKeyboardButton>>,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct InlineKeyboardButton {
     pub text: String,
     pub url: Option<String>,
@@ -1131,9 +1087,8 @@ pub struct InlineKeyboardButton {
     pub pay: Option<bool>,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LoginUrl {
     pub url: String,
     pub forward_text: Option<String>,
@@ -1141,9 +1096,8 @@ pub struct LoginUrl {
     pub request_write_access: Option<bool>,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SwitchInlineQueryChosenChat {
     pub query: Option<String>,
     pub allow_user_chats: Option<bool>,
@@ -1152,9 +1106,8 @@ pub struct SwitchInlineQueryChosenChat {
     pub allow_channel_chats: Option<bool>,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct CallbackQuery {
     pub id: String,
     pub from: User,
@@ -1165,17 +1118,16 @@ pub struct CallbackQuery {
     pub game_short_name: Option<String>,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ForceReply {
     pub force_reply: bool,
     pub input_field_placeholder: Option<String>,
     pub selective: Option<bool>,
 }
 
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ChatPhoto {
     pub small_file_id: String,
     pub small_file_unique_id: String,
@@ -1183,9 +1135,8 @@ pub struct ChatPhoto {
     pub big_file_unique_id: String,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ChatInviteLink {
     pub invite_link: String,
     pub creator: User,
@@ -1198,9 +1149,8 @@ pub struct ChatInviteLink {
     pub pending_join_request_count: Option<u32>,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ChatMemberUpdated {
     pub chat: Chat,
     pub from: User,
@@ -1212,9 +1162,8 @@ pub struct ChatMemberUpdated {
     pub via_chat_folder_invite_link: Option<bool>,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ChatJoinRequest {
     pub chat: Chat,
     pub from: User,
@@ -1224,9 +1173,8 @@ pub struct ChatJoinRequest {
     pub invite_link: Option<ChatInviteLink>,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ChatPermissions {
     pub can_send_messages: Option<bool>,
     pub can_send_audios: Option<bool>,
@@ -1244,47 +1192,45 @@ pub struct ChatPermissions {
     pub can_manage_topics: Option<bool>,
 }
 
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Birthdate {
     pub day: u8,
     pub month: u8,
     pub year: u16,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct BusinessIntro {
     pub title: Option<String>,
     pub message: Option<String>,
     pub sticker: Option<Sticker>,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct BusinessLocation {
     pub address: String,
     pub location: Option<Location>,
 }
 
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BusinessOpeningHoursInterval {
     pub opening_minute: u16,
     pub closing_minute: u16,
 }
 
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BusinessOpeningHours {
     pub time_zone_name: String,
     pub opening_hours: Vec<BusinessOpeningHoursInterval>,
 }
 
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct ChatLocation {
     pub location: Location,
     pub address: String,
@@ -1298,33 +1244,32 @@ pub enum ReactionType {
     Paid(ReactionTypePaid),
 }
 
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ReactionTypeEmoji {
     pub emoji: String,
 }
 
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ReactionTypeCustomEmoji {
     pub custom_emoji_id: String,
 }
 
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ReactionTypePaid {}
 
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ReactionCount {
     #[serde(rename = "type")]
     pub type_field: ReactionType,
     pub total_count: i32,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct MessageReactionUpdated {
     pub chat: Chat,
     pub message_id: i32,
@@ -1335,8 +1280,8 @@ pub struct MessageReactionUpdated {
     pub new_reaction: Vec<ReactionType>,
 }
 
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct MessageReactionCountUpdated {
     pub chat: Chat,
     pub message_id: i32,
@@ -1344,9 +1289,8 @@ pub struct MessageReactionCountUpdated {
     pub reactions: Vec<ReactionCount>,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub struct ForumTopic {
     pub message_thread_id: i32,
     pub name: String,
@@ -1354,24 +1298,22 @@ pub struct ForumTopic {
     pub icon_custom_emoji_id: Option<String>,
 }
 
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BotCommand {
     pub command: String,
     pub description: String,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ResponseParameters {
     pub migrate_to_chat_id: Option<i64>,
     pub retry_after: Option<u16>,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Sticker {
     pub file_id: String,
     pub file_unique_id: String,
@@ -1392,9 +1334,8 @@ pub struct Sticker {
     pub file_size: Option<u64>,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct InputSticker {
     pub sticker: FileUpload,
     pub format: StickerFormat,
@@ -1403,16 +1344,15 @@ pub struct InputSticker {
     pub keywords: Option<Vec<String>>,
 }
 
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Story {
     pub chat: Chat,
     pub id: u64,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct StickerSet {
     pub name: String,
     pub title: String,
@@ -1427,8 +1367,8 @@ pub struct StickerSet {
     pub thumbnail: Option<PhotoSize>,
 }
 
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct MaskPosition {
     pub point: String,
     pub x_shift: f64,
@@ -1436,9 +1376,8 @@ pub struct MaskPosition {
     pub scale: f64,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct InlineQuery {
     pub id: String,
     pub from: User,
@@ -1448,9 +1387,8 @@ pub struct InlineQuery {
     pub offset: String,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct InlineQueryResultArticle {
     pub id: String,
     pub title: String,
@@ -1464,9 +1402,8 @@ pub struct InlineQueryResultArticle {
     pub thumbnail_height: Option<u32>,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct InlineQueryResultPhoto {
     pub id: String,
     pub photo_url: String,
@@ -1483,9 +1420,8 @@ pub struct InlineQueryResultPhoto {
     pub input_message_content: Option<InputMessageContent>,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct InlineQueryResultGif {
     pub id: String,
     pub gif_url: String,
@@ -1503,9 +1439,8 @@ pub struct InlineQueryResultGif {
     pub input_message_content: Option<InputMessageContent>,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct InlineQueryResultMpeg4Gif {
     pub id: String,
     pub mpeg4_url: String,
@@ -1523,9 +1458,8 @@ pub struct InlineQueryResultMpeg4Gif {
     pub input_message_content: Option<InputMessageContent>,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct InlineQueryResultVideo {
     pub id: String,
     pub video_url: String,
@@ -1544,9 +1478,8 @@ pub struct InlineQueryResultVideo {
     pub input_message_content: Option<InputMessageContent>,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct InlineQueryResultAudio {
     pub id: String,
     pub audio_url: String,
@@ -1560,9 +1493,8 @@ pub struct InlineQueryResultAudio {
     pub input_message_content: Option<InputMessageContent>,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct InlineQueryResultVoice {
     pub id: String,
     pub voice_url: String,
@@ -1575,9 +1507,8 @@ pub struct InlineQueryResultVoice {
     pub input_message_content: Option<InputMessageContent>,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct InlineQueryResultDocument {
     pub id: String,
     pub title: String,
@@ -1594,9 +1525,8 @@ pub struct InlineQueryResultDocument {
     pub thumbnail_height: Option<u32>,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct InlineQueryResultLocation {
     pub id: String,
     pub latitude: f64,
@@ -1613,9 +1543,8 @@ pub struct InlineQueryResultLocation {
     pub thumbnail_height: Option<u32>,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct InlineQueryResultVenue {
     pub id: String,
     pub latitude: f64,
@@ -1633,9 +1562,8 @@ pub struct InlineQueryResultVenue {
     pub thumbnail_height: Option<u32>,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct InlineQueryResultContact {
     pub id: String,
     pub phone_number: String,
@@ -1649,18 +1577,16 @@ pub struct InlineQueryResultContact {
     pub thumbnail_height: Option<u32>,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct InlineQueryResultGame {
     pub id: String,
     pub game_short_name: String,
     pub reply_markup: Option<InlineKeyboardMarkup>,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct InlineQueryResultCachedPhoto {
     pub id: String,
     pub photo_file_id: String,
@@ -1674,9 +1600,8 @@ pub struct InlineQueryResultCachedPhoto {
     pub input_message_content: Option<InputMessageContent>,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct InlineQueryResultCachedGif {
     pub id: String,
     pub gif_file_id: String,
@@ -1689,9 +1614,8 @@ pub struct InlineQueryResultCachedGif {
     pub input_message_content: Option<InputMessageContent>,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct InlineQueryResultCachedMpeg4Gif {
     pub id: String,
     pub mpeg4_file_id: String,
@@ -1704,9 +1628,8 @@ pub struct InlineQueryResultCachedMpeg4Gif {
     pub input_message_content: Option<InputMessageContent>,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct InlineQueryResultCachedSticker {
     pub id: String,
     pub sticker_file_id: String,
@@ -1714,9 +1637,8 @@ pub struct InlineQueryResultCachedSticker {
     pub input_message_content: Option<InputMessageContent>,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct InlineQueryResultCachedDocument {
     pub id: String,
     pub title: String,
@@ -1729,9 +1651,8 @@ pub struct InlineQueryResultCachedDocument {
     pub input_message_content: Option<InputMessageContent>,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct InlineQueryResultCachedVideo {
     pub id: String,
     pub video_file_id: String,
@@ -1745,9 +1666,8 @@ pub struct InlineQueryResultCachedVideo {
     pub input_message_content: Option<InputMessageContent>,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct InlineQueryResultCachedVoice {
     pub id: String,
     pub voice_file_id: String,
@@ -1759,9 +1679,8 @@ pub struct InlineQueryResultCachedVoice {
     pub input_message_content: Option<InputMessageContent>,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct InlineQueryResultCachedAudio {
     pub id: String,
     pub audio_file_id: String,
@@ -1772,9 +1691,8 @@ pub struct InlineQueryResultCachedAudio {
     pub input_message_content: Option<InputMessageContent>,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct InputTextMessageContent {
     pub message_text: String,
     pub parse_mode: Option<ParseMode>,
@@ -1782,9 +1700,8 @@ pub struct InputTextMessageContent {
     pub link_preview_options: Option<LinkPreviewOptions>,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct InputLocationMessageContent {
     pub latitude: f64,
     pub longitude: f64,
@@ -1794,9 +1711,8 @@ pub struct InputLocationMessageContent {
     pub proximity_alert_radius: Option<u32>,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct InputInvoiceMessageContent {
     pub title: String,
     pub description: String,
@@ -1820,9 +1736,8 @@ pub struct InputInvoiceMessageContent {
     pub is_flexible: Option<bool>,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct InputVenueMessageContent {
     pub latitude: f64,
     pub longitude: f64,
@@ -1834,9 +1749,8 @@ pub struct InputVenueMessageContent {
     pub google_place_type: Option<String>,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct InputContactMessageContent {
     pub phone_number: String,
     pub first_name: String,
@@ -1844,9 +1758,8 @@ pub struct InputContactMessageContent {
     pub vcard: Option<String>,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct ChosenInlineResult {
     pub result_id: String,
     pub from: User,
@@ -1855,15 +1768,15 @@ pub struct ChosenInlineResult {
     pub query: String,
 }
 
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LabeledPrice {
     pub label: String,
     pub amount: u32,
 }
 
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Invoice {
     pub title: String,
     pub description: String,
@@ -1872,8 +1785,8 @@ pub struct Invoice {
     pub total_amount: u32,
 }
 
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PaidMediaInfo {
     pub star_count: u32,
     pub paid_media: Vec<PaidMedia>,
@@ -1887,21 +1800,22 @@ pub enum PaidMedia {
     Video(PaidMediaVideo),
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PaidMediaPreview {
     pub width: Option<u32>,
     pub height: Option<u32>,
     pub duration: Option<u32>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PaidMediaPhoto {
     pub photo: Vec<PhotoSize>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PaidMediaVideo {
     pub video: Video,
 }
@@ -1913,15 +1827,14 @@ pub enum InputPaidMedia {
     Video(InputPaidMediaVideo),
 }
 
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct InputPaidMediaPhoto {
     pub media: String,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct InputPaidMediaVideo {
     pub media: String,
     pub thumbnail: String,
@@ -1931,8 +1844,8 @@ pub struct InputPaidMediaVideo {
     pub supports_streaming: Option<bool>,
 }
 
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ShippingAddress {
     pub country_code: String,
     pub state: String,
@@ -1942,9 +1855,8 @@ pub struct ShippingAddress {
     pub post_code: String,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct OrderInfo {
     pub name: Option<String>,
     pub phone_number: Option<String>,
@@ -1952,17 +1864,16 @@ pub struct OrderInfo {
     pub shipping_address: Option<ShippingAddress>,
 }
 
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ShippingOption {
     pub id: String,
     pub title: String,
     pub prices: Vec<LabeledPrice>,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SuccessfulPayment {
     pub currency: String,
     pub total_amount: u32,
@@ -1973,8 +1884,8 @@ pub struct SuccessfulPayment {
     pub provider_payment_charge_id: String,
 }
 
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RefundedPayment {
     pub currency: String,
     pub total_amount: u32,
@@ -1983,8 +1894,8 @@ pub struct RefundedPayment {
     pub provider_payment_charge_id: Option<String>,
 }
 
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ShippingQuery {
     pub id: String,
     pub from: User,
@@ -1992,9 +1903,8 @@ pub struct ShippingQuery {
     pub shipping_address: ShippingAddress,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PreCheckoutQuery {
     pub id: String,
     pub from: User,
@@ -2005,22 +1915,22 @@ pub struct PreCheckoutQuery {
     pub order_info: Option<OrderInfo>,
 }
 
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PaidMediaPurchased {
     pub from: User,
     pub paid_media_payload: String,
 }
 
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PassportData {
     pub data: Vec<EncryptedPassportElement>,
     pub credentials: EncryptedCredentials,
 }
 
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PassportFile {
     pub file_id: String,
     pub file_unique_id: String,
@@ -2028,9 +1938,8 @@ pub struct PassportFile {
     pub file_date: u64,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct EncryptedPassportElement {
     #[serde(rename = "type")]
     pub type_field: EncryptedPassportElementType,
@@ -2045,16 +1954,16 @@ pub struct EncryptedPassportElement {
     pub hash: String,
 }
 
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct EncryptedCredentials {
     pub data: String,
     pub hash: String,
     pub secret: String,
 }
 
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PassportElementErrorDataField {
     #[serde(rename = "type")]
     pub type_field: PassportElementErrorDataFieldType,
@@ -2063,8 +1972,8 @@ pub struct PassportElementErrorDataField {
     pub message: String,
 }
 
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PassportElementErrorFrontSide {
     #[serde(rename = "type")]
     pub type_field: PassportElementErrorFrontSideType,
@@ -2072,8 +1981,8 @@ pub struct PassportElementErrorFrontSide {
     pub message: String,
 }
 
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PassportElementErrorReverseSide {
     #[serde(rename = "type")]
     pub type_field: PassportElementErrorReverseSideType,
@@ -2081,8 +1990,8 @@ pub struct PassportElementErrorReverseSide {
     pub message: String,
 }
 
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PassportElementErrorSelfie {
     #[serde(rename = "type")]
     pub type_field: PassportElementErrorSelfieType,
@@ -2090,8 +1999,8 @@ pub struct PassportElementErrorSelfie {
     pub message: String,
 }
 
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PassportElementErrorFile {
     #[serde(rename = "type")]
     pub type_field: PassportElementErrorFileType,
@@ -2099,8 +2008,8 @@ pub struct PassportElementErrorFile {
     pub message: String,
 }
 
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PassportElementErrorFiles {
     #[serde(rename = "type")]
     pub type_field: PassportElementErrorFileType,
@@ -2108,8 +2017,8 @@ pub struct PassportElementErrorFiles {
     pub message: String,
 }
 
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PassportElementErrorTranslationFile {
     #[serde(rename = "type")]
     pub type_field: PassportElementErrorTranslationFileType,
@@ -2117,8 +2026,8 @@ pub struct PassportElementErrorTranslationFile {
     pub message: String,
 }
 
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PassportElementErrorTranslationFiles {
     #[serde(rename = "type")]
     pub type_field: PassportElementErrorTranslationFileType,
@@ -2126,8 +2035,8 @@ pub struct PassportElementErrorTranslationFiles {
     pub message: String,
 }
 
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PassportElementErrorUnspecified {
     #[serde(rename = "type")]
     pub type_field: EncryptedPassportElementType,
@@ -2135,9 +2044,8 @@ pub struct PassportElementErrorUnspecified {
     pub message: String,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Game {
     pub title: String,
     pub description: String,
@@ -2147,24 +2055,22 @@ pub struct Game {
     pub animation: Option<Animation>,
 }
 
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct GameHighScore {
     pub position: u32,
     pub user: User,
     pub score: i32,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct GiveawayCreated {
     pub prize_star_count: Option<u32>,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Giveaway {
     pub chats: Vec<Chat>,
     pub winners_selection_date: u64,
@@ -2177,9 +2083,8 @@ pub struct Giveaway {
     pub premium_subscription_month_count: Option<u32>,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct GiveawayWinners {
     pub chat: Chat,
     pub giveaway_message_id: i32,
@@ -2195,9 +2100,8 @@ pub struct GiveawayWinners {
     pub prize_description: Option<String>,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct GiveawayCompleted {
     pub winner_count: u32,
     pub unclaimed_prize_count: Option<u32>,
@@ -2205,9 +2109,8 @@ pub struct GiveawayCompleted {
     pub is_star_giveaway: Option<bool>,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ChatAdministratorRights {
     pub is_anonymous: bool,
     pub can_manage_chat: bool,
@@ -2226,20 +2129,20 @@ pub struct ChatAdministratorRights {
     pub can_manage_topics: Option<bool>,
 }
 
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct WebAppInfo {
     pub url: String,
 }
 
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SentWebAppMessage {
     pub inline_message_id: String,
 }
 
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct WebAppData {
     pub data: String,
     pub button_text: String,
@@ -2253,21 +2156,20 @@ pub enum ChatBoostSource {
     Giveaway(ChatBoostSourceGiveaway),
 }
 
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ChatBoostSourcePremium {
     pub user: User,
 }
 
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ChatBoostSourceGiftCode {
     pub user: User,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ChatBoostSourceGiveaway {
     pub giveaway_message_id: i32,
     pub user: Option<User>,
@@ -2275,8 +2177,8 @@ pub struct ChatBoostSourceGiveaway {
     pub is_unclaimed: Option<bool>,
 }
 
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ChatBoost {
     pub boost_id: String,
     pub add_date: u64,
@@ -2284,15 +2186,15 @@ pub struct ChatBoost {
     pub source: ChatBoostSource,
 }
 
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ChatBoostUpdated {
     pub chat: Chat,
     pub boost: ChatBoost,
 }
 
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ChatBoostRemoved {
     pub chat: Chat,
     pub boost_id: String,
@@ -2300,14 +2202,14 @@ pub struct ChatBoostRemoved {
     pub source: ChatBoostSource,
 }
 
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct UserChatBoosts {
     pub boosts: Vec<ChatBoost>,
 }
 
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BusinessConnection {
     pub id: String,
     pub user: User,
@@ -2317,8 +2219,8 @@ pub struct BusinessConnection {
     pub is_enabled: bool,
 }
 
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BusinessMessagesDeleted {
     pub business_connection_id: String,
     pub chat: Chat,
@@ -2332,8 +2234,8 @@ pub enum MaybeInaccessibleMessage {
     InaccessibleMessage(InaccessibleMessage),
 }
 
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct InaccessibleMessage {
     pub chat: Chat,
     pub message_id: i32,
@@ -2348,19 +2250,19 @@ pub enum RevenueWithdrawalState {
     Failed(RevenueWithdrawalStateFailed),
 }
 
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RevenueWithdrawalStatePending {}
 
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RevenueWithdrawalStateSucceeded {
     pub date: u64,
     pub url: String,
 }
 
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RevenueWithdrawalStateFailed {}
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -2372,33 +2274,30 @@ pub enum TransactionPartner {
     Other(TransactionPartnerOther),
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TransactionPartnerUser {
     pub user: User,
     pub invoice_payload: Option<String>,
     pub paid_media: Option<Vec<PaidMedia>>,
 }
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TransactionPartnerFragment {
     pub withdrawal_state: Option<RevenueWithdrawalState>,
 }
 
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TransactionPartnerTelegramAds {}
 
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TransactionPartnerOther {}
 
-#[skip_serializing_none]
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct StarTransaction {
     pub id: String,
     pub amount: u32,
@@ -2407,8 +2306,8 @@ pub struct StarTransaction {
     pub receiver: Option<TransactionPartner>,
 }
 
-#[apply(builder!)]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[apply(serdebuilder!)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct StarTransactions {
     pub transactions: Vec<StarTransaction>,
 }

--- a/src/response.rs
+++ b/src/response.rs
@@ -8,12 +8,12 @@ use serde::{Deserialize, Serialize};
 
 use crate::objects::{Message, ResponseParameters};
 
+#[serde_with::skip_serializing_none]
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct MethodResponse<T> {
     /// Always true
     pub ok: bool,
     pub result: T,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
 }
 
@@ -24,6 +24,7 @@ pub struct MethodResponse<T> {
 /// Some errors may also have an optional field `parameters` of the type `ResponseParameters`, which can help to automatically handle the error.
 ///
 /// See <https://core.telegram.org/bots/api#making-requests>
+#[serde_with::skip_serializing_none]
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ErrorResponse {
     /// Always false
@@ -31,7 +32,6 @@ pub struct ErrorResponse {
     pub description: String,
     /// Contents are subject to change in the future
     pub error_code: u64,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub parameters: Option<ResponseParameters>,
 }
 


### PR DESCRIPTION
This combines all the serde and builder settings for the API structs into a single macro. [`serde_with::skip_serializing_none`](https://docs.rs/serde_with/3.9.0/serde_with/attr.skip_serializing_none.html) allows removing all the `#[serde(skip_serializing_if = "Option::is_none")]`.

Doing something similar for the enums results in more lines before, so I just cleaned them up to use the same order of derives.

Nothing of this PR should be breaking.