### PR TITLE
build!: rename the features and remove the default feature

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -131,7 +131,7 @@ jobs:
             features: --all-features
             os: ubuntu-latest
           - triple: wasm32-unknown-unknown
-            features: --no-default-features --features=async-http-client
+            features: --features=client-reqwest
             os: ubuntu-latest
 
           - triple: x86_64-apple-darwin

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,11 +14,10 @@ categories = ["web-programming::http-client"]
 all-features = true
 
 [features]
-default = ["http-client"]
-http-client = ["telegram-trait", "dep:ureq", "dep:multipart", "dep:mime_guess", "dep:serde_json"]
-telegram-trait = []
-async-http-client = ["async-telegram-trait", "dep:reqwest", "dep:tokio", "dep:serde_json"]
-async-telegram-trait = ["dep:async-trait"]
+client-reqwest = ["trait-async", "dep:reqwest", "dep:tokio", "dep:serde_json"]
+client-ureq = ["trait-sync", "dep:ureq", "dep:multipart", "dep:mime_guess", "dep:serde_json"]
+trait-async = ["dep:async-trait"]
+trait-sync = []
 
 [lints.rust]
 unsafe_code = "forbid"
@@ -34,43 +33,43 @@ unreadable_literal = "allow"
 
 [[example]]
 name = "get_me"
-required-features = ["http-client"]
+required-features = ["client-ureq"]
 
 [[example]]
 name = "reply_to_message_updates"
-required-features = ["http-client"]
+required-features = ["client-ureq"]
 
 [[example]]
 name = "reply_keyboard"
-required-features = ["http-client"]
+required-features = ["client-ureq"]
 
 [[example]]
 name = "inline_keyboard"
-required-features = ["http-client"]
+required-features = ["client-ureq"]
 
 [[example]]
 name = "custom_client"
-required-features = ["http-client"]
+required-features = ["client-ureq"]
 
 [[example]]
 name = "async_get_me"
-required-features = ["async-http-client"]
+required-features = ["client-reqwest"]
 
 [[example]]
 name = "async_reply_to_message_updates"
-required-features = ["async-http-client"]
+required-features = ["client-reqwest"]
 
 [[example]]
 name = "async_file_upload"
-required-features = ["async-http-client"]
+required-features = ["client-reqwest"]
 
 [[example]]
 name = "async_custom_client"
-required-features = ["async-http-client"]
+required-features = ["client-reqwest"]
 
 [[example]]
 name = "api_trait_implementation"
-required-features = ["telegram-trait"]
+required-features = ["trait-sync"]
 
 [dependencies]
 bon = "3.0.0"

--- a/README.md
+++ b/README.md
@@ -16,33 +16,26 @@ Run `cargo add frankenstein` or add the following to your `Cargo.toml`.
 
 ```toml
 [dependencies]
-frankenstein = "0.38"
+frankenstein = { version = "0.39", features = [] }
 ```
