### PR TITLE
feat(error)!: more specific errors including their source

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ unsafe_code = "forbid"
 [lints.clippy]
 pedantic = { level = "warn", priority = -1 }
 nursery = { level = "warn", priority = -1 }
+result_large_err = "allow" # due to ureq::Error
 struct_excessive_bools = "allow" # due to Telegram API
 
 # TODO: remove and fix (or allow explicitly on the specific problem)

--- a/src/client_reqwest.rs
+++ b/src/client_reqwest.rs
@@ -88,6 +88,7 @@ impl AsyncTelegramApi for AsyncApi {
         Self::decode_response(response).await
     }
 
+    #[cfg_attr(target_arch = "wasm32", allow(unused_variables))]
     async fn request_with_form_data<Params, Output>(
         &self,
         method: &str,

--- a/src/client_reqwest.rs
+++ b/src/client_reqwest.rs
@@ -145,11 +145,7 @@ impl AsyncTelegramApi for AsyncApi {
         }
 
         #[cfg(target_arch = "wasm32")]
-        {
-            Err(Error::Encode(format!(
-                "calling {method:?} with files is currently unsupported in WASM due to missing form_data / attachment support. Was called with params {params:?} and files {files:?}",
-            )))
-        }
+        Err(Error::WasmHasNoFileSupportYet)
     }
 }
 

--- a/src/client_reqwest.rs
+++ b/src/client_reqwest.rs
@@ -39,31 +39,24 @@ impl AsyncApi {
         Self::builder().api_url(api_url).build()
     }
 
-    pub async fn decode_response<Output>(response: reqwest::Response) -> Result<Output, Error>
+    async fn decode_response<Output>(response: reqwest::Response) -> Result<Output, Error>
     where
         Output: serde::de::DeserializeOwned,
     {
-        let status_code = response.status().as_u16();
-        match response.text().await {
-            Ok(message) => {
-                if status_code == 200 {
-                    Ok(crate::json::decode(&message)?)
-                } else {
-                    Err(Error::Api(crate::json::decode(&message)?))
-                }
-            }
-            Err(error) => Err(Error::Decode(format!("{error:?}"))),
+        let success = response.status().is_success();
+        let message = response.text().await?;
+        if success {
+            Ok(crate::json::decode(&message)?)
+        } else {
+            Err(Error::Api(crate::json::decode(&message)?))
         }
     }
 }
 
 impl From<reqwest::Error> for Error {
     fn from(error: reqwest::Error) -> Self {
-        let message = error.to_string();
-        let code = error
-            .status()
-            .map_or(500, |status_code| status_code.as_u16());
-        Self::Http { code, message }
+        // Prevent leakage of the bot token as its within the path
+        Self::HttpReqwest(error.without_url())
     }
 }
 
