### PR TITLE
docs(examples): read token and chat from env

### DIFF
--- a/examples/api_trait_implementation.rs
+++ b/examples/api_trait_implementation.rs
@@ -6,9 +6,7 @@ use frankenstein::TelegramApi;
 use isahc::prelude::*;
 use isahc::Request;
 
-static TOKEN: &str = "TOKEN";
 static BASE_API_URL: &str = "https://api.telegram.org/bot";
-static CHAT_ID: i64 = 1;
 
 pub struct MyApiClient {
     pub api_url: String,
@@ -105,13 +103,18 @@ impl TelegramApi for MyApiClient {
 }
 
 fn main() {
-    let bot = MyApiClient::new(TOKEN);
+    let token = std::env::var("BOT_TOKEN").expect("Should have BOT_TOKEN as environment variable");
+    let chat_id = std::env::var("TARGET_CHAT")
+        .expect("Should have TARGET_CHAT as environment variable")
+        .parse::<i64>()
+        .expect("TARGET_CHAT should be i64");
+
+    let bot = MyApiClient::new(&token);
 
     let params = SendMessageParams::builder()
-        .chat_id(CHAT_ID)
+        .chat_id(chat_id)
         .text("Hello!")
         .build();
-
     let result = bot.send_message(&params);
 
     eprintln!("{result:?}");

--- a/examples/async_custom_client.rs
+++ b/examples/async_custom_client.rs
@@ -3,8 +3,20 @@ use std::time::Duration;
 use frankenstein::client_reqwest::Bot;
 use frankenstein::AsyncTelegramApi;
 
-static TOKEN: &str = "API_TOKEN";
 static BASE_API_URL: &str = "https://api.telegram.org/bot";
+
+fn custom_client() -> Bot {
+    let token = std::env::var("BOT_TOKEN").expect("Should have BOT_TOKEN as environment variable");
+
+    let client = frankenstein::reqwest::ClientBuilder::new()
+        .connect_timeout(Duration::from_secs(100))
+        .timeout(Duration::from_secs(100))
+        .build()
+        .unwrap();
+    let api_url = format!("{BASE_API_URL}{token}");
+
+    Bot::builder().api_url(api_url).client(client).build()
+}
 
 #[tokio::main]
 async fn main() {
@@ -23,15 +35,4 @@ async fn main() {
             eprintln!("Failed to get me: {error:?}");
         }
     }
-}
-
-fn custom_client() -> Bot {
-    let client = frankenstein::reqwest::ClientBuilder::new()
-        .connect_timeout(Duration::from_secs(100))
-        .timeout(Duration::from_secs(100))
-        .build()
-        .unwrap();
-    let api_url = format!("{BASE_API_URL}{TOKEN}");
-
-    Bot::builder().api_url(api_url).client(client).build()
 }

--- a/examples/async_file_upload.rs
+++ b/examples/async_file_upload.rs
@@ -2,23 +2,26 @@ use frankenstein::api_params::SendPhotoParams;
 use frankenstein::client_reqwest::Bot;
 use frankenstein::AsyncTelegramApi;
 
-static TOKEN: &str = "TOKEN";
-static CHAT_ID: i64 = 1;
-
 #[tokio::main]
 async fn main() {
-    let bot = Bot::new(TOKEN);
+    let token = std::env::var("BOT_TOKEN").expect("Should have BOT_TOKEN as environment variable");
+    let chat_id = std::env::var("TARGET_CHAT")
+        .expect("Should have TARGET_CHAT as environment variable")
+        .parse::<i64>()
+        .expect("TARGET_CHAT should be i64");
+
+    let bot = Bot::new(&token);
 
     let file = std::path::PathBuf::from("./frankenstein_logo.png");
 
     let params = SendPhotoParams::builder()
-        .chat_id(CHAT_ID)
+        .chat_id(chat_id)
         .photo(file)
         .build();
-
     match bot.send_photo(&params).await {
         Ok(response) => {
-            println!("Photo was uploaded {response:?}");
+            println!("Photo was uploaded successfully");
+            dbg!(response);
         }
         Err(error) => {
             eprintln!("Failed to upload photo: {error:?}");

--- a/examples/async_get_me.rs
+++ b/examples/async_get_me.rs
@@ -1,11 +1,11 @@
 use frankenstein::client_reqwest::Bot;
 use frankenstein::AsyncTelegramApi;
 
-static TOKEN: &str = "API_TOKEN";
-
 #[tokio::main]
 async fn main() {
-    let bot = Bot::new(TOKEN);
+    let token = std::env::var("BOT_TOKEN").expect("Should have BOT_TOKEN as environment variable");
+
+    let bot = Bot::new(&token);
 
     match bot.get_me().await {
         Ok(response) => {

--- a/examples/async_reply_to_message_updates.rs
+++ b/examples/async_reply_to_message_updates.rs
@@ -3,18 +3,17 @@ use frankenstein::client_reqwest::Bot;
 use frankenstein::objects::{Message, UpdateContent};
 use frankenstein::AsyncTelegramApi;
 
-static TOKEN: &str = "API_TOKEN";
-
 #[tokio::main]
 async fn main() {
-    let bot = Bot::new(TOKEN);
+    let token = std::env::var("BOT_TOKEN").expect("Should have BOT_TOKEN as environment variable");
+
+    let bot = Bot::new(&token);
 
     let mut update_params = GetUpdatesParams::builder().build();
 
     loop {
         let result = bot.get_updates(&update_params).await;
-
-        println!("result: {result:?}");
+        dbg!(&result);
 
         match result {
             Ok(response) => {

--- a/examples/custom_client.rs
+++ b/examples/custom_client.rs
@@ -3,8 +3,23 @@ use std::time::Duration;
 use frankenstein::client_ureq::Bot;
 use frankenstein::TelegramApi;
 
-static TOKEN: &str = "API_TOKEN";
 static BASE_API_URL: &str = "https://api.telegram.org/bot";
+
+fn custom_client() -> Bot {
+    let token = std::env::var("BOT_TOKEN").expect("Should have BOT_TOKEN as environment variable");
+
+    let config = frankenstein::ureq::Agent::config_builder()
+        .http_status_as_error(false)
+        .timeout_global(Some(Duration::from_secs(100)))
+        .build();
+    let request_agent = frankenstein::ureq::Agent::new_with_config(config);
+    let api_url = format!("{BASE_API_URL}{token}");
+
+    Bot::builder()
+        .api_url(api_url)
+        .request_agent(request_agent)
+        .build()
+}
 
 fn main() {
     let bot = custom_client();
@@ -22,18 +37,4 @@ fn main() {
             eprintln!("Failed to get me: {error:?}");
         }
     }
-}
-
-fn custom_client() -> Bot {
-    let config = frankenstein::ureq::Agent::config_builder()
-        .http_status_as_error(false)
-        .timeout_global(Some(Duration::from_secs(100)))
-        .build();
-    let request_agent = frankenstein::ureq::Agent::new_with_config(config);
-    let api_url = format!("{BASE_API_URL}{TOKEN}");
-
-    Bot::builder()
-        .api_url(api_url)
-        .request_agent(request_agent)
-        .build()
 }

--- a/examples/get_me.rs
+++ b/examples/get_me.rs
@@ -1,10 +1,10 @@
 use frankenstein::client_ureq::Bot;
 use frankenstein::TelegramApi;
 
-static TOKEN: &str = "API_TOKEN";
-
 fn main() {
-    let bot = Bot::new(TOKEN);
+    let token = std::env::var("BOT_TOKEN").expect("Should have BOT_TOKEN as environment variable");
+
+    let bot = Bot::new(&token);
 
     match bot.get_me() {
         Ok(response) => {

--- a/examples/inline_keyboard.rs
+++ b/examples/inline_keyboard.rs
@@ -3,13 +3,14 @@ use frankenstein::client_ureq::Bot;
 use frankenstein::objects::{InlineKeyboardButton, InlineKeyboardMarkup};
 use frankenstein::TelegramApi;
 
-// replace with your token
-static TOKEN: &str = "TOKEN";
-// replace with your chat id
-static CHAT_ID: i64 = 275_808_073;
-
 fn main() {
-    let bot = Bot::new(TOKEN);
+    let token = std::env::var("BOT_TOKEN").expect("Should have BOT_TOKEN as environment variable");
+    let chat_id = std::env::var("TARGET_CHAT")
+        .expect("Should have TARGET_CHAT as environment variable")
+        .parse::<i64>()
+        .expect("TARGET_CHAT should be i64");
+
+    let bot = Bot::new(&token);
 
     let mut keyboard: Vec<Vec<InlineKeyboardButton>> = Vec::new();
 
@@ -22,7 +23,6 @@ fn main() {
                 .text(name)
                 .url("https://github.com/ayrat555/frankenstein")
                 .build();
-
             row.push(button);
         }
 
@@ -32,12 +32,10 @@ fn main() {
     let inline_keyboard = InlineKeyboardMarkup::builder()
         .inline_keyboard(keyboard)
         .build();
-
     let send_message_params = SendMessageParams::builder()
-        .chat_id(CHAT_ID)
+        .chat_id(chat_id)
         .text("hello!")
         .reply_markup(ReplyMarkup::InlineKeyboardMarkup(inline_keyboard))
         .build();
-
     bot.send_message(&send_message_params).unwrap();
 }

--- a/examples/reply_keyboard.rs
+++ b/examples/reply_keyboard.rs
@@ -3,13 +3,14 @@ use frankenstein::client_ureq::Bot;
 use frankenstein::objects::{KeyboardButton, ReplyKeyboardMarkup};
 use frankenstein::TelegramApi;
 
-// replace with your token
-static TOKEN: &str = "TOKEN";
-// replace with your chat id
-static CHAT_ID: i64 = 275_808_073;
-
 fn main() {
-    let bot = Bot::new(TOKEN);
+    let token = std::env::var("BOT_TOKEN").expect("Should have BOT_TOKEN as environment variable");
+    let chat_id = std::env::var("TARGET_CHAT")
+        .expect("Should have TARGET_CHAT as environment variable")
+        .parse::<i64>()
+        .expect("TARGET_CHAT should be i64");
+
+    let bot = Bot::new(&token);
 
     let mut keyboard: Vec<Vec<KeyboardButton>> = Vec::new();
 
@@ -19,7 +20,6 @@ fn main() {
         for j in 1..5 {
             let name = format!("{i}{j}");
             let button = KeyboardButton::builder().text(name).build();
-
             row.push(button);
         }
 
@@ -27,12 +27,10 @@ fn main() {
     }
 
     let keyboard_markup = ReplyKeyboardMarkup::builder().keyboard(keyboard).build();
-
     let send_message_params = SendMessageParams::builder()
-        .chat_id(CHAT_ID)
+        .chat_id(chat_id)
         .text("hello!")
         .reply_markup(ReplyMarkup::ReplyKeyboardMarkup(keyboard_markup))
         .build();
-
     bot.send_message(&send_message_params).unwrap();
 }

--- a/examples/reply_to_message_updates.rs
+++ b/examples/reply_to_message_updates.rs
@@ -3,17 +3,16 @@ use frankenstein::client_ureq::Bot;
 use frankenstein::objects::UpdateContent;
 use frankenstein::TelegramApi;
 
-static TOKEN: &str = "API_TOKEN";
-
 fn main() {
-    let bot = Bot::new(TOKEN);
+    let token = std::env::var("BOT_TOKEN").expect("Should have BOT_TOKEN as environment variable");
+
+    let bot = Bot::new(&token);
 
     let mut update_params = GetUpdatesParams::builder().build();
 
     loop {
         let result = bot.get_updates(&update_params);
-
-        println!("result: {result:?}");
+        dbg!(&result);
 
         match result {
             Ok(response) => {


### PR DESCRIPTION
Specifying secrets (mainly the bot token) in code is not very smart and examples shouldn't encourage this.
Also, it's just simpler to run examples with specifying something once in the current shell and then run different examples without needing to change them first.