+
+You likely want to use either a blocking or an async client. Enable it via the [Features](#features).
 
 ## Features
 
-### Default features
+Without enabling any additional features this crate will only ship with Telegram types.
 
-- `http-client` - a blocking HTTP client (uses `ureq`), it's the only default feature
-- `telegram-trait` - a blocking API trait, it's included in the `http-client` feature. It may be useful for people who want to create a custom blocking client (for example, replacing an HTTP client)
+- blocking (synchronous)
+  - `client-ureq` - a blocking HTTP API client based on `ureq`
+  - `trait-sync` - a blocking API trait, it's included in the `client-ureq` feature. It may be useful for people who want to create a custom blocking client (for example, replacing an HTTP client)
+- async
+  - `client-reqwest` - an async HTTP API client based on `reqwest`. This client partially supports wasm32, but file uploads are currently not supported there.
+  - `trait-async` - an async API trait, it's used in the `client-reqwest`. It may be useful for people who want to create a custom async client
 
-### Optional features
-
-- `async-http-client` - an async HTTP client, it uses `reqwest`, and it's disabled by default
-- `async-telegram-trait` - an async API trait, it's used in the `async-http-client`. It may be useful for people who want to create a custom async client
-
-To use the async client add the following line to your `Cargo.toml` file:
-
-```toml
-frankenstein = { version = "0.37", default-features = false, features = ["async-http-client"] }
-```
-
-The async client partially supports wasm32 target, file uploads in the wasm32 target are not supported.
-
-You can also disable all features. In this case the crate will ship only with Telegram types.
+For example for the async client add the following line to your `Cargo.toml` file:
 
 ```toml
-frankenstein = { version = "0.37", default-features = false }
+frankenstein = { version = "0.39", features = ["client-reqwest"] }
 ```
 
 ## Usage
@@ -202,11 +195,10 @@ You can check out real-world bots created using this library:
 ## Replacing the default HTTP client
 
 The library uses `ureq` HTTP client by default, but it can be easily replaced with any HTTP client of your choice.
-
-`ureq` comes with a default feature (`impl`). So the feature should be disabled.
+This is described here for the `trait-sync` and can be done similarly with `trait-async` based on your needs.
 
 ```toml
-frankenstein = { version = "0.37", default-features = false, features = ["telegram-trait"] }
+frankenstein = { version = "0.39", features = ["trait-sync"] }
 ```
 
 Then implement the `TelegramApi` trait for your HTTP client which requires two functions:
@@ -217,8 +209,6 @@ Then implement the `TelegramApi` trait for your HTTP client which requires two f
 You can check [the default `TelegramApi` trait implementation](https://github.com/ayrat555/frankenstein/blob/aac88c01d06aa945393db7255ef2485a7c764d47/src/api_impl.rs) for `ureq`.
 
 Also, you can take a look at the [implementation for `isahc` HTTP client](https://github.com/ayrat555/frankenstein/blob/master/examples/api_trait_implementation.rs) in the `examples` directory.
-
-Without the default `ureq` implementation, `frankenstein` has only one dependency - `serde`.
 
 ## Contributing
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,40 +1,40 @@
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![cfg_attr(test, allow(dead_code))]
 
-#[cfg(feature = "async-http-client")]
+#[cfg(feature = "client-reqwest")]
 pub use reqwest;
-#[cfg(feature = "http-client")]
+#[cfg(feature = "client-ureq")]
 pub use ureq;
 
 pub use self::api_params::*;
-#[cfg(feature = "async-http-client")]
+#[cfg(feature = "client-reqwest")]
 pub use self::client_reqwest::*;
-#[cfg(feature = "http-client")]
+#[cfg(feature = "client-ureq")]
 pub use self::client_ureq::*;
 pub use self::error::Error;
 pub use self::objects::*;
 pub use self::parse_mode::ParseMode;
 pub use self::response::*;
-#[cfg(feature = "async-telegram-trait")]
+#[cfg(feature = "trait-async")]
 pub use self::trait_async::AsyncTelegramApi;
-#[cfg(feature = "telegram-trait")]
+#[cfg(feature = "trait-sync")]
 pub use self::trait_sync::TelegramApi;
 
 pub mod api_params;
-#[cfg(feature = "async-http-client")]
+#[cfg(feature = "client-reqwest")]
 mod client_reqwest;
-#[cfg(feature = "http-client")]
+#[cfg(feature = "client-ureq")]
 mod client_ureq;
 mod error;
-#[cfg(any(test, feature = "http-client", feature = "async-http-client"))]
+#[cfg(any(test, feature = "client-ureq", feature = "client-reqwest"))]
 mod json;
 mod macros;
 pub mod objects;
 mod parse_mode;
 pub mod response;
-#[cfg(feature = "async-telegram-trait")]
+#[cfg(feature = "trait-async")]
 mod trait_async;
-#[cfg(feature = "telegram-trait")]
+#[cfg(feature = "trait-sync")]
 mod trait_sync;
 
 /// Default Bot API URL


### PR DESCRIPTION
This will definitely break for people as the default is gone and all features have different names. But I think the names are more helpful.