### PR TITLE
refactor(client-ureq): remove mime_guess

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -344,7 +344,6 @@ dependencies = [
  "bon",
  "isahc",
  "macro_rules_attribute",
- "mime_guess",
  "mockito",
  "multipart",
  "paste",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ all-features = true
 
 [features]
 client-reqwest = ["trait-async", "dep:reqwest", "dep:tokio", "dep:serde_json"]
-client-ureq = ["trait-sync", "dep:ureq", "dep:multipart", "dep:mime_guess", "dep:serde_json"]
+client-ureq = ["trait-sync", "dep:ureq", "dep:multipart", "dep:serde_json"]
 trait-async = ["dep:async-trait"]
 trait-sync = []
 
@@ -39,7 +39,6 @@ unreadable_literal = "allow"
 async-trait = { version = "0.1", optional = true }
 bon = "3.0.0"
 macro_rules_attribute = "0.2.0"
-mime_guess = { version = "2", optional = true }
 multipart = { version = "0.18", optional = true, default-features = false, features = ["client"] }
 paste = "1.0.2"
 serde = { version = "1.0.157", features = ["derive"] }

--- a/src/client_ureq.rs
+++ b/src/client_ureq.rs
@@ -113,13 +113,7 @@ impl TelegramApi for Bot {
 
         for (parameter_name, file_name, file_path) in files_with_names {
             let file = std::fs::File::open(&file_path).map_err(Error::ReadFile)?;
-            let file_extension = file_path
-                .extension()
-                .and_then(std::ffi::OsStr::to_str)
-                .unwrap_or("");
-            let mime = mime_guess::from_ext(file_extension).first_or_octet_stream();
-
-            form.add_stream(parameter_name, file, file_name, Some(mime));
+            form.add_stream(parameter_name, file, file_name, None);
         }
 
         let url = format!("{}/{method}", self.api_url);


### PR DESCRIPTION
While tinkering on #260 I noticed that mime_guess doesn't seem to be required. Everything I tested worked fine without. But I only tested with quite small files and the officially hosted bot API servers, not a self-hosted one.

reqwest also depends on mime_guess, so I'm not sure whether its used internally for the client-reqwest multipart stuff there. It's also possible to specify a mime with reqwest multipart, but it's not done there. Either it's not required at all or reqwest does the assumption internally which doesn't seem the case to be currently, but I haven't looked far.

@ayrat555 @pxp9 do you have any thoughts on this? There should probably more testing before something like this is changed.

