### PR TITLE
fix: attach video cover correctly as a file

### DIFF
--- a/src/trait_async.rs
+++ b/src/trait_async.rs
@@ -185,6 +185,16 @@ where
                         files.push((name, input_file.path.clone()));
                     }
 
+                    if let Some(FileUpload::InputFile(input_file)) = &video.cover {
+                        let name = format!("file{file_idx}");
+                        let attach_name = format!("attach://{name}");
+                        file_idx += 1;
+
+                        new_video.cover = Some(FileUpload::String(attach_name));
+
+                        files.push((name, input_file.path.clone()));
+                    }
+
                     if let Some(FileUpload::InputFile(input_file)) = &video.thumbnail {
                         let name = format!("file{file_idx}");
                         let attach_name = format!("attach://{name}");
@@ -240,6 +250,10 @@ where
 
         if let FileUpload::InputFile(input_file) = &params.video {
             files.push(("video", input_file.path.clone()));
+        }
+
+        if let Some(FileUpload::InputFile(input_file)) = &params.cover {
+            files.push(("cover", input_file.path.clone()));
         }
 
         if let Some(FileUpload::InputFile(input_file)) = &params.thumbnail {
@@ -483,6 +497,15 @@ where
                     let attach_name = format!("attach://{name}");
 
                     new_video.media = FileUpload::String(attach_name);
+
+                    files.push((name, input_file.path.clone()));
+                }
+
+                if let Some(FileUpload::InputFile(input_file)) = &video.cover {
+                    let name = "video_thumb".to_string();
+                    let attach_name = format!("attach://{name}");
+
+                    new_video.cover = Some(FileUpload::String(attach_name));
 
                     files.push((name, input_file.path.clone()));
                 }

--- a/src/trait_sync.rs
+++ b/src/trait_sync.rs
@@ -169,6 +169,16 @@ pub trait TelegramApi {
                         files.push((name, input_file.path.clone()));
                     }
 
+                    if let Some(FileUpload::InputFile(input_file)) = &video.cover {
+                        let name = format!("file{file_idx}");
+                        let attach_name = format!("attach://{name}");
+                        file_idx += 1;
+
+                        new_video.cover = Some(FileUpload::String(attach_name));
+
+                        files.push((name, input_file.path.clone()));
+                    }
+
                     if let Some(FileUpload::InputFile(input_file)) = &video.thumbnail {
                         let name = format!("file{file_idx}");
                         let attach_name = format!("attach://{name}");
@@ -219,6 +229,10 @@ pub trait TelegramApi {
 
         if let FileUpload::InputFile(input_file) = &params.video {
             files.push(("video", input_file.path.clone()));
+        }
+
+        if let Some(FileUpload::InputFile(input_file)) = &params.cover {
+            files.push(("cover", input_file.path.clone()));
         }
 
         if let Some(FileUpload::InputFile(input_file)) = &params.thumbnail {
@@ -454,6 +468,15 @@ pub trait TelegramApi {
                     let attach_name = format!("attach://{name}");
 
                     new_video.media = FileUpload::String(attach_name);
+
+                    files.push((name, input_file.path.clone()));
+                }
+
+                if let Some(FileUpload::InputFile(input_file)) = &video.cover {
+                    let name = "video_thumb".to_string();
+                    let attach_name = format!("attach://{name}");
+
+                    new_video.cover = Some(FileUpload::String(attach_name));
 
                     files.push((name, input_file.path.clone()));
                 }


### PR DESCRIPTION
While #256 added the `FileUpload` for cover, it did not correctly handle the actual `FileUpload`. Which I also forgot :innocent: 