@@ -140,7 +133,7 @@ impl AsyncTelegramApi for AsyncApi {
             for (parameter_name, file_path, file_name) in files_with_paths {
                 let file = tokio::fs::File::open(file_path)
                     .await
-                    .map_err(|error| Error::Encode(error.to_string()))?;
+                    .map_err(Error::ReadFile)?;
                 let part = multipart::Part::stream(file).file_name(file_name);
                 form = form.part(parameter_name, part);
             }
@@ -161,10 +154,9 @@ impl AsyncTelegramApi for AsyncApi {
 }
 
 #[cfg(test)]
-mod async_tests {
+mod tests {
     use super::*;
     use crate::api_params::SendMessageParams;
-    use crate::json;
 
     #[tokio::test]
     async fn async_send_message_success() {
@@ -186,7 +178,7 @@ mod async_tests {
         mock.assert();
         drop(server);
 
-        json::assert_str(&response, response_string);
+        crate::test_json::assert_json_str(&response, response_string);
     }
 
     #[tokio::test]

--- a/src/error.rs
+++ b/src/error.rs
@@ -23,6 +23,10 @@ pub enum Error {
     #[error("Read File Error: {0}")]
     ReadFile(#[source] std::io::Error),
 
+    #[cfg(all(feature = "client-reqwest", target_arch = "wasm32"))]
+    #[error("Handling files is not yet supported in Wasm due to missing form_data / attachment support. Pull Request welcome!")]
+    WasmHasNoFileSupportYet,
+
     #[cfg(feature = "client-reqwest")]
     #[error("HTTP error: {0}")]
     HttpReqwest(#[source] reqwest::Error),

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,19 +1,38 @@
-use serde::{Deserialize, Serialize};
-
 use crate::response::ErrorResponse;
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, thiserror::Error)]
+#[allow(clippy::large_enum_variant)]
+#[derive(Debug, thiserror::Error)]
 #[non_exhaustive]
-#[serde(untagged)]
 pub enum Error {
-    #[error("Http Error {code}: {message}")]
-    Http { code: u16, message: String },
     #[error("Api Error {0:?}")]
     Api(ErrorResponse),
-    #[error("Decode Error {0}")]
-    Decode(String),
-    #[error("Encode Error {0}")]
-    Encode(String),
+
+    #[cfg(any(feature = "client-reqwest", feature = "client-ureq"))]
+    #[error("JSON Decode Error: {source} on {input}")]
+    JsonDecode {
+        source: serde_json::Error,
+        input: String,
+    },
+    #[cfg(any(feature = "client-reqwest", feature = "client-ureq"))]
+    #[error("JSON Encode Error: {source} on {input}")]
+    JsonEncode {
+        source: serde_json::Error,
+        input: String,
+    },
+
+    #[error("Read File Error: {0}")]
+    ReadFile(#[source] std::io::Error),
+
+    #[cfg(feature = "client-reqwest")]
+    #[error("HTTP error: {0}")]
+    HttpReqwest(#[source] reqwest::Error),
+
+    #[cfg(feature = "client-ureq")]
+    #[error("HTTP error: {0}")]
+    HttpUreq(#[source] ureq::Transport),
+    #[cfg(feature = "client-ureq")]
+    #[error("Decode Body Error: {0}")]
+    DecodeUreqBody(#[source] std::io::Error),
 }
 
 impl Error {

--- a/src/json.rs
+++ b/src/json.rs
@@ -5,7 +5,10 @@ pub fn decode<T>(string: &str) -> Result<T, Error>
 where
     T: serde::de::DeserializeOwned,
 {
-    serde_json::from_str(string).map_err(|error| Error::Decode(format!("{error:?} : {string:?}")))
+    serde_json::from_str(string).map_err(|error| Error::JsonDecode {
+        source: error,
+        input: string.to_owned(),
+    })
 }
 
 /// Shortcut for [`serde_json::to_string`] with [`crate::Error`].
@@ -13,33 +16,8 @@ pub fn encode<T>(value: &T) -> Result<String, Error>
 where
     T: serde::ser::Serialize + std::fmt::Debug,
 {
-    serde_json::to_string(value).map_err(|error| Error::Encode(format!("{error:?} : {value:?}")))
-}
-
-#[cfg(test)]
-#[track_caller]
-pub fn assert_str<T>(value: &T, expected: &str)
-where
-    T: serde::ser::Serialize,
-{
-    let actual = serde_json::to_string(value).expect("Should be able to stringify to JSON");
-    assert!(
-        expected == actual,
-        "value should equal the expected JSON\n expected: {expected}\n   actual: {actual}"
-    );
-}
-
-#[test]
-fn assert_str_works() {
-    let value = serde_json::json!({"code": 42});
-    let expected = r#"{"code":42}"#;
-    assert_str(&value, expected);
-}
-
-#[test]
-#[should_panic = "value should equal the expected JSON"]
-fn assert_str_fails() {
-    let value = serde_json::json!({"code": 42});
-    let expected = r#"{"foo":"bar"}"#;
-    assert_str(&value, expected);
+    serde_json::to_string(value).map_err(|error| Error::JsonEncode {
+        source: error,
+        input: format!("{value:?}"),
+    })
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,12 +26,14 @@ mod client_reqwest;
 #[cfg(feature = "client-ureq")]
 mod client_ureq;
 mod error;
-#[cfg(any(test, feature = "client-ureq", feature = "client-reqwest"))]
+#[cfg(any(feature = "client-reqwest", feature = "client-ureq"))]
 mod json;
 mod macros;
 pub mod objects;
 mod parse_mode;
 pub mod response;
+#[cfg(test)]
+mod test_json;
 #[cfg(feature = "trait-async")]
 mod trait_async;
 #[cfg(feature = "trait-sync")]

--- a/src/parse_mode.rs
+++ b/src/parse_mode.rs
@@ -51,10 +51,10 @@ impl Display for ParseMode {
 
 #[test]
 fn serde_markdown_works() {
-    crate::json::assert_str(&ParseMode::MarkdownV2, r#""MarkdownV2""#);
+    crate::test_json::assert_json_str(&ParseMode::MarkdownV2, r#""MarkdownV2""#);
 }
 
 #[test]
 fn serde_html_works() {
-    crate::json::assert_str(&ParseMode::Html, r#""HTML""#);
+    crate::test_json::assert_json_str(&ParseMode::Html, r#""HTML""#);
 }

--- a/src/test_json.rs
+++ b/src/test_json.rs
@@ -1,0 +1,26 @@
+#[track_caller]
+pub fn assert_json_str<T>(value: &T, expected: &str)
+where
+    T: serde::ser::Serialize,
+{
+    let actual = serde_json::to_string(value).expect("Should be able to stringify to JSON");
+    assert!(
+        expected == actual,
+        "value should equal the expected JSON\n expected: {expected}\n   actual: {actual}"
+    );
+}
+
+#[test]
+fn assert_str_works() {
+    let value = serde_json::json!({"code": 42});
+    let expected = r#"{"code":42}"#;
+    assert_json_str(&value, expected);
+}
+
+#[test]
+#[should_panic = "value should equal the expected JSON"]
+fn assert_str_fails() {
+    let value = serde_json::json!({"code": 42});
+    let expected = r#"{"foo":"bar"}"#;
+    assert_json_str(&value, expected);
+}


### PR DESCRIPTION
Bugfix: A failing file doesn't panic anymore with client-ureq.

BREAKING CHANGE: decode_response methods are now private. They probably shouldn't have been public in the first place
BREAKING CHANGE: mostly all Error variants are now different (only the Api error response is the same)