### PR TITLE
refactor!: simplify code with internal HasInputFile trait

### DIFF
--- a/src/api_params.rs
+++ b/src/api_params.rs
@@ -1,9 +1,8 @@
 //! Parameters to Telegram API methods.
 
-use std::path::PathBuf;
-
 use serde::{Deserialize, Serialize};
 
+use crate::input_file::{FileUpload, InputFile};
 use crate::macros::{apistruct, apply};
 use crate::objects::{
     AllowedUpdate, BotCommand, ChatAdministratorRights, ChatPermissions, ForceReply,
@@ -23,33 +22,6 @@ use crate::objects::{
     WebAppInfo,
 };
 use crate::ParseMode;
-
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(untagged)]
-pub enum FileUpload {
-    InputFile(InputFile),
-    String(String),
-}
-
-impl From<PathBuf> for FileUpload {
-    fn from(path: PathBuf) -> Self {
-        let input_file = InputFile { path };
-
-        Self::InputFile(input_file)
-    }
-}
-
-impl From<InputFile> for FileUpload {
-    fn from(file: InputFile) -> Self {
-        Self::InputFile(file)
-    }
-}
-
-impl From<String> for FileUpload {
-    fn from(file: String) -> Self {
-        Self::String(file)
-    }
-}
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "type", rename_all = "snake_case")]
@@ -183,12 +155,6 @@ pub struct BotCommandScopeChatAdministrators {
 pub struct BotCommandScopeChatMember {
     pub chat_id: ChatId,
     pub user_id: u64,
-}
-
-#[apply(apistruct!)]
-#[derive(Eq)]
-pub struct InputFile {
-    pub path: PathBuf,
 }
 
 #[apply(apistruct!)]

--- a/src/client_ureq.rs
+++ b/src/client_ureq.rs
@@ -141,10 +141,10 @@ mod tests {
         DeleteChatPhotoParams, DeleteChatStickerSetParams, DeleteMessageParams,
         DeleteMyCommandsParams, DeleteWebhookParams, EditChatInviteLinkParams,
         EditMessageCaptionParams, EditMessageLiveLocationParams, EditMessageMediaParams,
-        EditMessageTextParams, ExportChatInviteLinkParams, FileUpload, ForwardMessageParams,
+        EditMessageTextParams, ExportChatInviteLinkParams, ForwardMessageParams,
         GetChatAdministratorsParams, GetChatMemberCountParams, GetChatMemberParams, GetChatParams,
         GetFileParams, GetMyCommandsParams, GetStickerSetParams, GetUpdatesParams,
-        GetUserProfilePhotosParams, InlineQueryResult, InputFile, InputMedia, InputMediaPhoto,
+        GetUserProfilePhotosParams, InlineQueryResult, InputMedia, InputMediaPhoto,
         LeaveChatParams, Media, PinChatMessageParams, PromoteChatMemberParams,
         RestrictChatMemberParams, RevokeChatInviteLinkParams, SendAnimationParams, SendAudioParams,
         SendChatActionParams, SendContactParams, SendDiceParams, SendDocumentParams,
@@ -592,9 +592,8 @@ mod tests {
     #[test]
     fn send_audio_file_id_success() {
         let response_string = "{\"ok\":true,\"result\":{\"message_id\":2769,\"from\":{\"id\":1276618370,\"is_bot\":true,\"first_name\":\"test_el_bot\",\"username\":\"el_mon_test_bot\"},\"date\":1618735333,\"chat\":{\"id\":275808073,\"type\":\"private\",\"username\":\"Ayrat555\",\"first_name\":\"Ayrat\",\"last_name\":\"Badykov\"},\"audio\":{\"file_id\":\"CQACAgIAAxkDAAIK0WB78OUFavWx6fjzCQ_d5qnu_R7mAALkDAACORLgS5co1z0uFAKgHwQ\",\"file_unique_id\":\"AgAD5AwAAjkS4Es\",\"duration\":123,\"title\":\"Way Back Home\",\"file_name\":\"audio.mp3\",\"mime_type\":\"audio/mpeg\",\"file_size\":2957092}}}";
-        let file = FileUpload::String(
-            "CQACAgIAAxkDAAIKzmB78EjK-iOHo-HKC-M6p4r0jGdmAALkDAACORLgS5co1z0uFAKgHwQ".to_string(),
-        );
+        let file =
+            "CQACAgIAAxkDAAIKzmB78EjK-iOHo-HKC-M6p4r0jGdmAALkDAACORLgS5co1z0uFAKgHwQ".to_string();
         let params = SendAudioParams::builder()
             .chat_id(275808073)
             .audio(file)
@@ -666,9 +665,7 @@ mod tests {
     #[test]
     fn set_chat_photo_success() {
         let response_string = "{\"ok\":true,\"result\":true}";
-        let file = InputFile {
-            path: std::path::PathBuf::from("./frankenstein_logo.png"),
-        };
+        let file = std::path::PathBuf::from("./frankenstein_logo.png");
         let params = SetChatPhotoParams::builder()
             .chat_id(275808073)
             .photo(file)

--- a/src/input_file.rs
+++ b/src/input_file.rs
@@ -1,0 +1,130 @@
+//! Structs for handling and uploading files
+
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+
+/// Represents a new file to be uploaded via `multipart/form-data`.
+///
+/// See <https://core.telegram.org/bots/api#inputfile>.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct InputFile {
+    pub path: PathBuf,
+}
+
+impl From<PathBuf> for InputFile {
+    fn from(path: PathBuf) -> Self {
+        Self { path }
+    }
+}
+
+/// Represents different approaches of sending files.
+///
+/// See <https://core.telegram.org/bots/api#sending-files>.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(untagged)]
+pub enum FileUpload {
+    /// `file_id` to send a file that exists on the Telegram servers (recommended) or pass an HTTP URL for Telegram to get a file from the Internet
+    String(String),
+    /// upload a new file using `multipart/form-data`
+    InputFile(InputFile),
+}
+
+impl From<String> for FileUpload {
+    fn from(file: String) -> Self {
+        Self::String(file)
+    }
+}
+
+impl From<PathBuf> for FileUpload {
+    fn from(path: PathBuf) -> Self {
+        Self::InputFile(InputFile { path })
+    }
+}
+
+impl From<InputFile> for FileUpload {
+    fn from(file: InputFile) -> Self {
+        Self::InputFile(file)
+    }
+}
+
+#[cfg(any(feature = "trait-sync", feature = "trait-async"))]
+pub(crate) trait HasInputFile {
+    fn clone_path(&self) -> Option<PathBuf>;
+    fn replace_attach(&mut self, name: &str) -> Option<PathBuf>;
+    fn replace_attach_dyn(&mut self, index: impl FnOnce() -> usize) -> Option<(String, PathBuf)>;
+}
+
+#[cfg(any(feature = "trait-sync", feature = "trait-async"))]
+impl HasInputFile for FileUpload {
+    fn clone_path(&self) -> Option<PathBuf> {
+        match self {
+            Self::InputFile(input_file) => Some(input_file.path.clone()),
+            Self::String(_) => None,
+        }
+    }
+
+    fn replace_attach(&mut self, name: &str) -> Option<PathBuf> {
+        match self {
+            Self::InputFile(_) => {
+                let attach = Self::String(format!("attach://{name}"));
+                let Self::InputFile(file) = std::mem::replace(self, attach) else {
+                    unreachable!("the match already ensures it being an input file");
+                };
+                Some(file.path)
+            }
+            Self::String(_) => None,
+        }
+    }
+
+    fn replace_attach_dyn(&mut self, index: impl FnOnce() -> usize) -> Option<(String, PathBuf)> {
+        match self {
+            Self::InputFile(_) => {
+                let name = format!("file{}", index());
+                let attach = Self::String(format!("attach://{name}"));
+                let Self::InputFile(file) = std::mem::replace(self, attach) else {
+                    unreachable!("the match already ensures it being an input file");
+                };
+                Some((name, file.path))
+            }
+            Self::String(_) => None,
+        }
+    }
+}
+
+#[cfg(any(feature = "trait-sync", feature = "trait-async"))]
+impl HasInputFile for Option<FileUpload> {
+    fn clone_path(&self) -> Option<PathBuf> {
+        match self {
+            Some(FileUpload::InputFile(input_file)) => Some(input_file.path.clone()),
+            _ => None,
+        }
+    }
+
+    fn replace_attach(&mut self, name: &str) -> Option<PathBuf> {
+        match self {
+            Some(FileUpload::InputFile(_)) => {
+                let attach = Some(FileUpload::String(format!("attach://{name}")));
+                let Some(FileUpload::InputFile(file)) = std::mem::replace(self, attach) else {
+                    unreachable!("the match already ensures it being an input file");
+                };
+                Some(file.path)
+            }
+            _ => None,
+        }
+    }
+
+    fn replace_attach_dyn(&mut self, index: impl FnOnce() -> usize) -> Option<(String, PathBuf)> {
+        match self {
+            Some(FileUpload::InputFile(_)) => {
+                let name = format!("file{}", index());
+                let attach = Some(FileUpload::String(format!("attach://{name}")));
+                let Some(FileUpload::InputFile(file)) = std::mem::replace(self, attach) else {
+                    unreachable!("the match already ensures it being an input file");
+                };
+                Some((name, file.path))
+            }
+            _ => None,
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@ pub use ureq;
 
 pub use self::api_params::*;
 pub use self::error::Error;
+pub use self::input_file::*;
 pub use self::objects::*;
 pub use self::parse_mode::ParseMode;
 pub use self::response::*;
@@ -23,6 +24,7 @@ pub mod client_reqwest;
 #[cfg(feature = "client-ureq")]
 pub mod client_ureq;
 mod error;
+pub mod input_file;
 #[cfg(any(feature = "client-reqwest", feature = "client-ureq"))]
 mod json;
 mod macros;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -6,9 +6,10 @@ macro_rules_attribute::attribute_alias! {
         #[::serde_with::skip_serializing_none]
         #[derive(Clone, Debug, PartialEq, ::bon::Builder, ::serde::Serialize, ::serde::Deserialize)]
         #[builder(
-            on(String, into),
+            on(Box<_>, into),
             on(ChatId, into),
             on(FileUpload, into),
-            on(Box<_>, into),
+            on(InputFile, into),
+            on(String, into),
         )];
 }

--- a/src/objects.rs
+++ b/src/objects.rs
@@ -4,7 +4,7 @@
 
 use serde::{Deserialize, Serialize};
 
-use crate::api_params::FileUpload;
+use crate::input_file::FileUpload;
 use crate::macros::{apistruct, apply};
 use crate::ParseMode;
 

--- a/src/trait_async.rs
+++ b/src/trait_async.rs
@@ -1,9 +1,6 @@
 use std::path::PathBuf;
 
-use crate::api_params::{
-    AddStickerToSetParams, CreateNewStickerSetParams, EditMessageMediaParams, InputMedia, Media,
-    SendMediaGroupParams, SetChatPhotoParams, UploadStickerFileParams,
-};
+use crate::api_params::{InputMedia, Media};
 use crate::input_file::HasInputFile;
 use crate::objects::{
     BotCommand, BotDescription, BotName, BotShortDescription, BusinessConnection,
@@ -95,7 +92,7 @@ where
 
     async fn send_media_group(
         &self,
-        params: &SendMediaGroupParams,
+        params: &crate::api_params::SendMediaGroupParams,
     ) -> Result<MethodResponse<Vec<Message>>, Self::Error> {
         let mut files = Vec::new();
 
@@ -174,7 +171,7 @@ where
 
     async fn set_chat_photo(
         &self,
-        params: &SetChatPhotoParams,
+        params: &crate::api_params::SetChatPhotoParams,
     ) -> Result<MethodResponse<bool>, Self::Error> {
         let photo = &params.photo;
         self.request_with_form_data("setChatPhoto", params, vec![("photo", photo.path.clone())])
@@ -224,7 +221,7 @@ where
 
     async fn edit_message_media(
         &self,
-        params: &EditMessageMediaParams,
+        params: &crate::api_params::EditMessageMediaParams,
     ) -> Result<MethodResponse<MessageOrBool>, Self::Error> {
         let mut files = Vec::new();
 
@@ -274,7 +271,7 @@ where
 
     async fn upload_sticker_file(
         &self,
-        params: &UploadStickerFileParams,
+        params: &crate::api_params::UploadStickerFileParams,
     ) -> Result<MethodResponse<File>, Self::Error> {
         let sticker = &params.sticker;
         self.request_with_form_data(
@@ -287,7 +284,7 @@ where
 
     async fn create_new_sticker_set(
         &self,
-        params: &CreateNewStickerSetParams,
+        params: &crate::api_params::CreateNewStickerSetParams,
     ) -> Result<MethodResponse<bool>, Self::Error> {
         let mut files = Vec::new();
 
@@ -311,7 +308,7 @@ where
 
     async fn add_sticker_to_set(
         &self,
-        params: &AddStickerToSetParams,
+        params: &crate::api_params::AddStickerToSetParams,
     ) -> Result<MethodResponse<bool>, Self::Error> {
         let mut files = Vec::new();
         if let Some(file) = params.sticker.sticker.clone_path() {

--- a/src/trait_async.rs
+++ b/src/trait_async.rs
@@ -1,11 +1,10 @@
 use std::path::PathBuf;
 
 use crate::api_params::{
-    AddStickerToSetParams, CreateNewStickerSetParams, EditMessageMediaParams, FileUpload,
-    InputMedia, Media, SendAnimationParams, SendAudioParams, SendDocumentParams,
-    SendMediaGroupParams, SendPhotoParams, SendStickerParams, SendVideoNoteParams, SendVideoParams,
-    SendVoiceParams, SetChatPhotoParams, SetStickerSetThumbnailParams, UploadStickerFileParams,
+    AddStickerToSetParams, CreateNewStickerSetParams, EditMessageMediaParams, InputMedia, Media,
+    SendMediaGroupParams, SetChatPhotoParams, UploadStickerFileParams,
 };
+use crate::input_file::HasInputFile;
 use crate::objects::{
     BotCommand, BotDescription, BotName, BotShortDescription, BusinessConnection,
     ChatAdministratorRights, ChatFullInfo, ChatInviteLink, ChatMember, File, ForumTopic,
@@ -48,6 +47,28 @@ macro_rules! request_nb {
     }
 }
 
+/// request with some properties utilizing [`HasInputFile`]
+macro_rules! request_f {
+    ($name:ident, $return:ty, $($fileproperty:ident),+) => {
+        paste::paste! {
+            #[allow(async_fn_in_trait)]
+            #[doc = "Call the `" $name "` method.\n\nSee <https://core.telegram.org/bots/api#" $name:lower ">."]
+            async fn [<$name:snake>] (
+                &self,
+                params: &crate::api_params::[<$name:camel Params>],
+            ) -> Result<MethodResponse<$return>, Self::Error> {
+                let mut files = Vec::new();
+                $(
+                    if let Some(path) = params.$fileproperty.clone_path() {
+                        files.push((stringify!($fileproperty), path));
+                    }
+                )+
+                self.request_with_possible_form_data(stringify!($name), params, files).await
+            }
+        }
+    }
+}
+
 // Wasm target need not be `Send` because it is single-threaded
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
@@ -69,226 +90,58 @@ where
     request!(forwardMessages, Vec<MessageId>);
     request!(copyMessage, MessageId);
     request!(copyMessages, Vec<MessageId>);
-
-    async fn send_photo(
-        &self,
-        params: &SendPhotoParams,
-    ) -> Result<MethodResponse<Message>, Self::Error> {
-        let method_name = "sendPhoto";
-        let mut files = Vec::new();
-
-        if let FileUpload::InputFile(input_file) = &params.photo {
-            files.push(("photo", input_file.path.clone()));
-        }
-
-        self.request_with_possible_form_data(method_name, params, files)
-            .await
-    }
-
-    async fn send_audio(
-        &self,
-        params: &SendAudioParams,
-    ) -> Result<MethodResponse<Message>, Self::Error> {
-        let method_name = "sendAudio";
-        let mut files = Vec::new();
-
-        if let FileUpload::InputFile(input_file) = &params.audio {
-            files.push(("audio", input_file.path.clone()));
-        }
-
-        if let Some(FileUpload::InputFile(input_file)) = &params.thumbnail {
-            files.push(("thumbnail", input_file.path.clone()));
-        }
-
-        self.request_with_possible_form_data(method_name, params, files)
-            .await
-    }
+    request_f!(sendPhoto, Message, photo);
+    request_f!(sendAudio, Message, audio, thumbnail);
 
     async fn send_media_group(
         &self,
         params: &SendMediaGroupParams,
     ) -> Result<MethodResponse<Vec<Message>>, Self::Error> {
-        let method_name = "sendMediaGroup";
         let mut files = Vec::new();
 
-        let new_medias = params
-            .media
-            .iter()
-            .map(|media| match media {
+        macro_rules! replace_attach {
+            ($base:ident. $property:ident) => {
+                if let Some(file) = $base.$property.replace_attach_dyn(|| files.len()) {
+                    files.push(file);
+                }
+            };
+        }
+
+        let mut params = params.clone();
+        for media in &mut params.media {
+            match media {
                 Media::Audio(audio) => {
-                    let mut new_audio = audio.clone();
-
-                    if let FileUpload::InputFile(input_file) = &audio.media {
-                        let name = format!("file{}", files.len());
-                        new_audio.media = FileUpload::String(format!("attach://{name}"));
-                        files.push((name, input_file.path.clone()));
-                    }
-
-                    if let Some(FileUpload::InputFile(input_file)) = &audio.thumbnail {
-                        let name = format!("file{}", files.len());
-                        new_audio.thumbnail = Some(FileUpload::String(format!("attach://{name}")));
-                        files.push((name, input_file.path.clone()));
-                    }
-
-                    Media::Audio(new_audio)
+                    replace_attach!(audio.media);
+                    replace_attach!(audio.thumbnail);
                 }
                 Media::Document(document) => {
-                    let mut new_document = document.clone();
-
-                    if let FileUpload::InputFile(input_file) = &document.media {
-                        let name = format!("file{}", files.len());
-                        new_document.media = FileUpload::String(format!("attach://{name}"));
-                        files.push((name, input_file.path.clone()));
-                    }
-
-                    Media::Document(new_document)
+                    replace_attach!(document.media);
                 }
                 Media::Photo(photo) => {
-                    let mut new_photo = photo.clone();
-
-                    if let FileUpload::InputFile(input_file) = &photo.media {
-                        let name = format!("file{}", files.len());
-                        new_photo.media = FileUpload::String(format!("attach://{name}"));
-                        files.push((name, input_file.path.clone()));
-                    }
-
-                    Media::Photo(new_photo)
+                    replace_attach!(photo.media);
                 }
                 Media::Video(video) => {
-                    let mut new_video = video.clone();
-
-                    if let FileUpload::InputFile(input_file) = &video.media {
-                        let name = format!("file{}", files.len());
-                        new_video.media = FileUpload::String(format!("attach://{name}"));
-                        files.push((name, input_file.path.clone()));
-                    }
-
-                    if let Some(FileUpload::InputFile(input_file)) = &video.cover {
-                        let name = format!("file{}", files.len());
-                        new_video.cover = Some(FileUpload::String(format!("attach://{name}")));
-                        files.push((name, input_file.path.clone()));
-                    }
-
-                    if let Some(FileUpload::InputFile(input_file)) = &video.thumbnail {
-                        let name = format!("file{}", files.len());
-                        new_video.thumbnail = Some(FileUpload::String(format!("attach://{name}")));
-                        files.push((name, input_file.path.clone()));
-                    }
-
-                    Media::Video(new_video)
+                    replace_attach!(video.media);
+                    replace_attach!(video.cover);
+                    replace_attach!(video.thumbnail);
                 }
-            })
-            .collect();
-
-        let new_params = SendMediaGroupParams {
-            media: new_medias,
-            ..params.clone()
-        };
+            }
+        }
 
         let files_with_str_names = files
             .iter()
             .map(|(key, path)| (key.as_str(), path.clone()))
             .collect();
 
-        self.request_with_possible_form_data(method_name, &new_params, files_with_str_names)
+        self.request_with_possible_form_data("sendMediaGroup", &params, files_with_str_names)
             .await
     }
 
-    async fn send_document(
-        &self,
-        params: &SendDocumentParams,
-    ) -> Result<MethodResponse<Message>, Self::Error> {
-        let method_name = "sendDocument";
-        let mut files = Vec::new();
-
-        if let FileUpload::InputFile(input_file) = &params.document {
-            files.push(("document", input_file.path.clone()));
-        }
-
-        if let Some(FileUpload::InputFile(input_file)) = &params.thumbnail {
-            files.push(("thumbnail", input_file.path.clone()));
-        }
-
-        self.request_with_possible_form_data(method_name, params, files)
-            .await
-    }
-
-    async fn send_video(
-        &self,
-        params: &SendVideoParams,
-    ) -> Result<MethodResponse<Message>, Self::Error> {
-        let method_name = "sendVideo";
-        let mut files = Vec::new();
-
-        if let FileUpload::InputFile(input_file) = &params.video {
-            files.push(("video", input_file.path.clone()));
-        }
-
-        if let Some(FileUpload::InputFile(input_file)) = &params.cover {
-            files.push(("cover", input_file.path.clone()));
-        }
-
-        if let Some(FileUpload::InputFile(input_file)) = &params.thumbnail {
-            files.push(("thumbnail", input_file.path.clone()));
-        }
-
-        self.request_with_possible_form_data(method_name, params, files)
-            .await
-    }
-
-    async fn send_animation(
-        &self,
-        params: &SendAnimationParams,
-    ) -> Result<MethodResponse<Message>, Self::Error> {
-        let method_name = "sendAnimation";
-        let mut files = Vec::new();
-
-        if let FileUpload::InputFile(input_file) = &params.animation {
-            files.push(("animation", input_file.path.clone()));
-        }
-
-        if let Some(FileUpload::InputFile(input_file)) = &params.thumbnail {
-            files.push(("thumbnail", input_file.path.clone()));
-        }
-
-        self.request_with_possible_form_data(method_name, params, files)
-            .await
-    }
-
-    async fn send_voice(
-        &self,
-        params: &SendVoiceParams,
-    ) -> Result<MethodResponse<Message>, Self::Error> {
-        let method_name = "sendVoice";
-        let mut files = Vec::new();
-
-        if let FileUpload::InputFile(input_file) = &params.voice {
-            files.push(("voice", input_file.path.clone()));
-        }
-
-        self.request_with_possible_form_data(method_name, params, files)
-            .await
-    }
-
-    async fn send_video_note(
-        &self,
-        params: &SendVideoNoteParams,
-    ) -> Result<MethodResponse<Message>, Self::Error> {
-        let method_name = "sendVideoNote";
-        let mut files = Vec::new();
-
-        if let FileUpload::InputFile(input_file) = &params.video_note {
-            files.push(("video_note", input_file.path.clone()));
-        }
-
-        if let Some(FileUpload::InputFile(input_file)) = &params.thumbnail {
-            files.push(("thumbnail", input_file.path.clone()));
-        }
-
-        self.request_with_possible_form_data(method_name, params, files)
-            .await
-    }
-
+    request_f!(sendDocument, Message, document, thumbnail);
+    request_f!(sendVideo, Message, video, cover, thumbnail);
+    request_f!(sendAnimation, Message, animation, thumbnail);
+    request_f!(sendVoice, Message, voice);
+    request_f!(sendVideoNote, Message, video_note, thumbnail);
     request!(sendPaidMedia, Message);
     request!(sendLocation, Message);
     request!(editMessageLiveLocation, MessageOrBool);
@@ -373,112 +226,42 @@ where
         &self,
         params: &EditMessageMediaParams,
     ) -> Result<MethodResponse<MessageOrBool>, Self::Error> {
-        let method_name = "editMessageMedia";
         let mut files = Vec::new();
 
-        let new_media = match &params.media {
+        macro_rules! replace_attach {
+            ($base:ident. $property:ident) => {{
+                const NAME: &str = concat!(stringify!($base), "_", stringify!($property));
+                if let Some(file) = $base.$property.replace_attach(NAME) {
+                    files.push((NAME, file));
+                }
+            }};
+        }
+
+        let mut params = params.clone();
+        match &mut params.media {
             InputMedia::Animation(animation) => {
-                let mut new_animation = animation.clone();
-
-                if let FileUpload::InputFile(input_file) = &animation.media {
-                    let name = "animation";
-                    let attach_name = format!("attach://{name}");
-                    new_animation.media = FileUpload::String(attach_name);
-                    files.push((name, input_file.path.clone()));
-                }
-
-                if let Some(FileUpload::InputFile(input_file)) = &animation.thumbnail {
-                    let name = "animation_thumb";
-                    let attach_name = format!("attach://{name}");
-                    new_animation.thumbnail = Some(FileUpload::String(attach_name));
-                    files.push((name, input_file.path.clone()));
-                }
-
-                InputMedia::Animation(new_animation)
+                replace_attach!(animation.media);
+                replace_attach!(animation.thumbnail);
             }
             InputMedia::Document(document) => {
-                let mut new_document = document.clone();
-
-                if let FileUpload::InputFile(input_file) = &document.media {
-                    let name = "document";
-                    let attach_name = format!("attach://{name}");
-                    new_document.media = FileUpload::String(attach_name);
-                    files.push((name, input_file.path.clone()));
-                }
-
-                if let Some(FileUpload::InputFile(input_file)) = &document.thumbnail {
-                    let name = "document_thumb";
-                    let attach_name = format!("attach://{name}");
-                    new_document.thumbnail = Some(FileUpload::String(attach_name));
-                    files.push((name, input_file.path.clone()));
-                }
-
-                InputMedia::Document(new_document)
+                replace_attach!(document.media);
+                replace_attach!(document.thumbnail);
             }
             InputMedia::Audio(audio) => {
-                let mut new_audio = audio.clone();
-
-                if let FileUpload::InputFile(input_file) = &audio.media {
-                    let name = "audio";
-                    let attach_name = format!("attach://{name}");
-                    new_audio.media = FileUpload::String(attach_name);
-                    files.push((name, input_file.path.clone()));
-                }
-
-                if let Some(FileUpload::InputFile(input_file)) = &audio.thumbnail {
-                    let name = "audio_thumb";
-                    let attach_name = format!("attach://{name}");
-                    new_audio.thumbnail = Some(FileUpload::String(attach_name));
-                    files.push((name, input_file.path.clone()));
-                }
-
-                InputMedia::Audio(new_audio)
+                replace_attach!(audio.media);
+                replace_attach!(audio.thumbnail);
             }
             InputMedia::Photo(photo) => {
-                let mut new_photo = photo.clone();
-
-                if let FileUpload::InputFile(input_file) = &photo.media {
-                    let name = "photo";
-                    let attach_name = format!("attach://{name}");
-                    new_photo.media = FileUpload::String(attach_name);
-                    files.push((name, input_file.path.clone()));
-                }
-
-                InputMedia::Photo(new_photo)
+                replace_attach!(photo.media);
             }
             InputMedia::Video(video) => {
-                let mut new_video = video.clone();
-
-                if let FileUpload::InputFile(input_file) = &video.media {
-                    let name = "video";
-                    let attach_name = format!("attach://{name}");
-                    new_video.media = FileUpload::String(attach_name);
-                    files.push((name, input_file.path.clone()));
-                }
-
-                if let Some(FileUpload::InputFile(input_file)) = &video.cover {
-                    let name = "video_cover";
-                    let attach_name = format!("attach://{name}");
-                    new_video.cover = Some(FileUpload::String(attach_name));
-                    files.push((name, input_file.path.clone()));
-                }
-
-                if let Some(FileUpload::InputFile(input_file)) = &video.thumbnail {
-                    let name = "video_thumb";
-                    let attach_name = format!("attach://{name}");
-                    new_video.thumbnail = Some(FileUpload::String(attach_name));
-                    files.push((name, input_file.path.clone()));
-                }
-
-                InputMedia::Video(new_video)
+                replace_attach!(video.media);
+                replace_attach!(video.cover);
+                replace_attach!(video.thumbnail);
             }
-        };
-        let new_params = EditMessageMediaParams {
-            media: new_media,
-            ..params.clone()
-        };
+        }
 
-        self.request_with_possible_form_data(method_name, &new_params, files)
+        self.request_with_possible_form_data("editMessageMedia", &params, files)
             .await
     }
 
@@ -486,22 +269,7 @@ where
     request!(stopPoll, Poll);
     request!(deleteMessage, bool);
     request!(deleteMessages, bool);
-
-    async fn send_sticker(
-        &self,
-        params: &SendStickerParams,
-    ) -> Result<MethodResponse<Message>, Self::Error> {
-        let method_name = "sendSticker";
-        let mut files = Vec::new();
-
-        if let FileUpload::InputFile(input_file) = &params.sticker {
-            files.push(("sticker", input_file.path.clone()));
-        }
-
-        self.request_with_possible_form_data(method_name, params, files)
-            .await
-    }
-
+    request_f!(sendSticker, Message, sticker);
     request!(getStickerSet, StickerSet);
 
     async fn upload_sticker_file(
@@ -521,75 +289,46 @@ where
         &self,
         params: &CreateNewStickerSetParams,
     ) -> Result<MethodResponse<bool>, Self::Error> {
-        let method_name = "createNewStickerSet";
         let mut files = Vec::new();
 
-        let new_params = CreateNewStickerSetParams {
-            stickers: params
-                .stickers
-                .iter()
-                .enumerate()
-                .map(|(index, sticker)| {
-                    let mut new_sticker = sticker.clone();
-                    if let FileUpload::InputFile(input_file) = &sticker.sticker {
-                        let name = format!("file{index}");
-                        new_sticker.sticker = FileUpload::String(format!("attach://{name}"));
-                        files.push((name, input_file.path.clone()));
-                    }
-                    new_sticker
-                })
-                .collect(),
-            ..params.clone()
-        };
+        let mut params = params.clone();
+        for (index, sticker) in params.stickers.iter_mut().enumerate() {
+            if let Some(file) = sticker.sticker.replace_attach_dyn(|| index) {
+                files.push(file);
+            }
+        }
 
         let files_with_str_names = files
             .iter()
             .map(|(key, path)| (key.as_str(), path.clone()))
             .collect();
 
-        self.request_with_possible_form_data(method_name, &new_params, files_with_str_names)
+        self.request_with_possible_form_data("createNewStickerSet", &params, files_with_str_names)
             .await
     }
 
     request!(getCustomEmojiStickers, Vec<Sticker>);
+
     async fn add_sticker_to_set(
         &self,
         params: &AddStickerToSetParams,
     ) -> Result<MethodResponse<bool>, Self::Error> {
-        let method_name = "addStickerToSet";
         let mut files = Vec::new();
-
-        if let FileUpload::InputFile(input_file) = &params.sticker.sticker {
-            files.push(("sticker", input_file.path.clone()));
+        if let Some(file) = params.sticker.sticker.clone_path() {
+            files.push(("sticker", file));
         }
-
-        self.request_with_possible_form_data(method_name, params, files)
+        self.request_with_possible_form_data("addStickerToSet", params, files)
             .await
     }
 
     request!(setStickerPositionInSet, bool);
-    request!(replaceStickerInSet, bool);
     request!(deleteStickerFromSet, bool);
+    request!(replaceStickerInSet, bool);
     request!(setStickerEmojiList, bool);
     request!(setStickerKeywords, bool);
     request!(setStickerMaskPosition, bool);
     request!(setStickerSetTitle, bool);
-
-    async fn set_sticker_set_thumb(
-        &self,
-        params: &SetStickerSetThumbnailParams,
-    ) -> Result<MethodResponse<bool>, Self::Error> {
-        let method_name = "setStickerSetThumbnail";
-        let mut files = Vec::new();
-
-        if let Some(FileUpload::InputFile(input_file)) = &params.thumbnail {
-            files.push(("thumbnail", input_file.path.clone()));
-        }
-
-        self.request_with_possible_form_data(method_name, params, files)
-            .await
-    }
-
+    request_f!(setStickerSetThumbnail, bool, thumbnail);
     request!(setCustomEmojiStickerSetThumbnail, bool);
     request!(deleteStickerSet, bool);
     request_nb!(getAvailableGifts, Gifts);
@@ -616,15 +355,6 @@ where
     request!(getChatMenuButton, MenuButton);
     request!(unpinAllGeneralForumTopicMessages, bool);
 
-    async fn request<Params, Output>(
-        &self,
-        method: &str,
-        params: Option<Params>,
-    ) -> Result<Output, Self::Error>
-    where
-        Params: serde::ser::Serialize + std::fmt::Debug + std::marker::Send,
-        Output: serde::de::DeserializeOwned;
-
     async fn request_with_possible_form_data<Params, Output>(
         &self,
         method_name: &str,
@@ -642,6 +372,15 @@ where
                 .await
         }
     }
+
+    async fn request<Params, Output>(
+        &self,
+        method: &str,
+        params: Option<Params>,
+    ) -> Result<Output, Self::Error>
+    where
+        Params: serde::ser::Serialize + std::fmt::Debug + std::marker::Send,
+        Output: serde::de::DeserializeOwned;
 
     async fn request_with_form_data<Params, Output>(
         &self,

--- a/src/trait_sync.rs
+++ b/src/trait_sync.rs
@@ -1,9 +1,6 @@
 use std::path::PathBuf;
 
-use crate::api_params::{
-    AddStickerToSetParams, CreateNewStickerSetParams, EditMessageMediaParams, InputMedia, Media,
-    SendMediaGroupParams, SetChatPhotoParams, UploadStickerFileParams,
-};
+use crate::api_params::{InputMedia, Media};
 use crate::input_file::HasInputFile;
 use crate::objects::{
     BotCommand, BotDescription, BotName, BotShortDescription, BusinessConnection,
@@ -86,7 +83,7 @@ pub trait TelegramApi {
 
     fn send_media_group(
         &self,
-        params: &SendMediaGroupParams,
+        params: &crate::api_params::SendMediaGroupParams,
     ) -> Result<MethodResponse<Vec<Message>>, Self::Error> {
         let mut files = Vec::new();
 
@@ -164,7 +161,7 @@ pub trait TelegramApi {
 
     fn set_chat_photo(
         &self,
-        params: &SetChatPhotoParams,
+        params: &crate::api_params::SetChatPhotoParams,
     ) -> Result<MethodResponse<bool>, Self::Error> {
         let photo = &params.photo;
         self.request_with_form_data("setChatPhoto", params, vec![("photo", photo.path.clone())])
@@ -213,7 +210,7 @@ pub trait TelegramApi {
 
     fn edit_message_media(
         &self,
-        params: &EditMessageMediaParams,
+        params: &crate::api_params::EditMessageMediaParams,
     ) -> Result<MethodResponse<MessageOrBool>, Self::Error> {
         let mut files = Vec::new();
 
@@ -262,7 +259,7 @@ pub trait TelegramApi {
 
     fn upload_sticker_file(
         &self,
-        params: &UploadStickerFileParams,
+        params: &crate::api_params::UploadStickerFileParams,
     ) -> Result<MethodResponse<File>, Self::Error> {
         let sticker = &params.sticker;
         self.request_with_form_data(
@@ -274,7 +271,7 @@ pub trait TelegramApi {
 
     fn create_new_sticker_set(
         &self,
-        params: &CreateNewStickerSetParams,
+        params: &crate::api_params::CreateNewStickerSetParams,
     ) -> Result<MethodResponse<bool>, Self::Error> {
         let mut files = Vec::new();
 
@@ -297,7 +294,7 @@ pub trait TelegramApi {
 
     fn add_sticker_to_set(
         &self,
-        params: &AddStickerToSetParams,
+        params: &crate::api_params::AddStickerToSetParams,
     ) -> Result<MethodResponse<bool>, Self::Error> {
         let mut files = Vec::new();
         if let Some(file) = params.sticker.sticker.clone_path() {

--- a/src/trait_sync.rs
+++ b/src/trait_sync.rs
@@ -1,11 +1,10 @@
 use std::path::PathBuf;
 
 use crate::api_params::{
-    AddStickerToSetParams, CreateNewStickerSetParams, EditMessageMediaParams, FileUpload,
-    InputMedia, Media, SendAnimationParams, SendAudioParams, SendDocumentParams,
-    SendMediaGroupParams, SendPhotoParams, SendStickerParams, SendVideoNoteParams, SendVideoParams,
-    SendVoiceParams, SetChatPhotoParams, SetStickerSetThumbnailParams, UploadStickerFileParams,
+    AddStickerToSetParams, CreateNewStickerSetParams, EditMessageMediaParams, InputMedia, Media,
+    SendMediaGroupParams, SetChatPhotoParams, UploadStickerFileParams,
 };
+use crate::input_file::HasInputFile;
 use crate::objects::{
     BotCommand, BotDescription, BotName, BotShortDescription, BusinessConnection,
     ChatAdministratorRights, ChatFullInfo, ChatInviteLink, ChatMember, File, ForumTopic,
@@ -46,6 +45,27 @@ macro_rules! request_nb {
     }
 }
 
+/// request with some properties utilizing [`HasInputFile`]
+macro_rules! request_f {
+    ($name:ident, $return:ty, $($fileproperty:ident),+) => {
+        paste::paste! {
+            #[doc = "Call the `" $name "` method.\n\nSee <https://core.telegram.org/bots/api#" $name:lower ">."]
+            fn [<$name:snake>] (
+                &self,
+                params: &crate::api_params::[<$name:camel Params>],
+            ) -> Result<MethodResponse<$return>, Self::Error> {
+                let mut files = Vec::new();
+                $(
+                    if let Some(path) = params.$fileproperty.clone_path() {
+                        files.push((stringify!($fileproperty), path));
+                    }
+                )+
+                self.request_with_possible_form_data(stringify!($name), params, files)
+            }
+        }
+    }
+}
+
 pub trait TelegramApi {
     type Error;
 
@@ -61,206 +81,57 @@ pub trait TelegramApi {
     request!(forwardMessages, Vec<MessageId>);
     request!(copyMessage, MessageId);
     request!(copyMessages, Vec<MessageId>);
-
-    fn send_photo(&self, params: &SendPhotoParams) -> Result<MethodResponse<Message>, Self::Error> {
-        let method_name = "sendPhoto";
-        let mut files = Vec::new();
-
-        if let FileUpload::InputFile(input_file) = &params.photo {
-            files.push(("photo", input_file.path.clone()));
-        }
-
-        self.request_with_possible_form_data(method_name, params, files)
-    }
-
-    fn send_audio(&self, params: &SendAudioParams) -> Result<MethodResponse<Message>, Self::Error> {
-        let method_name = "sendAudio";
-        let mut files = Vec::new();
-
-        if let FileUpload::InputFile(input_file) = &params.audio {
-            files.push(("audio", input_file.path.clone()));
-        }
-
-        if let Some(FileUpload::InputFile(input_file)) = &params.thumbnail {
-            files.push(("thumbnail", input_file.path.clone()));
-        }
-
-        self.request_with_possible_form_data(method_name, params, files)
-    }
+    request_f!(sendPhoto, Message, photo);
+    request_f!(sendAudio, Message, audio, thumbnail);
 
     fn send_media_group(
         &self,
         params: &SendMediaGroupParams,
     ) -> Result<MethodResponse<Vec<Message>>, Self::Error> {
-        let method_name = "sendMediaGroup";
         let mut files = Vec::new();
 
-        let new_medias = params
-            .media
-            .iter()
-            .map(|media| match media {
+        macro_rules! replace_attach {
+            ($base:ident. $property:ident) => {
+                if let Some(file) = $base.$property.replace_attach_dyn(|| files.len()) {
+                    files.push(file);
+                }
+            };
+        }
+
+        let mut params = params.clone();
+        for media in &mut params.media {
+            match media {
                 Media::Audio(audio) => {
-                    let mut new_audio = audio.clone();
-
-                    if let FileUpload::InputFile(input_file) = &audio.media {
-                        let name = format!("file{}", files.len());
-                        new_audio.media = FileUpload::String(format!("attach://{name}"));
-                        files.push((name, input_file.path.clone()));
-                    }
-
-                    if let Some(FileUpload::InputFile(input_file)) = &audio.thumbnail {
-                        let name = format!("file{}", files.len());
-                        new_audio.thumbnail = Some(FileUpload::String(format!("attach://{name}")));
-                        files.push((name, input_file.path.clone()));
-                    }
-
-                    Media::Audio(new_audio)
+                    replace_attach!(audio.media);
+                    replace_attach!(audio.thumbnail);
                 }
                 Media::Document(document) => {
-                    let mut new_document = document.clone();
-
-                    if let FileUpload::InputFile(input_file) = &document.media {
-                        let name = format!("file{}", files.len());
-                        new_document.media = FileUpload::String(format!("attach://{name}"));
-                        files.push((name, input_file.path.clone()));
-                    }
-
-                    Media::Document(new_document)
+                    replace_attach!(document.media);
                 }
                 Media::Photo(photo) => {
-                    let mut new_photo = photo.clone();
-
-                    if let FileUpload::InputFile(input_file) = &photo.media {
-                        let name = format!("file{}", files.len());
-                        new_photo.media = FileUpload::String(format!("attach://{name}"));
-                        files.push((name, input_file.path.clone()));
-                    }
-
-                    Media::Photo(new_photo)
+                    replace_attach!(photo.media);
                 }
                 Media::Video(video) => {
-                    let mut new_video = video.clone();
-
-                    if let FileUpload::InputFile(input_file) = &video.media {
-                        let name = format!("file{}", files.len());
-                        new_video.media = FileUpload::String(format!("attach://{name}"));
-                        files.push((name, input_file.path.clone()));
-                    }
-
-                    if let Some(FileUpload::InputFile(input_file)) = &video.cover {
-                        let name = format!("file{}", files.len());
-                        new_video.cover = Some(FileUpload::String(format!("attach://{name}")));
-                        files.push((name, input_file.path.clone()));
-                    }
-
-                    if let Some(FileUpload::InputFile(input_file)) = &video.thumbnail {
-                        let name = format!("file{}", files.len());
-                        new_video.thumbnail = Some(FileUpload::String(format!("attach://{name}")));
-                        files.push((name, input_file.path.clone()));
-                    }
-
-                    Media::Video(new_video)
+                    replace_attach!(video.media);
+                    replace_attach!(video.cover);
+                    replace_attach!(video.thumbnail);
                 }
-            })
-            .collect();
-
-        let new_params = SendMediaGroupParams {
-            media: new_medias,
-            ..params.clone()
-        };
+            }
+        }
 
         let files_with_str_names = files
             .iter()
             .map(|(key, path)| (key.as_str(), path.clone()))
             .collect();
 
-        self.request_with_possible_form_data(method_name, &new_params, files_with_str_names)
+        self.request_with_possible_form_data("sendMediaGroup", &params, files_with_str_names)
     }
 
-    fn send_document(
-        &self,
-        params: &SendDocumentParams,
-    ) -> Result<MethodResponse<Message>, Self::Error> {
-        let method_name = "sendDocument";
-        let mut files = Vec::new();
-
-        if let FileUpload::InputFile(input_file) = &params.document {
-            files.push(("document", input_file.path.clone()));
-        }
-
-        if let Some(FileUpload::InputFile(input_file)) = &params.thumbnail {
-            files.push(("thumbnail", input_file.path.clone()));
-        }
-
-        self.request_with_possible_form_data(method_name, params, files)
-    }
-
-    fn send_video(&self, params: &SendVideoParams) -> Result<MethodResponse<Message>, Self::Error> {
-        let method_name = "sendVideo";
-        let mut files = Vec::new();
-
-        if let FileUpload::InputFile(input_file) = &params.video {
-            files.push(("video", input_file.path.clone()));
-        }
-
-        if let Some(FileUpload::InputFile(input_file)) = &params.cover {
-            files.push(("cover", input_file.path.clone()));
-        }
-
-        if let Some(FileUpload::InputFile(input_file)) = &params.thumbnail {
-            files.push(("thumbnail", input_file.path.clone()));
-        }
-
-        self.request_with_possible_form_data(method_name, params, files)
-    }
-
-    fn send_animation(
-        &self,
-        params: &SendAnimationParams,
-    ) -> Result<MethodResponse<Message>, Self::Error> {
-        let method_name = "sendAnimation";
-        let mut files = Vec::new();
-
-        if let FileUpload::InputFile(input_file) = &params.animation {
-            files.push(("animation", input_file.path.clone()));
-        }
-
-        if let Some(FileUpload::InputFile(input_file)) = &params.thumbnail {
-            files.push(("thumbnail", input_file.path.clone()));
-        }
-
-        self.request_with_possible_form_data(method_name, params, files)
-    }
-
-    fn send_voice(&self, params: &SendVoiceParams) -> Result<MethodResponse<Message>, Self::Error> {
-        let method_name = "sendVoice";
-        let mut files = Vec::new();
-
-        if let FileUpload::InputFile(input_file) = &params.voice {
-            files.push(("voice", input_file.path.clone()));
-        }
-
-        self.request_with_possible_form_data(method_name, params, files)
-    }
-
-    fn send_video_note(
-        &self,
-        params: &SendVideoNoteParams,
-    ) -> Result<MethodResponse<Message>, Self::Error> {
-        let method_name = "sendVideoNote";
-        let mut files = Vec::new();
-
-        if let FileUpload::InputFile(input_file) = &params.video_note {
-            files.push(("video_note", input_file.path.clone()));
-        }
-
-        if let Some(FileUpload::InputFile(input_file)) = &params.thumbnail {
-            files.push(("thumbnail", input_file.path.clone()));
-        }
-
-        self.request_with_possible_form_data(method_name, params, files)
-    }
-
+    request_f!(sendDocument, Message, document, thumbnail);
+    request_f!(sendVideo, Message, video, cover, thumbnail);
+    request_f!(sendAnimation, Message, animation, thumbnail);
+    request_f!(sendVoice, Message, voice);
+    request_f!(sendVideoNote, Message, video_note, thumbnail);
     request!(sendPaidMedia, Message);
     request!(sendLocation, Message);
     request!(editMessageLiveLocation, MessageOrBool);
@@ -344,133 +215,49 @@ pub trait TelegramApi {
         &self,
         params: &EditMessageMediaParams,
     ) -> Result<MethodResponse<MessageOrBool>, Self::Error> {
-        let method_name = "editMessageMedia";
         let mut files = Vec::new();
 
-        let new_media = match &params.media {
+        macro_rules! replace_attach {
+            ($base:ident. $property:ident) => {{
+                const NAME: &str = concat!(stringify!($base), "_", stringify!($property));
+                if let Some(file) = $base.$property.replace_attach(NAME) {
+                    files.push((NAME, file));
+                }
+            }};
+        }
+
+        let mut params = params.clone();
+        match &mut params.media {
             InputMedia::Animation(animation) => {
-                let mut new_animation = animation.clone();
-
-                if let FileUpload::InputFile(input_file) = &animation.media {
-                    let name = "animation";
-                    let attach_name = format!("attach://{name}");
-                    new_animation.media = FileUpload::String(attach_name);
-                    files.push((name, input_file.path.clone()));
-                }
-
-                if let Some(FileUpload::InputFile(input_file)) = &animation.thumbnail {
-                    let name = "animation_thumb";
-                    let attach_name = format!("attach://{name}");
-                    new_animation.thumbnail = Some(FileUpload::String(attach_name));
-                    files.push((name, input_file.path.clone()));
-                }
-
-                InputMedia::Animation(new_animation)
+                replace_attach!(animation.media);
+                replace_attach!(animation.thumbnail);
             }
             InputMedia::Document(document) => {
-                let mut new_document = document.clone();
-
-                if let FileUpload::InputFile(input_file) = &document.media {
-                    let name = "document";
-                    let attach_name = format!("attach://{name}");
-                    new_document.media = FileUpload::String(attach_name);
-                    files.push((name, input_file.path.clone()));
-                }
-
-                if let Some(FileUpload::InputFile(input_file)) = &document.thumbnail {
-                    let name = "document_thumb";
-                    let attach_name = format!("attach://{name}");
-                    new_document.thumbnail = Some(FileUpload::String(attach_name));
-                    files.push((name, input_file.path.clone()));
-                }
-
-                InputMedia::Document(new_document)
+                replace_attach!(document.media);
+                replace_attach!(document.thumbnail);
             }
             InputMedia::Audio(audio) => {
-                let mut new_audio = audio.clone();
-
-                if let FileUpload::InputFile(input_file) = &audio.media {
-                    let name = "audio";
-                    let attach_name = format!("attach://{name}");
-                    new_audio.media = FileUpload::String(attach_name);
-                    files.push((name, input_file.path.clone()));
-                }
-
-                if let Some(FileUpload::InputFile(input_file)) = &audio.thumbnail {
-                    let name = "audio_thumb";
-                    let attach_name = format!("attach://{name}");
-                    new_audio.thumbnail = Some(FileUpload::String(attach_name));
-                    files.push((name, input_file.path.clone()));
-                }
-
-                InputMedia::Audio(new_audio)
+                replace_attach!(audio.media);
+                replace_attach!(audio.thumbnail);
             }
             InputMedia::Photo(photo) => {
-                let mut new_photo = photo.clone();
-
-                if let FileUpload::InputFile(input_file) = &photo.media {
-                    let name = "photo";
-                    let attach_name = format!("attach://{name}");
-                    new_photo.media = FileUpload::String(attach_name);
-                    files.push((name, input_file.path.clone()));
-                }
-
-                InputMedia::Photo(new_photo)
+                replace_attach!(photo.media);
             }
             InputMedia::Video(video) => {
-                let mut new_video = video.clone();
-
-                if let FileUpload::InputFile(input_file) = &video.media {
-                    let name = "video";
-                    let attach_name = format!("attach://{name}");
-                    new_video.media = FileUpload::String(attach_name);
-                    files.push((name, input_file.path.clone()));
-                }
-
-                if let Some(FileUpload::InputFile(input_file)) = &video.cover {
-                    let name = "video_cover";
-                    let attach_name = format!("attach://{name}");
-                    new_video.cover = Some(FileUpload::String(attach_name));
-                    files.push((name, input_file.path.clone()));
-                }
-
-                if let Some(FileUpload::InputFile(input_file)) = &video.thumbnail {
-                    let name = "video_thumb";
-                    let attach_name = format!("attach://{name}");
-                    new_video.thumbnail = Some(FileUpload::String(attach_name));
-                    files.push((name, input_file.path.clone()));
-                }
-
-                InputMedia::Video(new_video)
+                replace_attach!(video.media);
+                replace_attach!(video.cover);
+                replace_attach!(video.thumbnail);
             }
-        };
-        let new_params = EditMessageMediaParams {
-            media: new_media,
-            ..params.clone()
-        };
+        }
 
-        self.request_with_possible_form_data(method_name, &new_params, files)
+        self.request_with_possible_form_data("editMessageMedia", &params, files)
     }
 
     request!(editMessageReplyMarkup, MessageOrBool);
     request!(stopPoll, Poll);
     request!(deleteMessage, bool);
     request!(deleteMessages, bool);
-
-    fn send_sticker(
-        &self,
-        params: &SendStickerParams,
-    ) -> Result<MethodResponse<Message>, Self::Error> {
-        let method_name = "sendSticker";
-        let mut files = Vec::new();
-
-        if let FileUpload::InputFile(input_file) = &params.sticker {
-            files.push(("sticker", input_file.path.clone()));
-        }
-
-        self.request_with_possible_form_data(method_name, params, files)
-    }
-
+    request_f!(sendSticker, Message, sticker);
     request!(getStickerSet, StickerSet);
 
     fn upload_sticker_file(
@@ -489,33 +276,21 @@ pub trait TelegramApi {
         &self,
         params: &CreateNewStickerSetParams,
     ) -> Result<MethodResponse<bool>, Self::Error> {
-        let method_name = "createNewStickerSet";
         let mut files = Vec::new();
 
-        let new_params = CreateNewStickerSetParams {
-            stickers: params
-                .stickers
-                .iter()
-                .enumerate()
-                .map(|(index, sticker)| {
-                    let mut new_sticker = sticker.clone();
-                    if let FileUpload::InputFile(input_file) = &sticker.sticker {
-                        let name = format!("file{index}");
-                        new_sticker.sticker = FileUpload::String(format!("attach://{name}"));
-                        files.push((name, input_file.path.clone()));
-                    }
-                    new_sticker
-                })
-                .collect(),
-            ..params.clone()
-        };
+        let mut params = params.clone();
+        for (index, sticker) in params.stickers.iter_mut().enumerate() {
+            if let Some(file) = sticker.sticker.replace_attach_dyn(|| index) {
+                files.push(file);
+            }
+        }
 
         let files_with_str_names = files
             .iter()
             .map(|(key, path)| (key.as_str(), path.clone()))
             .collect();
 
-        self.request_with_possible_form_data(method_name, &new_params, files_with_str_names)
+        self.request_with_possible_form_data("createNewStickerSet", &params, files_with_str_names)
     }
 
     request!(getCustomEmojiStickers, Vec<Sticker>);
@@ -524,14 +299,11 @@ pub trait TelegramApi {
         &self,
         params: &AddStickerToSetParams,
     ) -> Result<MethodResponse<bool>, Self::Error> {
-        let method_name = "addStickerToSet";
         let mut files = Vec::new();
-
-        if let FileUpload::InputFile(input_file) = &params.sticker.sticker {
-            files.push(("sticker", input_file.path.clone()));
+        if let Some(file) = params.sticker.sticker.clone_path() {
+            files.push(("sticker", file));
         }
-
-        self.request_with_possible_form_data(method_name, params, files)
+        self.request_with_possible_form_data("addStickerToSet", params, files)
     }
 
     request!(setStickerPositionInSet, bool);
@@ -541,21 +313,7 @@ pub trait TelegramApi {
     request!(setStickerKeywords, bool);
     request!(setStickerMaskPosition, bool);
     request!(setStickerSetTitle, bool);
-
-    fn set_sticker_set_thumbnail(
-        &self,
-        params: &SetStickerSetThumbnailParams,
-    ) -> Result<MethodResponse<bool>, Self::Error> {
-        let method_name = "setStickerSetThumbnail";
-        let mut files = Vec::new();
-
-        if let Some(FileUpload::InputFile(input_file)) = &params.thumbnail {
-            files.push(("thumbnail", input_file.path.clone()));
-        }
-
-        self.request_with_possible_form_data(method_name, params, files)
-    }
-
+    request_f!(setStickerSetThumbnail, bool, thumbnail);
     request!(setCustomEmojiStickerSetThumbnail, bool);
     request!(deleteStickerSet, bool);
     request_nb!(getAvailableGifts, Gifts);
@@ -585,7 +343,7 @@ pub trait TelegramApi {
     fn request_with_possible_form_data<Params, Output>(
         &self,
         method_name: &str,
-        params: &Params,
+        params: Params,
         files: Vec<(&str, PathBuf)>,
     ) -> Result<Output, Self::Error>
     where
@@ -599,20 +357,20 @@ pub trait TelegramApi {
         }
     }
 
-    fn request_with_form_data<Params, Output>(
+    fn request<Params, Output>(
         &self,
         method: &str,
-        params: Params,
-        files: Vec<(&str, PathBuf)>,
+        params: Option<Params>,
     ) -> Result<Output, Self::Error>
     where
         Params: serde::ser::Serialize + std::fmt::Debug,
         Output: serde::de::DeserializeOwned;
 
-    fn request<Params, Output>(
+    fn request_with_form_data<Params, Output>(
         &self,
         method: &str,
-        params: Option<Params>,
+        params: Params,
+        files: Vec<(&str, PathBuf)>,
     ) -> Result<Output, Self::Error>
     where
         Params: serde::ser::Serialize + std::fmt::Debug,


### PR DESCRIPTION
This trait works for both FileUpload and Option<FileUpload> which simplifies creating macros a lot.

The replace_attach method replaces an InputFile with an attach string in-place returning the previous InputFile without any clones. While this is neat it's not a big change for the PathBuf. When some code in the future involves Vec<u8> this will make a way bigger difference.

BREAKING CHANGE: method set_sticker_set_thumb is now named set_sticker_set_thumbnail like in the official API documentation.

BREAKING CHANGE: some imports are shifted around (api_params → input_file)