### PR TITLE
refactor!: move objects into multiple modules

### DIFF
--- a/examples/async_reply_to_message_updates.rs
+++ b/examples/async_reply_to_message_updates.rs
@@ -1,6 +1,7 @@
-use frankenstein::api_params::{GetUpdatesParams, ReplyParameters, SendMessageParams};
+use frankenstein::api_params::{GetUpdatesParams, SendMessageParams};
 use frankenstein::client_reqwest::Bot;
-use frankenstein::objects::{Message, UpdateContent};
+use frankenstein::objects::{Message, ReplyParameters};
+use frankenstein::updates::UpdateContent;
 use frankenstein::AsyncTelegramApi;
 
 #[tokio::main]

--- a/examples/inline_keyboard.rs
+++ b/examples/inline_keyboard.rs
@@ -1,6 +1,6 @@
-use frankenstein::api_params::{ReplyMarkup, SendMessageParams};
+use frankenstein::api_params::SendMessageParams;
 use frankenstein::client_ureq::Bot;
-use frankenstein::objects::{InlineKeyboardButton, InlineKeyboardMarkup};
+use frankenstein::objects::{InlineKeyboardButton, InlineKeyboardMarkup, ReplyMarkup};
 use frankenstein::TelegramApi;
 
 fn main() {

--- a/examples/reply_keyboard.rs
+++ b/examples/reply_keyboard.rs
@@ -1,6 +1,6 @@
-use frankenstein::api_params::{ReplyMarkup, SendMessageParams};
+use frankenstein::api_params::SendMessageParams;
 use frankenstein::client_ureq::Bot;
-use frankenstein::objects::{KeyboardButton, ReplyKeyboardMarkup};
+use frankenstein::objects::{KeyboardButton, ReplyKeyboardMarkup, ReplyMarkup};
 use frankenstein::TelegramApi;
 
 fn main() {

--- a/examples/reply_to_message_updates.rs
+++ b/examples/reply_to_message_updates.rs
@@ -1,6 +1,7 @@
-use frankenstein::api_params::{GetUpdatesParams, ReplyParameters, SendMessageParams};
+use frankenstein::api_params::{GetUpdatesParams, SendMessageParams};
 use frankenstein::client_ureq::Bot;
-use frankenstein::objects::UpdateContent;
+use frankenstein::objects::ReplyParameters;
+use frankenstein::updates::UpdateContent;
 use frankenstein::TelegramApi;
 
 fn main() {

--- a/src/api_params.rs
+++ b/src/api_params.rs
@@ -1,161 +1,18 @@
-//! Parameters to Telegram API methods.
+//! Parameters of [Bot API methods](https://core.telegram.org/bots/api#available-methods).
 
-use serde::{Deserialize, Serialize};
-
+use crate::inline_mode::{InlineQueryResult, InlineQueryResultsButton};
 use crate::input_file::{FileUpload, InputFile};
+use crate::input_media::{InputMedia, InputPaidMedia, MediaGroupInputMedia};
 use crate::macros::{apistruct, apply};
 use crate::objects::{
-    AllowedUpdate, BotCommand, ChatAdministratorRights, ChatPermissions, ForceReply,
-    InlineKeyboardMarkup, InlineQueryResultArticle, InlineQueryResultAudio,
-    InlineQueryResultCachedAudio, InlineQueryResultCachedDocument, InlineQueryResultCachedGif,
-    InlineQueryResultCachedMpeg4Gif, InlineQueryResultCachedPhoto, InlineQueryResultCachedSticker,
-    InlineQueryResultCachedVideo, InlineQueryResultCachedVoice, InlineQueryResultContact,
-    InlineQueryResultDocument, InlineQueryResultGame, InlineQueryResultGif,
-    InlineQueryResultLocation, InlineQueryResultMpeg4Gif, InlineQueryResultPhoto,
-    InlineQueryResultVenue, InlineQueryResultVideo, InlineQueryResultVoice, InputPaidMedia,
-    InputPollOption, InputSticker, LabeledPrice, LinkPreviewOptions, MaskPosition, MenuButton,
-    MessageEntity, PassportElementErrorDataField, PassportElementErrorFile,
-    PassportElementErrorFiles, PassportElementErrorFrontSide, PassportElementErrorReverseSide,
-    PassportElementErrorSelfie, PassportElementErrorTranslationFile,
-    PassportElementErrorTranslationFiles, PassportElementErrorUnspecified, PollType, ReactionType,
-    ReplyKeyboardMarkup, ReplyKeyboardRemove, ShippingOption, StickerFormat, StickerType,
-    WebAppInfo,
+    AllowedUpdate, BotCommand, BotCommandScope, ChatAction, ChatAdministratorRights, ChatId,
+    ChatPermissions, InlineKeyboardMarkup, InputPollOption, LinkPreviewOptions, MenuButton,
+    MessageEntity, PollType, ReactionType, ReplyMarkup, ReplyParameters,
 };
+use crate::passport::PassportElementError;
+use crate::payments::{LabeledPrice, ShippingOption};
+use crate::stickers::{InputSticker, MaskPosition, StickerFormat, StickerType};
 use crate::ParseMode;
-
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
-#[serde(tag = "type", rename_all = "snake_case")]
-pub enum InlineQueryResult {
-    Audio(MaybeCached<InlineQueryResultCachedAudio, InlineQueryResultAudio>),
-    Document(MaybeCached<InlineQueryResultCachedDocument, InlineQueryResultDocument>),
-    Gif(MaybeCached<InlineQueryResultCachedGif, InlineQueryResultGif>),
-    Mpeg4Gif(MaybeCached<InlineQueryResultCachedMpeg4Gif, InlineQueryResultMpeg4Gif>),
-    Photo(MaybeCached<InlineQueryResultCachedPhoto, InlineQueryResultPhoto>),
-    Sticker(InlineQueryResultCachedSticker),
-    Video(MaybeCached<InlineQueryResultCachedVideo, InlineQueryResultVideo>),
-    Voice(MaybeCached<InlineQueryResultCachedVoice, InlineQueryResultVoice>),
-    Article(InlineQueryResultArticle),
-    Contact(InlineQueryResultContact),
-    Game(InlineQueryResultGame),
-    Location(InlineQueryResultLocation),
-    Venue(InlineQueryResultVenue),
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(untagged)]
-pub enum MaybeCached<T1, T2> {
-    Cached(T1),
-    NotCached(T2),
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(tag = "type", rename_all = "snake_case")]
-pub enum InputMedia {
-    Animation(InputMediaAnimation),
-    Document(InputMediaDocument),
-    Audio(InputMediaAudio),
-    Photo(InputMediaPhoto),
-    Video(InputMediaVideo),
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(tag = "source", rename_all = "snake_case")]
-pub enum PassportElementError {
-    #[serde(rename = "data")]
-    DataField(PassportElementErrorDataField),
-    FrontSide(PassportElementErrorFrontSide),
-    ReverseSide(PassportElementErrorReverseSide),
-    Selfie(PassportElementErrorSelfie),
-    File(PassportElementErrorFile),
-    Files(PassportElementErrorFiles),
-    TranslationFile(PassportElementErrorTranslationFile),
-    TranslationFiles(PassportElementErrorTranslationFiles),
-    Unspecified(PassportElementErrorUnspecified),
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(untagged)]
-pub enum ChatId {
-    Integer(i64),
-    String(String),
-}
-
-impl From<i64> for ChatId {
-    fn from(id: i64) -> Self {
-        Self::Integer(id)
-    }
-}
-
-impl From<String> for ChatId {
-    fn from(id: String) -> Self {
-        Self::String(id)
-    }
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(untagged)]
-pub enum ReplyMarkup {
-    InlineKeyboardMarkup(InlineKeyboardMarkup),
-    ReplyKeyboardMarkup(ReplyKeyboardMarkup),
-    ReplyKeyboardRemove(ReplyKeyboardRemove),
-    ForceReply(ForceReply),
-}
-
-#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(rename_all = "snake_case")]
-pub enum ChatAction {
-    Typing,
-    UploadPhoto,
-    RecordVideo,
-    UploadVideo,
-    RecordVoice,
-    UploadVoice,
-    UploadDocument,
-    ChooseSticker,
-    FindLocation,
-    RecordVideoNote,
-    UploadVideoNote,
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(tag = "type", rename_all = "snake_case")]
-pub enum Media {
-    Audio(InputMediaAudio),
-    Document(InputMediaDocument),
-    Photo(InputMediaPhoto),
-    Video(InputMediaVideo),
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(tag = "type", rename_all = "snake_case")]
-pub enum BotCommandScope {
-    Default,
-    AllPrivateChats,
-    AllGroupChats,
-    AllChatAdministrators,
-    Chat(BotCommandScopeChat),
-    ChatAdministrators(BotCommandScopeChatAdministrators),
-    ChatMember(BotCommandScopeChatMember),
-}
-
-#[apply(apistruct!)]
-#[derive(Eq)]
-pub struct BotCommandScopeChat {
-    pub chat_id: ChatId,
-}
-
-#[apply(apistruct!)]
-#[derive(Eq)]
-pub struct BotCommandScopeChatAdministrators {
-    pub chat_id: ChatId,
-}
-
-#[apply(apistruct!)]
-#[derive(Eq)]
-pub struct BotCommandScopeChatMember {
-    pub chat_id: ChatId,
-    pub user_id: u64,
-}
 
 #[apply(apistruct!)]
 #[derive(Eq)]
@@ -431,7 +288,7 @@ pub struct SendMediaGroupParams {
     pub business_connection_id: Option<String>,
     pub chat_id: ChatId,
     pub message_thread_id: Option<i32>,
-    pub media: Vec<Media>,
+    pub media: Vec<MediaGroupInputMedia>,
     pub disable_notification: Option<bool>,
     pub protect_content: Option<bool>,
     pub allow_paid_broadcast: Option<bool>,
@@ -1250,14 +1107,6 @@ pub struct AnswerInlineQueryParams {
 
 #[apply(apistruct!)]
 #[derive(Eq)]
-pub struct InlineQueryResultsButton {
-    pub text: String,
-    pub web_app: Option<WebAppInfo>,
-    pub start_parameter: Option<String>,
-}
-
-#[apply(apistruct!)]
-#[derive(Eq)]
 pub struct SendInvoiceParams {
     pub chat_id: ChatId,
     pub message_thread_id: Option<i32>,
@@ -1402,74 +1251,6 @@ pub struct GetGameHighScoresParams {
 
 #[apply(apistruct!)]
 #[derive(Eq)]
-pub struct InputMediaPhoto {
-    pub media: FileUpload,
-    pub caption: Option<String>,
-    pub parse_mode: Option<ParseMode>,
-    pub caption_entities: Option<Vec<MessageEntity>>,
-    pub show_caption_above_media: Option<bool>,
-    pub has_spoiler: Option<bool>,
-}
-
-#[apply(apistruct!)]
-#[derive(Eq)]
-pub struct InputMediaVideo {
-    pub media: FileUpload,
-    pub thumbnail: Option<FileUpload>,
-    pub cover: Option<FileUpload>,
-    pub start_timestamp: Option<u64>,
-    pub caption: Option<String>,
-    pub parse_mode: Option<ParseMode>,
-    pub caption_entities: Option<Vec<MessageEntity>>,
-    pub show_caption_above_media: Option<bool>,
-    pub width: Option<u32>,
-    pub height: Option<u32>,
-    pub duration: Option<u32>,
-    pub supports_streaming: Option<bool>,
-    pub has_spoiler: Option<bool>,
-}
-
-#[apply(apistruct!)]
-#[derive(Eq)]
-pub struct InputMediaAnimation {
-    pub media: FileUpload,
-    pub thumbnail: Option<FileUpload>,
-    pub caption: Option<String>,
-    pub parse_mode: Option<ParseMode>,
-    pub caption_entities: Option<Vec<MessageEntity>>,
-    pub show_caption_above_media: Option<bool>,
-    pub width: Option<u32>,
-    pub height: Option<u32>,
-    pub duration: Option<u32>,
-    pub has_spoiler: Option<bool>,
-}
-
-#[apply(apistruct!)]
-#[derive(Eq)]
-pub struct InputMediaAudio {
-    pub media: FileUpload,
-    pub thumbnail: Option<FileUpload>,
-    pub caption: Option<String>,
-    pub parse_mode: Option<ParseMode>,
-    pub caption_entities: Option<Vec<MessageEntity>>,
-    pub duration: Option<u32>,
-    pub performer: Option<String>,
-    pub title: Option<String>,
-}
-
-#[apply(apistruct!)]
-#[derive(Eq)]
-pub struct InputMediaDocument {
-    pub media: FileUpload,
-    pub thumbnail: Option<FileUpload>,
-    pub caption: Option<String>,
-    pub parse_mode: Option<ParseMode>,
-    pub caption_entities: Option<Vec<MessageEntity>>,
-    pub disable_content_type_detection: Option<bool>,
-}
-
-#[apply(apistruct!)]
-#[derive(Eq)]
 pub struct SetMyDefaultAdministratorRightsParams {
     pub rights: ChatAdministratorRights,
     pub for_channels: Option<bool>,
@@ -1514,16 +1295,4 @@ pub struct GetChatMenuButtonParams {
 #[derive(Eq)]
 pub struct UnpinAllGeneralForumTopicMessagesParams {
     pub chat_id: ChatId,
-}
-
-#[apply(apistruct!)]
-#[derive(Eq)]
-pub struct ReplyParameters {
-    pub message_id: i32,
-    pub chat_id: Option<ChatId>,
-    pub allow_sending_without_reply: Option<bool>,
-    pub quote: Option<String>,
-    pub quote_parse_mode: Option<ParseMode>,
-    pub quote_entities: Option<Vec<MessageEntity>>,
-    pub quote_position: Option<u32>,
 }

--- a/src/client_ureq.rs
+++ b/src/client_ureq.rs
@@ -136,16 +136,14 @@ impl TelegramApi for Bot {
 mod tests {
     use super::*;
     use crate::api_params::{
-        AnswerCallbackQueryParams, AnswerInlineQueryParams, BanChatMemberParams, BotCommandScope,
-        BotCommandScopeChat, ChatAction, ChatId, CopyMessageParams, CreateChatInviteLinkParams,
-        DeleteChatPhotoParams, DeleteChatStickerSetParams, DeleteMessageParams,
-        DeleteMyCommandsParams, DeleteWebhookParams, EditChatInviteLinkParams,
+        AnswerCallbackQueryParams, AnswerInlineQueryParams, BanChatMemberParams, CopyMessageParams,
+        CreateChatInviteLinkParams, DeleteChatPhotoParams, DeleteChatStickerSetParams,
+        DeleteMessageParams, DeleteMyCommandsParams, DeleteWebhookParams, EditChatInviteLinkParams,
         EditMessageCaptionParams, EditMessageLiveLocationParams, EditMessageMediaParams,
         EditMessageTextParams, ExportChatInviteLinkParams, ForwardMessageParams,
         GetChatAdministratorsParams, GetChatMemberCountParams, GetChatMemberParams, GetChatParams,
         GetFileParams, GetMyCommandsParams, GetStickerSetParams, GetUpdatesParams,
-        GetUserProfilePhotosParams, InlineQueryResult, InputMedia, InputMediaPhoto,
-        LeaveChatParams, Media, PinChatMessageParams, PromoteChatMemberParams,
+        GetUserProfilePhotosParams, LeaveChatParams, PinChatMessageParams, PromoteChatMemberParams,
         RestrictChatMemberParams, RevokeChatInviteLinkParams, SendAnimationParams, SendAudioParams,
         SendChatActionParams, SendContactParams, SendDiceParams, SendDocumentParams,
         SendLocationParams, SendMediaGroupParams, SendMessageParams, SendPhotoParams,
@@ -155,8 +153,11 @@ mod tests {
         SetMyCommandsParams, SetWebhookParams, StopMessageLiveLocationParams, StopPollParams,
         UnbanChatMemberParams, UnpinChatMessageParams,
     };
+    use crate::inline_mode::{InlineQueryResult, InlineQueryResultVenue};
+    use crate::input_media::{InputMediaPhoto, MediaGroupInputMedia};
     use crate::objects::{
-        AllowedUpdate, BotCommand, ChatPermissions, InlineQueryResultVenue, InputPollOption,
+        AllowedUpdate, BotCommand, BotCommandScope, BotCommandScopeChat, ChatAction, ChatId,
+        ChatPermissions, InputPollOption,
     };
     use crate::test_json::assert_json_str;
 
@@ -957,7 +958,10 @@ mod tests {
         let response_string = "{\"ok\":true,\"result\":[{\"message_id\":510,\"from\":{\"id\":1276618370,\"is_bot\":true,\"first_name\":\"test_el_bot\",\"username\":\"el_mon_test_bot\"},\"date\":1619267462,\"chat\":{\"id\":-1001368460856,\"type\":\"supergroup\",\"title\":\"Frankenstein\"},\"media_group_id\":\"12954139699368426\",\"photo\":[{\"file_id\":\"AgACAgIAAx0EUZEOOAACAf5ghA-GtOaBIP2NOmtXdze-Un7PGgAC_q8xG0cfEUgpwpFo17XTfWTS5p8uAAMBAAMCAANtAANYQgACHwQ\",\"file_unique_id\":\"AQADZNLmny4AA1hCAAI\",\"width\":320,\"height\":320,\"file_size\":19162},{\"file_id\":\"AgACAgIAAx0EUZEOOAACAf5ghA-GtOaBIP2NOmtXdze-Un7PGgAC_q8xG0cfEUgpwpFo17XTfWTS5p8uAAMBAAMCAAN4AANZQgACHwQ\",\"file_unique_id\":\"AQADZNLmny4AA1lCAAI\",\"width\":800,\"height\":800,\"file_size\":65697},{\"file_id\":\"AgACAgIAAx0EUZEOOAACAf5ghA-GtOaBIP2NOmtXdze-Un7PGgAC_q8xG0cfEUgpwpFo17XTfWTS5p8uAAMBAAMCAAN5AANaQgACHwQ\",\"file_unique_id\":\"AQADZNLmny4AA1pCAAI\",\"width\":1146,\"height\":1146,\"file_size\":101324}]},{\"message_id\":511,\"from\":{\"id\":1276618370,\"is_bot\":true,\"first_name\":\"test_el_bot\",\"username\":\"el_mon_test_bot\"},\"date\":1619267462,\"chat\":{\"id\":-1001368460856,\"type\":\"supergroup\",\"title\":\"Frankenstein\"},\"media_group_id\":\"12954139699368426\",\"photo\":[{\"file_id\":\"AgACAgIAAx0EUZEOOAACAf9ghA-GeFo0B7v78UyXoOD9drjEGgAC_q8xG0cfEUgpwpFo17XTfWTS5p8uAAMBAAMCAANtAANYQgACHwQ\",\"file_unique_id\":\"AQADZNLmny4AA1hCAAI\",\"width\":320,\"height\":320,\"file_size\":19162},{\"file_id\":\"AgACAgIAAx0EUZEOOAACAf9ghA-GeFo0B7v78UyXoOD9drjEGgAC_q8xG0cfEUgpwpFo17XTfWTS5p8uAAMBAAMCAAN4AANZQgACHwQ\",\"file_unique_id\":\"AQADZNLmny4AA1lCAAI\",\"width\":800,\"height\":800,\"file_size\":65697},{\"file_id\":\"AgACAgIAAx0EUZEOOAACAf9ghA-GeFo0B7v78UyXoOD9drjEGgAC_q8xG0cfEUgpwpFo17XTfWTS5p8uAAMBAAMCAAN5AANaQgACHwQ\",\"file_unique_id\":\"AQADZNLmny4AA1pCAAI\",\"width\":1146,\"height\":1146,\"file_size\":101324}]}]}";
         let file = std::path::PathBuf::from("./frankenstein_logo.png");
         let photo = InputMediaPhoto::builder().media(file).build();
-        let medias = vec![Media::Photo(photo.clone()), Media::Photo(photo)];
+        let medias = vec![
+            MediaGroupInputMedia::Photo(photo.clone()),
+            MediaGroupInputMedia::Photo(photo),
+        ];
         let params = SendMediaGroupParams::builder()
             .chat_id(-1001368460856)
             .media(medias)
@@ -971,9 +975,7 @@ mod tests {
         let response_string = "{\"ok\":true,\"result\":{\"message_id\":513,\"from\":{\"id\":1276618370,\"is_bot\":true,\"first_name\":\"test_el_bot\",\"username\":\"el_mon_test_bot\"},\"date\":1619336672,\"chat\":{\"id\":-1001368460856,\"type\":\"supergroup\",\"title\":\"Frankenstein\"},\"edit_date\":1619336788,\"photo\":[{\"file_id\":\"AgACAgIAAx0EUZEOOAACAgFghR5URaBN41jx7VNgLPi29xmfQgAC_q8xG0cfEUgpwpFo17XTfWTS5p8uAAMBAAMCAANtAANYQgACHwQ\",\"file_unique_id\":\"AQADZNLmny4AA1hCAAI\",\"width\":320,\"height\":320,\"file_size\":19162},{\"file_id\":\"AgACAgIAAx0EUZEOOAACAgFghR5URaBN41jx7VNgLPi29xmfQgAC_q8xG0cfEUgpwpFo17XTfWTS5p8uAAMBAAMCAAN4AANZQgACHwQ\",\"file_unique_id\":\"AQADZNLmny4AA1lCAAI\",\"width\":800,\"height\":800,\"file_size\":65697},{\"file_id\":\"AgACAgIAAx0EUZEOOAACAgFghR5URaBN41jx7VNgLPi29xmfQgAC_q8xG0cfEUgpwpFo17XTfWTS5p8uAAMBAAMCAAN5AANaQgACHwQ\",\"file_unique_id\":\"AQADZNLmny4AA1pCAAI\",\"width\":1146,\"height\":1146,\"file_size\":101324}]}}";
         let file = std::path::PathBuf::from("./frankenstein_logo.png");
         let params = EditMessageMediaParams::builder()
-            .media(InputMedia::Photo(
-                InputMediaPhoto::builder().media(file).build(),
-            ))
+            .media(InputMediaPhoto::builder().media(file).build())
             .chat_id(-1001368460856)
             .message_id(513)
             .build();

--- a/src/games.rs
+++ b/src/games.rs
@@ -1,0 +1,27 @@
+//! API Objects to be used with [HTML5 games](https://core.telegram.org/bots/api#games).
+
+use crate::macros::{apistruct, apply};
+use crate::objects::{Animation, MessageEntity, PhotoSize, User};
+
+#[apply(apistruct!)]
+#[derive(Copy, Eq)]
+pub struct CallbackGame {}
+
+#[apply(apistruct!)]
+#[derive(Eq)]
+pub struct Game {
+    pub title: String,
+    pub description: String,
+    pub photo: Vec<PhotoSize>,
+    pub text: Option<String>,
+    pub text_entities: Option<Vec<MessageEntity>>,
+    pub animation: Option<Animation>,
+}
+
+#[apply(apistruct!)]
+#[derive(Eq)]
+pub struct GameHighScore {
+    pub position: u32,
+    pub user: User,
+    pub score: i32,
+}

--- a/src/inline_mode.rs
+++ b/src/inline_mode.rs
@@ -1,0 +1,518 @@
+//! API Objects to be used with [Inline Mode](https://core.telegram.org/bots/api#inline-mode).
+
+#![allow(deprecated)]
+
+use serde::{Deserialize, Serialize};
+
+use crate::macros::{apistruct, apply};
+use crate::objects::{
+    InlineKeyboardMarkup, LinkPreviewOptions, Location, MessageEntity, User, WebAppInfo,
+};
+use crate::payments::LabeledPrice;
+use crate::ParseMode;
+
+#[apply(apistruct!)]
+pub struct InlineQuery {
+    pub id: String,
+    pub from: User,
+    pub location: Option<Location>,
+    pub chat_type: Option<String>,
+    pub query: String,
+    pub offset: String,
+}
+
+#[apply(apistruct!)]
+#[derive(Eq)]
+pub struct InlineQueryResultsButton {
+    pub text: String,
+    pub web_app: Option<WebAppInfo>,
+    pub start_parameter: Option<String>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum InlineQueryResult {
+    Audio(MaybeCached<InlineQueryResultCachedAudio, InlineQueryResultAudio>),
+    Document(MaybeCached<InlineQueryResultCachedDocument, InlineQueryResultDocument>),
+    Gif(MaybeCached<InlineQueryResultCachedGif, InlineQueryResultGif>),
+    Mpeg4Gif(MaybeCached<InlineQueryResultCachedMpeg4Gif, InlineQueryResultMpeg4Gif>),
+    Photo(MaybeCached<InlineQueryResultCachedPhoto, InlineQueryResultPhoto>),
+    Sticker(InlineQueryResultCachedSticker),
+    Video(MaybeCached<InlineQueryResultCachedVideo, InlineQueryResultVideo>),
+    Voice(MaybeCached<InlineQueryResultCachedVoice, InlineQueryResultVoice>),
+    Article(InlineQueryResultArticle),
+    Contact(InlineQueryResultContact),
+    Game(InlineQueryResultGame),
+    Location(InlineQueryResultLocation),
+    Venue(InlineQueryResultVenue),
+}
+
+macro_rules! iqr_from {
+    (maybecached $type:ident) => {
+        paste::paste! {
+            impl From<[< InlineQueryResultCached $type >] > for InlineQueryResult {
+                fn from(value: [< InlineQueryResultCached $type >]) -> Self {
+                    Self::$type(MaybeCached::Cached(value))
+                }
+            }
+            impl From<[< InlineQueryResult $type >] > for InlineQueryResult {
+                fn from(value: [< InlineQueryResult $type >]) -> Self {
+                    Self::$type(MaybeCached::NotCached(value))
+                }
+            }
+        }
+    };
+    (cached $type:ident) => {
+        paste::paste! {
+            impl From<[< InlineQueryResultCached $type >] > for InlineQueryResult {
+                fn from(value: [< InlineQueryResultCached $type >]) -> Self {
+                    Self::$type(value)
+                }
+            }
+        }
+    };
+    ($type:ident) => {
+        paste::paste! {
+            impl From<[< InlineQueryResult $type >] > for InlineQueryResult {
+                fn from(value: [< InlineQueryResult $type >]) -> Self {
+                    Self::$type(value)
+                }
+            }
+        }
+    };
+}
+
+iqr_from!(maybecached Audio);
+iqr_from!(maybecached Document);
+iqr_from!(maybecached Gif);
+iqr_from!(maybecached Mpeg4Gif);
+iqr_from!(maybecached Photo);
+iqr_from!(cached Sticker);
+iqr_from!(maybecached Video);
+iqr_from!(maybecached Voice);
+iqr_from!(Article);
+iqr_from!(Contact);
+iqr_from!(Game);
+iqr_from!(Location);
+iqr_from!(Venue);
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(untagged)]
+pub enum MaybeCached<T1, T2> {
+    Cached(T1),
+    NotCached(T2),
+}
+
+#[apply(apistruct!)]
+pub struct InlineQueryResultArticle {
+    pub id: String,
+    pub title: String,
+    pub input_message_content: InputMessageContent,
+    pub reply_markup: Option<InlineKeyboardMarkup>,
+    pub url: Option<String>,
+    #[doc(hidden)]
+    #[deprecated(
+        since = "0.38.0",
+        note = "Please pass an empty string as `url` instead"
+    )]
+    pub hide_url: Option<bool>,
+    pub description: Option<String>,
+    pub thumbnail_url: Option<String>,
+    pub thumbnail_width: Option<u32>,
+    pub thumbnail_height: Option<u32>,
+}
+
+#[apply(apistruct!)]
+pub struct InlineQueryResultPhoto {
+    pub id: String,
+    pub photo_url: String,
+    pub thumbnail_url: String,
+    pub photo_width: Option<u32>,
+    pub photo_height: Option<u32>,
+    pub title: Option<String>,
+    pub description: Option<String>,
+    pub caption: Option<String>,
+    pub parse_mode: Option<ParseMode>,
+    pub caption_entities: Option<Vec<MessageEntity>>,
+    pub show_caption_above_media: Option<bool>,
+    pub reply_markup: Option<InlineKeyboardMarkup>,
+    pub input_message_content: Option<InputMessageContent>,
+}
+
+#[apply(apistruct!)]
+pub struct InlineQueryResultGif {
+    pub id: String,
+    pub gif_url: String,
+    pub gif_width: Option<u32>,
+    pub gif_height: Option<u32>,
+    pub gif_duration: Option<u32>,
+    pub thumbnail_url: String,
+    pub thumbnail_mime_type: Option<String>,
+    pub title: Option<String>,
+    pub caption: Option<String>,
+    pub parse_mode: Option<ParseMode>,
+    pub caption_entities: Option<Vec<MessageEntity>>,
+    pub show_caption_above_media: Option<bool>,
+    pub reply_markup: Option<InlineKeyboardMarkup>,
+    pub input_message_content: Option<InputMessageContent>,
+}
+
+#[apply(apistruct!)]
+pub struct InlineQueryResultMpeg4Gif {
+    pub id: String,
+    pub mpeg4_url: String,
+    pub mpeg4_width: Option<u32>,
+    pub mpeg4_height: Option<u32>,
+    pub mpeg4_duration: Option<u32>,
+    pub thumbnail_url: String,
+    pub thumbnail_mime_type: Option<String>,
+    pub title: Option<String>,
+    pub caption: Option<String>,
+    pub parse_mode: Option<ParseMode>,
+    pub caption_entities: Option<Vec<MessageEntity>>,
+    pub show_caption_above_media: Option<bool>,
+    pub reply_markup: Option<InlineKeyboardMarkup>,
+    pub input_message_content: Option<InputMessageContent>,
+}
+
+#[apply(apistruct!)]
+pub struct InlineQueryResultVideo {
+    pub id: String,
+    pub video_url: String,
+    pub mime_type: String,
+    pub thumbnail_url: String,
+    pub title: String,
+    pub caption: Option<String>,
+    pub parse_mode: Option<ParseMode>,
+    pub caption_entities: Option<Vec<MessageEntity>>,
+    pub video_width: Option<u32>,
+    pub video_height: Option<u32>,
+    pub video_duration: Option<u32>,
+    pub description: Option<String>,
+    pub show_caption_above_media: Option<bool>,
+    pub reply_markup: Option<InlineKeyboardMarkup>,
+    pub input_message_content: Option<InputMessageContent>,
+}
+
+#[apply(apistruct!)]
+pub struct InlineQueryResultAudio {
+    pub id: String,
+    pub audio_url: String,
+    pub title: String,
+    pub caption: Option<String>,
+    pub parse_mode: Option<ParseMode>,
+    pub caption_entities: Option<Vec<MessageEntity>>,
+    pub performer: Option<String>,
+    pub audio_duration: Option<u32>,
+    pub reply_markup: Option<InlineKeyboardMarkup>,
+    pub input_message_content: Option<InputMessageContent>,
+}
+
+#[apply(apistruct!)]
+pub struct InlineQueryResultVoice {
+    pub id: String,
+    pub voice_url: String,
+    pub title: String,
+    pub caption: Option<String>,
+    pub parse_mode: Option<ParseMode>,
+    pub caption_entities: Option<Vec<MessageEntity>>,
+    pub voice_duration: Option<u32>,
+    pub reply_markup: Option<InlineKeyboardMarkup>,
+    pub input_message_content: Option<InputMessageContent>,
+}
+
+#[apply(apistruct!)]
+pub struct InlineQueryResultDocument {
+    pub id: String,
+    pub title: String,
+    pub caption: Option<String>,
+    pub parse_mode: Option<ParseMode>,
+    pub caption_entities: Option<Vec<MessageEntity>>,
+    pub document_url: String,
+    pub mime_type: String,
+    pub description: Option<String>,
+    pub reply_markup: Option<InlineKeyboardMarkup>,
+    pub input_message_content: Option<InputMessageContent>,
+    pub thumbnail_url: Option<String>,
+    pub thumbnail_width: Option<u32>,
+    pub thumbnail_height: Option<u32>,
+}
+
+#[apply(apistruct!)]
+pub struct InlineQueryResultLocation {
+    pub id: String,
+    pub latitude: f64,
+    pub longitude: f64,
+    pub title: String,
+    pub horizontal_accuracy: Option<f64>,
+    pub live_period: Option<u32>,
+    pub heading: Option<u16>,
+    pub proximity_alert_radius: Option<u32>,
+    pub reply_markup: Option<InlineKeyboardMarkup>,
+    pub input_message_content: Option<InputMessageContent>,
+    pub thumbnail_url: Option<String>,
+    pub thumbnail_width: Option<u32>,
+    pub thumbnail_height: Option<u32>,
+}
+
+#[apply(apistruct!)]
+pub struct InlineQueryResultVenue {
+    pub id: String,
+    pub latitude: f64,
+    pub longitude: f64,
+    pub title: String,
+    pub address: String,
+    pub foursquare_id: Option<String>,
+    pub foursquare_type: Option<String>,
+    pub google_place_id: Option<String>,
+    pub google_place_type: Option<String>,
+    pub reply_markup: Option<InlineKeyboardMarkup>,
+    pub input_message_content: Option<InputMessageContent>,
+    pub thumbnail_url: Option<String>,
+    pub thumbnail_width: Option<u32>,
+    pub thumbnail_height: Option<u32>,
+}
+
+#[apply(apistruct!)]
+pub struct InlineQueryResultContact {
+    pub id: String,
+    pub phone_number: String,
+    pub first_name: String,
+    pub last_name: Option<String>,
+    pub vcard: Option<String>,
+    pub reply_markup: Option<InlineKeyboardMarkup>,
+    pub input_message_content: Option<InputMessageContent>,
+    pub thumbnail_url: Option<String>,
+    pub thumbnail_width: Option<u32>,
+    pub thumbnail_height: Option<u32>,
+}
+
+#[apply(apistruct!)]
+#[derive(Eq)]
+pub struct InlineQueryResultGame {
+    pub id: String,
+    pub game_short_name: String,
+    pub reply_markup: Option<InlineKeyboardMarkup>,
+}
+
+#[apply(apistruct!)]
+pub struct InlineQueryResultCachedPhoto {
+    pub id: String,
+    pub photo_file_id: String,
+    pub title: Option<String>,
+    pub description: Option<String>,
+    pub caption: Option<String>,
+    pub parse_mode: Option<ParseMode>,
+    pub caption_entities: Option<Vec<MessageEntity>>,
+    pub show_caption_above_media: Option<bool>,
+    pub reply_markup: Option<InlineKeyboardMarkup>,
+    pub input_message_content: Option<InputMessageContent>,
+}
+
+#[apply(apistruct!)]
+pub struct InlineQueryResultCachedGif {
+    pub id: String,
+    pub gif_file_id: String,
+    pub title: Option<String>,
+    pub caption: Option<String>,
+    pub parse_mode: Option<ParseMode>,
+    pub caption_entities: Option<Vec<MessageEntity>>,
+    pub show_caption_above_media: Option<bool>,
+    pub reply_markup: Option<InlineKeyboardMarkup>,
+    pub input_message_content: Option<InputMessageContent>,
+}
+
+#[apply(apistruct!)]
+pub struct InlineQueryResultCachedMpeg4Gif {
+    pub id: String,
+    pub mpeg4_file_id: String,
+    pub title: Option<String>,
+    pub caption: Option<String>,
+    pub parse_mode: Option<ParseMode>,
+    pub caption_entities: Option<Vec<MessageEntity>>,
+    pub show_caption_above_media: Option<bool>,
+    pub reply_markup: Option<InlineKeyboardMarkup>,
+    pub input_message_content: Option<InputMessageContent>,
+}
+
+#[apply(apistruct!)]
+pub struct InlineQueryResultCachedSticker {
+    pub id: String,
+    pub sticker_file_id: String,
+    pub reply_markup: Option<InlineKeyboardMarkup>,
+    pub input_message_content: Option<InputMessageContent>,
+}
+
+#[apply(apistruct!)]
+pub struct InlineQueryResultCachedDocument {
+    pub id: String,
+    pub title: String,
+    pub document_file_id: String,
+    pub description: Option<String>,
+    pub caption: Option<String>,
+    pub parse_mode: Option<ParseMode>,
+    pub caption_entities: Option<Vec<MessageEntity>>,
+    pub reply_markup: Option<InlineKeyboardMarkup>,
+    pub input_message_content: Option<InputMessageContent>,
+}
+
+#[apply(apistruct!)]
+pub struct InlineQueryResultCachedVideo {
+    pub id: String,
+    pub video_file_id: String,
+    pub title: String,
+    pub description: Option<String>,
+    pub caption: Option<String>,
+    pub parse_mode: Option<ParseMode>,
+    pub caption_entities: Option<Vec<MessageEntity>>,
+    pub show_caption_above_media: Option<bool>,
+    pub reply_markup: Option<InlineKeyboardMarkup>,
+    pub input_message_content: Option<InputMessageContent>,
+}
+
+#[apply(apistruct!)]
+pub struct InlineQueryResultCachedVoice {
+    pub id: String,
+    pub voice_file_id: String,
+    pub title: String,
+    pub caption: Option<String>,
+    pub parse_mode: Option<ParseMode>,
+    pub caption_entities: Option<Vec<MessageEntity>>,
+    pub reply_markup: Option<InlineKeyboardMarkup>,
+    pub input_message_content: Option<InputMessageContent>,
+}
+
+#[apply(apistruct!)]
+pub struct InlineQueryResultCachedAudio {
+    pub id: String,
+    pub audio_file_id: String,
+    pub caption: Option<String>,
+    pub parse_mode: Option<ParseMode>,
+    pub caption_entities: Option<Vec<MessageEntity>>,
+    pub reply_markup: Option<InlineKeyboardMarkup>,
+    pub input_message_content: Option<InputMessageContent>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[serde(untagged)]
+pub enum InputMessageContent {
+    Text(InputTextMessageContent),
+    Location(InputLocationMessageContent),
+    Venue(InputVenueMessageContent),
+    Contact(InputContactMessageContent),
+    Invoice(InputInvoiceMessageContent),
+}
+
+impl From<InputTextMessageContent> for InputMessageContent {
+    fn from(value: InputTextMessageContent) -> Self {
+        Self::Text(value)
+    }
+}
+impl From<InputLocationMessageContent> for InputMessageContent {
+    fn from(value: InputLocationMessageContent) -> Self {
+        Self::Location(value)
+    }
+}
+impl From<InputVenueMessageContent> for InputMessageContent {
+    fn from(value: InputVenueMessageContent) -> Self {
+        Self::Venue(value)
+    }
+}
+impl From<InputContactMessageContent> for InputMessageContent {
+    fn from(value: InputContactMessageContent) -> Self {
+        Self::Contact(value)
+    }
+}
+impl From<InputInvoiceMessageContent> for InputMessageContent {
+    fn from(value: InputInvoiceMessageContent) -> Self {
+        Self::Invoice(value)
+    }
+}
+
+#[apply(apistruct!)]
+#[derive(Eq)]
+pub struct InputTextMessageContent {
+    pub message_text: String,
+    pub parse_mode: Option<ParseMode>,
+    pub entities: Option<Vec<MessageEntity>>,
+    pub link_preview_options: Option<LinkPreviewOptions>,
+}
+
+#[apply(apistruct!)]
+#[derive(Copy)]
+pub struct InputLocationMessageContent {
+    pub latitude: f64,
+    pub longitude: f64,
+    pub horizontal_accuracy: Option<f64>,
+    pub live_period: Option<u32>,
+    pub heading: Option<u16>,
+    pub proximity_alert_radius: Option<u32>,
+}
+
+#[apply(apistruct!)]
+pub struct InputVenueMessageContent {
+    pub latitude: f64,
+    pub longitude: f64,
+    pub title: String,
+    pub address: String,
+    pub foursquare_id: Option<String>,
+    pub foursquare_type: Option<String>,
+    pub google_place_id: Option<String>,
+    pub google_place_type: Option<String>,
+}
+
+#[apply(apistruct!)]
+#[derive(Eq)]
+pub struct InputContactMessageContent {
+    pub phone_number: String,
+    pub first_name: String,
+    pub last_name: Option<String>,
+    pub vcard: Option<String>,
+}
+
+#[apply(apistruct!)]
+#[derive(Eq)]
+pub struct InputInvoiceMessageContent {
+    pub title: String,
+    pub description: String,
+    pub payload: String,
+    pub provider_token: Option<String>,
+    pub currency: String,
+    pub prices: Vec<LabeledPrice>,
+    pub max_tip_amount: Option<u32>,
+    pub suggested_tip_amounts: Option<Vec<u32>>,
+    pub provider_data: Option<String>,
+    pub photo_url: Option<String>,
+    pub photo_size: Option<u32>,
+    pub photo_width: Option<u32>,
+    pub photo_height: Option<u32>,
+    pub need_name: Option<bool>,
+    pub need_phone_number: Option<bool>,
+    pub need_email: Option<bool>,
+    pub need_shipping_address: Option<bool>,
+    pub send_phone_number_to_provider: Option<bool>,
+    pub send_email_to_provider: Option<bool>,
+    pub is_flexible: Option<bool>,
+}
+
+#[apply(apistruct!)]
+pub struct ChosenInlineResult {
+    pub result_id: String,
+    pub from: User,
+    pub location: Option<Location>,
+    pub inline_message_id: Option<String>,
+    pub query: String,
+}
+
+#[apply(apistruct!)]
+#[derive(Eq)]
+pub struct SentWebAppMessage {
+    pub inline_message_id: String,
+}
+
+#[apply(apistruct!)]
+#[derive(Eq)]
+pub struct PreparedInlineMessage {
+    pub id: String,
+    pub expiration_date: u64,
+}

--- a/src/input_media.rs
+++ b/src/input_media.rs
@@ -1,0 +1,169 @@
+use serde::{Deserialize, Serialize};
+
+use crate::input_file::FileUpload;
+use crate::macros::{apistruct, apply};
+use crate::objects::MessageEntity;
+use crate::ParseMode;
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum InputMedia {
+    Animation(InputMediaAnimation),
+    Document(InputMediaDocument),
+    Audio(InputMediaAudio),
+    Photo(InputMediaPhoto),
+    Video(InputMediaVideo),
+}
+
+impl From<InputMediaAnimation> for InputMedia {
+    fn from(value: InputMediaAnimation) -> Self {
+        Self::Animation(value)
+    }
+}
+impl From<InputMediaDocument> for InputMedia {
+    fn from(value: InputMediaDocument) -> Self {
+        Self::Document(value)
+    }
+}
+impl From<InputMediaAudio> for InputMedia {
+    fn from(value: InputMediaAudio) -> Self {
+        Self::Audio(value)
+    }
+}
+impl From<InputMediaPhoto> for InputMedia {
+    fn from(value: InputMediaPhoto) -> Self {
+        Self::Photo(value)
+    }
+}
+impl From<InputMediaVideo> for InputMedia {
+    fn from(value: InputMediaVideo) -> Self {
+        Self::Video(value)
+    }
+}
+
+/// Media relevant for `sendMediaGroup`.
+///
+/// See <https://core.telegram.org/bots/api#sendmediagroup>
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum MediaGroupInputMedia {
+    Audio(InputMediaAudio),
+    Document(InputMediaDocument),
+    Photo(InputMediaPhoto),
+    Video(InputMediaVideo),
+}
+
+impl From<InputMediaAudio> for MediaGroupInputMedia {
+    fn from(value: InputMediaAudio) -> Self {
+        Self::Audio(value)
+    }
+}
+impl From<InputMediaDocument> for MediaGroupInputMedia {
+    fn from(value: InputMediaDocument) -> Self {
+        Self::Document(value)
+    }
+}
+impl From<InputMediaPhoto> for MediaGroupInputMedia {
+    fn from(value: InputMediaPhoto) -> Self {
+        Self::Photo(value)
+    }
+}
+impl From<InputMediaVideo> for MediaGroupInputMedia {
+    fn from(value: InputMediaVideo) -> Self {
+        Self::Video(value)
+    }
+}
+
+#[apply(apistruct!)]
+#[derive(Eq)]
+pub struct InputMediaPhoto {
+    pub media: FileUpload,
+    pub caption: Option<String>,
+    pub parse_mode: Option<ParseMode>,
+    pub caption_entities: Option<Vec<MessageEntity>>,
+    pub show_caption_above_media: Option<bool>,
+    pub has_spoiler: Option<bool>,
+}
+
+#[apply(apistruct!)]
+#[derive(Eq)]
+pub struct InputMediaVideo {
+    pub media: FileUpload,
+    pub thumbnail: Option<FileUpload>,
+    pub cover: Option<FileUpload>,
+    pub start_timestamp: Option<u64>,
+    pub caption: Option<String>,
+    pub parse_mode: Option<ParseMode>,
+    pub caption_entities: Option<Vec<MessageEntity>>,
+    pub show_caption_above_media: Option<bool>,
+    pub width: Option<u32>,
+    pub height: Option<u32>,
+    pub duration: Option<u32>,
+    pub supports_streaming: Option<bool>,
+    pub has_spoiler: Option<bool>,
+}
+
+#[apply(apistruct!)]
+#[derive(Eq)]
+pub struct InputMediaAnimation {
+    pub media: FileUpload,
+    pub thumbnail: Option<FileUpload>,
+    pub caption: Option<String>,
+    pub parse_mode: Option<ParseMode>,
+    pub caption_entities: Option<Vec<MessageEntity>>,
+    pub show_caption_above_media: Option<bool>,
+    pub width: Option<u32>,
+    pub height: Option<u32>,
+    pub duration: Option<u32>,
+    pub has_spoiler: Option<bool>,
+}
+
+#[apply(apistruct!)]
+#[derive(Eq)]
+pub struct InputMediaAudio {
+    pub media: FileUpload,
+    pub thumbnail: Option<FileUpload>,
+    pub caption: Option<String>,
+    pub parse_mode: Option<ParseMode>,
+    pub caption_entities: Option<Vec<MessageEntity>>,
+    pub duration: Option<u32>,
+    pub performer: Option<String>,
+    pub title: Option<String>,
+}
+
+#[apply(apistruct!)]
+#[derive(Eq)]
+pub struct InputMediaDocument {
+    pub media: FileUpload,
+    pub thumbnail: Option<FileUpload>,
+    pub caption: Option<String>,
+    pub parse_mode: Option<ParseMode>,
+    pub caption_entities: Option<Vec<MessageEntity>>,
+    pub disable_content_type_detection: Option<bool>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum InputPaidMedia {
+    Photo(InputPaidMediaPhoto),
+    Video(InputPaidMediaVideo),
+}
+
+#[apply(apistruct!)]
+#[derive(Eq)]
+pub struct InputPaidMediaPhoto {
+    pub media: String,
+}
+
+#[apply(apistruct!)]
+#[derive(Eq)]
+pub struct InputPaidMediaVideo {
+    pub media: String,
+    pub thumbnail: String,
+    pub cover: Option<String>,
+    pub start_timestamp: Option<u64>,
+    pub width: Option<u32>,
+    pub height: Option<u32>,
+    pub duration: Option<u32>,
+    pub supports_streaming: Option<bool>,
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@ pub use ureq;
 pub use self::api_params::*;
 pub use self::error::Error;
 pub use self::input_file::*;
+pub use self::input_media::*;
 pub use self::objects::*;
 pub use self::parse_mode::ParseMode;
 pub use self::response::*;
@@ -24,19 +25,26 @@ pub mod client_reqwest;
 #[cfg(feature = "client-ureq")]
 pub mod client_ureq;
 mod error;
+pub mod games;
+pub mod inline_mode;
 pub mod input_file;
+pub mod input_media;
 #[cfg(any(feature = "client-reqwest", feature = "client-ureq"))]
 mod json;
 mod macros;
 pub mod objects;
 mod parse_mode;
+pub mod passport;
+pub mod payments;
 pub mod response;
+pub mod stickers;
 #[cfg(test)]
 mod test_json;
 #[cfg(feature = "trait-async")]
 mod trait_async;
 #[cfg(feature = "trait-sync")]
 mod trait_sync;
+pub mod updates;
 
 /// Default Bot API URL
 pub const BASE_API_URL: &str = "https://api.telegram.org/bot";

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -10,6 +10,8 @@ macro_rules_attribute::attribute_alias! {
             on(ChatId, into),
             on(FileUpload, into),
             on(InputFile, into),
+            on(InputMedia, into),
+            on(InputMessageContent, into),
             on(String, into),
         )];
 }

--- a/src/objects.rs
+++ b/src/objects.rs
@@ -1,37 +1,101 @@
-//! Objects returned or used with the Telegram API.
+//! [Available Types](https://core.telegram.org/bots/api#available-types) of the Bot API.
 
 #![allow(deprecated)]
 
 use serde::{Deserialize, Serialize};
 
-use crate::input_file::FileUpload;
+use crate::games::{CallbackGame, Game};
 use crate::macros::{apistruct, apply};
+use crate::passport::PassportData;
+use crate::payments::{Invoice, RefundedPayment, SuccessfulPayment};
+use crate::stickers::Sticker;
 use crate::ParseMode;
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(rename_all = "snake_case")]
-pub enum StickerType {
-    Regular,
-    Mask,
-    CustomEmoji,
+#[serde(untagged)]
+pub enum ChatId {
+    Integer(i64),
+    String(String),
+}
+
+impl From<i64> for ChatId {
+    fn from(id: i64) -> Self {
+        Self::Integer(id)
+    }
+}
+
+impl From<String> for ChatId {
+    fn from(id: String) -> Self {
+        Self::String(id)
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(untagged)]
+pub enum ReplyMarkup {
+    InlineKeyboardMarkup(InlineKeyboardMarkup),
+    ReplyKeyboardMarkup(ReplyKeyboardMarkup),
+    ReplyKeyboardRemove(ReplyKeyboardRemove),
+    ForceReply(ForceReply),
 }
 
 #[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
-pub enum StickerFormat {
-    Static,
-    Animated,
-    Video,
+pub enum ChatAction {
+    Typing,
+    UploadPhoto,
+    RecordVideo,
+    UploadVideo,
+    RecordVoice,
+    UploadVoice,
+    UploadDocument,
+    ChooseSticker,
+    FindLocation,
+    RecordVideoNote,
+    UploadVideoNote,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
-#[serde(untagged)]
-pub enum InputMessageContent {
-    Text(InputTextMessageContent),
-    Location(InputLocationMessageContent),
-    Venue(InputVenueMessageContent),
-    Contact(InputContactMessageContent),
-    Invoice(InputInvoiceMessageContent),
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum BotCommandScope {
+    Default,
+    AllPrivateChats,
+    AllGroupChats,
+    AllChatAdministrators,
+    Chat(BotCommandScopeChat),
+    ChatAdministrators(BotCommandScopeChatAdministrators),
+    ChatMember(BotCommandScopeChatMember),
+}
+
+#[apply(apistruct!)]
+#[derive(Eq)]
+pub struct BotCommandScopeChat {
+    pub chat_id: ChatId,
+}
+
+#[apply(apistruct!)]
+#[derive(Eq)]
+pub struct BotCommandScopeChatAdministrators {
+    pub chat_id: ChatId,
+}
+
+#[apply(apistruct!)]
+#[derive(Eq)]
+pub struct BotCommandScopeChatMember {
+    pub chat_id: ChatId,
+    pub user_id: u64,
+}
+
+#[apply(apistruct!)]
+#[derive(Eq)]
+pub struct ReplyParameters {
+    pub message_id: i32,
+    pub chat_id: Option<ChatId>,
+    pub allow_sending_without_reply: Option<bool>,
+    pub quote: Option<String>,
+    pub quote_parse_mode: Option<ParseMode>,
+    pub quote_entities: Option<Vec<MessageEntity>>,
+    pub quote_position: Option<u32>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
@@ -85,84 +149,6 @@ pub enum MessageEntityType {
 pub enum PollType {
     Regular,
     Quiz,
-}
-
-#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(rename_all = "snake_case")]
-pub enum EncryptedPassportElementType {
-    PersonalDetails,
-    Passport,
-    DriverLicense,
-    IdentityCard,
-    InternalPassport,
-    Address,
-    UtilityBill,
-    BankStatement,
-    RentalAgreement,
-    PassportRegistration,
-    TemporaryRegistration,
-    PhoneNumber,
-    Email,
-}
-
-#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(rename_all = "snake_case")]
-pub enum PassportElementErrorDataFieldType {
-    PersonalDetails,
-    Passport,
-    DriverLicense,
-    IdentityCard,
-    InternalPassport,
-    Address,
-}
-
-#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(rename_all = "snake_case")]
-pub enum PassportElementErrorFrontSideType {
-    Passport,
-    DriverLicense,
-    IdentityCard,
-    InternalPassport,
-}
-
-#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(rename_all = "snake_case")]
-pub enum PassportElementErrorReverseSideType {
-    DriverLicense,
-    IdentityCard,
-}
-
-#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(rename_all = "snake_case")]
-pub enum PassportElementErrorSelfieType {
-    Passport,
-    DriverLicense,
-    IdentityCard,
-    InternalPassport,
-}
-
-#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(rename_all = "snake_case")]
-pub enum PassportElementErrorFileType {
-    UtilityBill,
-    BankStatement,
-    RentalAgreement,
-    PassportRegistration,
-    TemporaryRegistration,
-}
-
-#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(rename_all = "snake_case")]
-pub enum PassportElementErrorTranslationFileType {
-    Passport,
-    DriverLicense,
-    IdentityCard,
-    InternalPassport,
-    UtilityBill,
-    BankStatement,
-    RentalAgreement,
-    PassportRegistration,
-    TemporaryRegistration,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
@@ -281,10 +267,6 @@ pub struct VideoChatScheduled {
 }
 
 #[apply(apistruct!)]
-#[derive(Copy, Eq)]
-pub struct CallbackGame {}
-
-#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct BotDescription {
     pub description: String,
@@ -300,60 +282,6 @@ pub struct BotName {
 #[derive(Eq)]
 pub struct BotShortDescription {
     pub short_description: String,
-}
-
-/// Represents an incoming update from telegram.
-/// [Official documentation.](https://core.telegram.org/bots/api#update)
-#[apply(apistruct!)]
-pub struct Update {
-    pub update_id: u32,
-
-    /// Maps to exactly one of the many optional fields
-    /// from [the official documentation](https://core.telegram.org/bots/api#update).
-    #[serde(flatten)]
-    pub content: UpdateContent,
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
-#[serde(rename_all = "snake_case")]
-pub enum UpdateContent {
-    Message(Message),
-    EditedMessage(Message),
-    ChannelPost(Message),
-    EditedChannelPost(Message),
-    BusinessConnection(BusinessConnection),
-    BusinessMessage(Message),
-    EditedBusinessMessage(Message),
-    DeletedBusinessMessages(BusinessMessagesDeleted),
-    MessageReaction(MessageReactionUpdated),
-    MessageReactionCount(MessageReactionCountUpdated),
-    InlineQuery(InlineQuery),
-    ChosenInlineResult(ChosenInlineResult),
-    CallbackQuery(CallbackQuery),
-    ShippingQuery(ShippingQuery),
-    PreCheckoutQuery(PreCheckoutQuery),
-    Poll(Poll),
-    PollAnswer(PollAnswer),
-    MyChatMember(ChatMemberUpdated),
-    ChatMember(ChatMemberUpdated),
-    ChatJoinRequest(ChatJoinRequest),
-    ChatBoost(ChatBoostUpdated),
-    RemovedChatBoost(ChatBoostRemoved),
-    PurchasedPaidMedia(PaidMediaPurchased),
-}
-
-#[apply(apistruct!)]
-#[derive(Eq)]
-pub struct WebhookInfo {
-    pub url: String,
-    pub has_custom_certificate: bool,
-    pub pending_update_count: u32,
-    pub ip_address: Option<String>,
-    pub last_error_date: Option<u64>,
-    pub last_error_message: Option<String>,
-    pub last_synchronization_error_date: Option<u64>,
-    pub max_connections: Option<u16>,
-    pub allowed_updates: Option<Vec<AllowedUpdate>>,
 }
 
 /// Control which updates to receive.
@@ -1315,473 +1243,10 @@ pub struct ResponseParameters {
 }
 
 #[apply(apistruct!)]
-pub struct Sticker {
-    pub file_id: String,
-    pub file_unique_id: String,
-    #[serde(rename = "type")]
-    pub sticker_type: StickerType,
-    pub width: u32,
-    pub height: u32,
-    pub is_animated: bool,
-    pub is_video: bool,
-    pub thumbnail: Option<PhotoSize>,
-    pub emoji: Option<String>,
-    pub set_name: Option<String>,
-    pub premium_animation: Option<File>,
-    pub mask_position: Option<MaskPosition>,
-    pub custom_emoji_id: Option<String>,
-    pub needs_repainting: Option<bool>,
-    pub file_size: Option<u64>,
-}
-
-#[apply(apistruct!)]
-pub struct InputSticker {
-    pub sticker: FileUpload,
-    pub format: StickerFormat,
-    pub emoji_list: Vec<String>,
-    pub mask_position: Option<MaskPosition>,
-    pub keywords: Option<Vec<String>>,
-}
-
-#[apply(apistruct!)]
-pub struct Gift {
-    pub id: String,
-    pub stricker: Sticker,
-    pub star_count: u32,
-    pub upgrade_star_count: Option<u32>,
-    pub total_count: Option<u32>,
-    pub remaining_count: Option<u32>,
-}
-
-#[apply(apistruct!)]
-pub struct Gifts {
-    pub gifts: Vec<Gift>,
-}
-
-#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct Story {
     pub chat: Chat,
     pub id: u64,
-}
-
-#[apply(apistruct!)]
-pub struct StickerSet {
-    pub name: String,
-    pub title: String,
-    pub sticker_type: StickerType,
-    #[doc(hidden)]
-    #[deprecated(since = "0.19.2", note = "Please use `sticker_type` instead")]
-    pub contains_masks: bool,
-    pub stickers: Vec<Sticker>,
-    pub thumbnail: Option<PhotoSize>,
-}
-
-#[apply(apistruct!)]
-pub struct MaskPosition {
-    pub point: String,
-    pub x_shift: f64,
-    pub y_shift: f64,
-    pub scale: f64,
-}
-
-#[apply(apistruct!)]
-pub struct InlineQuery {
-    pub id: String,
-    pub from: User,
-    pub location: Option<Location>,
-    pub chat_type: Option<String>,
-    pub query: String,
-    pub offset: String,
-}
-
-#[apply(apistruct!)]
-pub struct InlineQueryResultArticle {
-    pub id: String,
-    pub title: String,
-    pub input_message_content: InputMessageContent,
-    pub reply_markup: Option<InlineKeyboardMarkup>,
-    pub url: Option<String>,
-    #[doc(hidden)]
-    #[deprecated(
-        since = "0.38.0",
-        note = "Please pass an empty string as `url` instead"
-    )]
-    pub hide_url: Option<bool>,
-    pub description: Option<String>,
-    pub thumbnail_url: Option<String>,
-    pub thumbnail_width: Option<u32>,
-    pub thumbnail_height: Option<u32>,
-}
-
-#[apply(apistruct!)]
-pub struct InlineQueryResultPhoto {
-    pub id: String,
-    pub photo_url: String,
-    pub thumbnail_url: String,
-    pub photo_width: Option<u32>,
-    pub photo_height: Option<u32>,
-    pub title: Option<String>,
-    pub description: Option<String>,
-    pub caption: Option<String>,
-    pub parse_mode: Option<ParseMode>,
-    pub caption_entities: Option<Vec<MessageEntity>>,
-    pub show_caption_above_media: Option<bool>,
-    pub reply_markup: Option<InlineKeyboardMarkup>,
-    pub input_message_content: Option<InputMessageContent>,
-}
-
-#[apply(apistruct!)]
-pub struct InlineQueryResultGif {
-    pub id: String,
-    pub gif_url: String,
-    pub gif_width: Option<u32>,
-    pub gif_height: Option<u32>,
-    pub gif_duration: Option<u32>,
-    pub thumbnail_url: String,
-    pub thumbnail_mime_type: Option<String>,
-    pub title: Option<String>,
-    pub caption: Option<String>,
-    pub parse_mode: Option<ParseMode>,
-    pub caption_entities: Option<Vec<MessageEntity>>,
-    pub show_caption_above_media: Option<bool>,
-    pub reply_markup: Option<InlineKeyboardMarkup>,
-    pub input_message_content: Option<InputMessageContent>,
-}
-
-#[apply(apistruct!)]
-pub struct InlineQueryResultMpeg4Gif {
-    pub id: String,
-    pub mpeg4_url: String,
-    pub mpeg4_width: Option<u32>,
-    pub mpeg4_height: Option<u32>,
-    pub mpeg4_duration: Option<u32>,
-    pub thumbnail_url: String,
-    pub thumbnail_mime_type: Option<String>,
-    pub title: Option<String>,
-    pub caption: Option<String>,
-    pub parse_mode: Option<ParseMode>,
-    pub caption_entities: Option<Vec<MessageEntity>>,
-    pub show_caption_above_media: Option<bool>,
-    pub reply_markup: Option<InlineKeyboardMarkup>,
-    pub input_message_content: Option<InputMessageContent>,
-}
-
-#[apply(apistruct!)]
-pub struct InlineQueryResultVideo {
-    pub id: String,
-    pub video_url: String,
-    pub mime_type: String,
-    pub thumbnail_url: String,
-    pub title: String,
-    pub caption: Option<String>,
-    pub parse_mode: Option<ParseMode>,
-    pub caption_entities: Option<Vec<MessageEntity>>,
-    pub video_width: Option<u32>,
-    pub video_height: Option<u32>,
-    pub video_duration: Option<u32>,
-    pub description: Option<String>,
-    pub show_caption_above_media: Option<bool>,
-    pub reply_markup: Option<InlineKeyboardMarkup>,
-    pub input_message_content: Option<InputMessageContent>,
-}
-
-#[apply(apistruct!)]
-pub struct InlineQueryResultAudio {
-    pub id: String,
-    pub audio_url: String,
-    pub title: String,
-    pub caption: Option<String>,
-    pub parse_mode: Option<ParseMode>,
-    pub caption_entities: Option<Vec<MessageEntity>>,
-    pub performer: Option<String>,
-    pub audio_duration: Option<u32>,
-    pub reply_markup: Option<InlineKeyboardMarkup>,
-    pub input_message_content: Option<InputMessageContent>,
-}
-
-#[apply(apistruct!)]
-pub struct InlineQueryResultVoice {
-    pub id: String,
-    pub voice_url: String,
-    pub title: String,
-    pub caption: Option<String>,
-    pub parse_mode: Option<ParseMode>,
-    pub caption_entities: Option<Vec<MessageEntity>>,
-    pub voice_duration: Option<u32>,
-    pub reply_markup: Option<InlineKeyboardMarkup>,
-    pub input_message_content: Option<InputMessageContent>,
-}
-
-#[apply(apistruct!)]
-pub struct InlineQueryResultDocument {
-    pub id: String,
-    pub title: String,
-    pub caption: Option<String>,
-    pub parse_mode: Option<ParseMode>,
-    pub caption_entities: Option<Vec<MessageEntity>>,
-    pub document_url: String,
-    pub mime_type: String,
-    pub description: Option<String>,
-    pub reply_markup: Option<InlineKeyboardMarkup>,
-    pub input_message_content: Option<InputMessageContent>,
-    pub thumbnail_url: Option<String>,
-    pub thumbnail_width: Option<u32>,
-    pub thumbnail_height: Option<u32>,
-}
-
-#[apply(apistruct!)]
-pub struct InlineQueryResultLocation {
-    pub id: String,
-    pub latitude: f64,
-    pub longitude: f64,
-    pub title: String,
-    pub horizontal_accuracy: Option<f64>,
-    pub live_period: Option<u32>,
-    pub heading: Option<u16>,
-    pub proximity_alert_radius: Option<u32>,
-    pub reply_markup: Option<InlineKeyboardMarkup>,
-    pub input_message_content: Option<InputMessageContent>,
-    pub thumbnail_url: Option<String>,
-    pub thumbnail_width: Option<u32>,
-    pub thumbnail_height: Option<u32>,
-}
-
-#[apply(apistruct!)]
-pub struct InlineQueryResultVenue {
-    pub id: String,
-    pub latitude: f64,
-    pub longitude: f64,
-    pub title: String,
-    pub address: String,
-    pub foursquare_id: Option<String>,
-    pub foursquare_type: Option<String>,
-    pub google_place_id: Option<String>,
-    pub google_place_type: Option<String>,
-    pub reply_markup: Option<InlineKeyboardMarkup>,
-    pub input_message_content: Option<InputMessageContent>,
-    pub thumbnail_url: Option<String>,
-    pub thumbnail_width: Option<u32>,
-    pub thumbnail_height: Option<u32>,
-}
-
-#[apply(apistruct!)]
-pub struct InlineQueryResultContact {
-    pub id: String,
-    pub phone_number: String,
-    pub first_name: String,
-    pub last_name: Option<String>,
-    pub vcard: Option<String>,
-    pub reply_markup: Option<InlineKeyboardMarkup>,
-    pub input_message_content: Option<InputMessageContent>,
-    pub thumbnail_url: Option<String>,
-    pub thumbnail_width: Option<u32>,
-    pub thumbnail_height: Option<u32>,
-}
-
-#[apply(apistruct!)]
-#[derive(Eq)]
-pub struct InlineQueryResultGame {
-    pub id: String,
-    pub game_short_name: String,
-    pub reply_markup: Option<InlineKeyboardMarkup>,
-}
-
-#[apply(apistruct!)]
-pub struct InlineQueryResultCachedPhoto {
-    pub id: String,
-    pub photo_file_id: String,
-    pub title: Option<String>,
-    pub description: Option<String>,
-    pub caption: Option<String>,
-    pub parse_mode: Option<ParseMode>,
-    pub caption_entities: Option<Vec<MessageEntity>>,
-    pub show_caption_above_media: Option<bool>,
-    pub reply_markup: Option<InlineKeyboardMarkup>,
-    pub input_message_content: Option<InputMessageContent>,
-}
-
-#[apply(apistruct!)]
-pub struct InlineQueryResultCachedGif {
-    pub id: String,
-    pub gif_file_id: String,
-    pub title: Option<String>,
-    pub caption: Option<String>,
-    pub parse_mode: Option<ParseMode>,
-    pub caption_entities: Option<Vec<MessageEntity>>,
-    pub show_caption_above_media: Option<bool>,
-    pub reply_markup: Option<InlineKeyboardMarkup>,
-    pub input_message_content: Option<InputMessageContent>,
-}
-
-#[apply(apistruct!)]
-pub struct InlineQueryResultCachedMpeg4Gif {
-    pub id: String,
-    pub mpeg4_file_id: String,
-    pub title: Option<String>,
-    pub caption: Option<String>,
-    pub parse_mode: Option<ParseMode>,
-    pub caption_entities: Option<Vec<MessageEntity>>,
-    pub show_caption_above_media: Option<bool>,
-    pub reply_markup: Option<InlineKeyboardMarkup>,
-    pub input_message_content: Option<InputMessageContent>,
-}
-
-#[apply(apistruct!)]
-pub struct InlineQueryResultCachedSticker {
-    pub id: String,
-    pub sticker_file_id: String,
-    pub reply_markup: Option<InlineKeyboardMarkup>,
-    pub input_message_content: Option<InputMessageContent>,
-}
-
-#[apply(apistruct!)]
-pub struct InlineQueryResultCachedDocument {
-    pub id: String,
-    pub title: String,
-    pub document_file_id: String,
-    pub description: Option<String>,
-    pub caption: Option<String>,
-    pub parse_mode: Option<ParseMode>,
-    pub caption_entities: Option<Vec<MessageEntity>>,
-    pub reply_markup: Option<InlineKeyboardMarkup>,
-    pub input_message_content: Option<InputMessageContent>,
-}
-
-#[apply(apistruct!)]
-pub struct InlineQueryResultCachedVideo {
-    pub id: String,
-    pub video_file_id: String,
-    pub title: String,
-    pub description: Option<String>,
-    pub caption: Option<String>,
-    pub parse_mode: Option<ParseMode>,
-    pub caption_entities: Option<Vec<MessageEntity>>,
-    pub show_caption_above_media: Option<bool>,
-    pub reply_markup: Option<InlineKeyboardMarkup>,
-    pub input_message_content: Option<InputMessageContent>,
-}
-
-#[apply(apistruct!)]
-pub struct InlineQueryResultCachedVoice {
-    pub id: String,
-    pub voice_file_id: String,
-    pub title: String,
-    pub caption: Option<String>,
-    pub parse_mode: Option<ParseMode>,
-    pub caption_entities: Option<Vec<MessageEntity>>,
-    pub reply_markup: Option<InlineKeyboardMarkup>,
-    pub input_message_content: Option<InputMessageContent>,
-}
-
-#[apply(apistruct!)]
-pub struct InlineQueryResultCachedAudio {
-    pub id: String,
-    pub audio_file_id: String,
-    pub caption: Option<String>,
-    pub parse_mode: Option<ParseMode>,
-    pub caption_entities: Option<Vec<MessageEntity>>,
-    pub reply_markup: Option<InlineKeyboardMarkup>,
-    pub input_message_content: Option<InputMessageContent>,
-}
-
-#[apply(apistruct!)]
-#[derive(Eq)]
-pub struct InputTextMessageContent {
-    pub message_text: String,
-    pub parse_mode: Option<ParseMode>,
-    pub entities: Option<Vec<MessageEntity>>,
-    pub link_preview_options: Option<LinkPreviewOptions>,
-}
-
-#[apply(apistruct!)]
-#[derive(Copy)]
-pub struct InputLocationMessageContent {
-    pub latitude: f64,
-    pub longitude: f64,
-    pub horizontal_accuracy: Option<f64>,
-    pub live_period: Option<u32>,
-    pub heading: Option<u16>,
-    pub proximity_alert_radius: Option<u32>,
-}
-
-#[apply(apistruct!)]
-#[derive(Eq)]
-pub struct InputInvoiceMessageContent {
-    pub title: String,
-    pub description: String,
-    pub payload: String,
-    pub provider_token: Option<String>,
-    pub currency: String,
-    pub prices: Vec<LabeledPrice>,
-    pub max_tip_amount: Option<u32>,
-    pub suggested_tip_amounts: Option<Vec<u32>>,
-    pub provider_data: Option<String>,
-    pub photo_url: Option<String>,
-    pub photo_size: Option<u32>,
-    pub photo_width: Option<u32>,
-    pub photo_height: Option<u32>,
-    pub need_name: Option<bool>,
-    pub need_phone_number: Option<bool>,
-    pub need_email: Option<bool>,
-    pub need_shipping_address: Option<bool>,
-    pub send_phone_number_to_provider: Option<bool>,
-    pub send_email_to_provider: Option<bool>,
-    pub is_flexible: Option<bool>,
-}
-
-#[apply(apistruct!)]
-pub struct InputVenueMessageContent {
-    pub latitude: f64,
-    pub longitude: f64,
-    pub title: String,
-    pub address: String,
-    pub foursquare_id: Option<String>,
-    pub foursquare_type: Option<String>,
-    pub google_place_id: Option<String>,
-    pub google_place_type: Option<String>,
-}
-
-#[apply(apistruct!)]
-#[derive(Eq)]
-pub struct InputContactMessageContent {
-    pub phone_number: String,
-    pub first_name: String,
-    pub last_name: Option<String>,
-    pub vcard: Option<String>,
-}
-
-#[apply(apistruct!)]
-pub struct ChosenInlineResult {
-    pub result_id: String,
-    pub from: User,
-    pub location: Option<Location>,
-    pub inline_message_id: Option<String>,
-    pub query: String,
-}
-
-#[apply(apistruct!)]
-#[derive(Eq)]
-pub struct PreparedInlineMessage {
-    pub id: String,
-    pub expiration_date: u64,
-}
-
-#[apply(apistruct!)]
-#[derive(Eq)]
-pub struct LabeledPrice {
-    pub label: String,
-    pub amount: u32,
-}
-
-#[apply(apistruct!)]
-#[derive(Eq)]
-pub struct Invoice {
-    pub title: String,
-    pub description: String,
-    pub start_parameter: String,
-    pub currency: String,
-    pub total_amount: u32,
 }
 
 #[apply(apistruct!)]
@@ -1817,254 +1282,6 @@ pub struct PaidMediaPhoto {
 #[derive(Eq)]
 pub struct PaidMediaVideo {
     pub video: Video,
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(tag = "type", rename_all = "snake_case")]
-pub enum InputPaidMedia {
-    Photo(InputPaidMediaPhoto),
-    Video(InputPaidMediaVideo),
-}
-
-#[apply(apistruct!)]
-#[derive(Eq)]
-pub struct InputPaidMediaPhoto {
-    pub media: String,
-}
-
-#[apply(apistruct!)]
-#[derive(Eq)]
-pub struct InputPaidMediaVideo {
-    pub media: String,
-    pub thumbnail: String,
-    pub cover: Option<String>,
-    pub start_timestamp: Option<u64>,
-    pub width: Option<u32>,
-    pub height: Option<u32>,
-    pub duration: Option<u32>,
-    pub supports_streaming: Option<bool>,
-}
-
-#[apply(apistruct!)]
-#[derive(Eq)]
-pub struct ShippingAddress {
-    pub country_code: String,
-    pub state: String,
-    pub city: String,
-    pub street_line1: String,
-    pub street_line2: String,
-    pub post_code: String,
-}
-
-#[apply(apistruct!)]
-#[derive(Eq)]
-pub struct OrderInfo {
-    pub name: Option<String>,
-    pub phone_number: Option<String>,
-    pub email: Option<String>,
-    pub shipping_address: Option<ShippingAddress>,
-}
-
-#[apply(apistruct!)]
-#[derive(Eq)]
-pub struct ShippingOption {
-    pub id: String,
-    pub title: String,
-    pub prices: Vec<LabeledPrice>,
-}
-
-#[apply(apistruct!)]
-#[derive(Eq)]
-pub struct SuccessfulPayment {
-    pub currency: String,
-    pub total_amount: u32,
-    pub invoice_payload: String,
-    pub subscription_expiration_date: Option<u64>,
-    pub is_recurring: Option<bool>,
-    pub is_first_recurring: Option<bool>,
-    pub shipping_option_id: Option<String>,
-    pub order_info: Option<OrderInfo>,
-    pub telegram_payment_charge_id: String,
-    pub provider_payment_charge_id: String,
-}
-
-#[apply(apistruct!)]
-#[derive(Eq)]
-pub struct RefundedPayment {
-    pub currency: String,
-    pub total_amount: u32,
-    pub invoice_payload: String,
-    pub telegram_payment_charge_id: String,
-    pub provider_payment_charge_id: Option<String>,
-}
-
-#[apply(apistruct!)]
-#[derive(Eq)]
-pub struct ShippingQuery {
-    pub id: String,
-    pub from: User,
-    pub invoice_payload: String,
-    pub shipping_address: ShippingAddress,
-}
-
-#[apply(apistruct!)]
-#[derive(Eq)]
-pub struct PreCheckoutQuery {
-    pub id: String,
-    pub from: User,
-    pub currency: String,
-    pub total_amount: u32,
-    pub invoice_payload: String,
-    pub shipping_option_id: Option<String>,
-    pub order_info: Option<OrderInfo>,
-}
-
-#[apply(apistruct!)]
-#[derive(Eq)]
-pub struct PaidMediaPurchased {
-    pub from: User,
-    pub paid_media_payload: String,
-}
-
-#[apply(apistruct!)]
-#[derive(Eq)]
-pub struct PassportData {
-    pub data: Vec<EncryptedPassportElement>,
-    pub credentials: EncryptedCredentials,
-}
-
-#[apply(apistruct!)]
-#[derive(Eq)]
-pub struct PassportFile {
-    pub file_id: String,
-    pub file_unique_id: String,
-    pub file_size: u64,
-    pub file_date: u64,
-}
-
-#[apply(apistruct!)]
-#[derive(Eq)]
-pub struct EncryptedPassportElement {
-    #[serde(rename = "type")]
-    pub type_field: EncryptedPassportElementType,
-    pub data: Option<String>,
-    pub phone_number: Option<String>,
-    pub email: Option<String>,
-    pub files: Option<Vec<PassportFile>>,
-    pub front_side: Option<PassportFile>,
-    pub reverse_side: Option<PassportFile>,
-    pub selfie: Option<PassportFile>,
-    pub translation: Option<Vec<PassportFile>>,
-    pub hash: String,
-}
-
-#[apply(apistruct!)]
-#[derive(Eq)]
-pub struct EncryptedCredentials {
-    pub data: String,
-    pub hash: String,
-    pub secret: String,
-}
-
-#[apply(apistruct!)]
-#[derive(Eq)]
-pub struct PassportElementErrorDataField {
-    #[serde(rename = "type")]
-    pub type_field: PassportElementErrorDataFieldType,
-    pub field_name: String,
-    pub data_hash: String,
-    pub message: String,
-}
-
-#[apply(apistruct!)]
-#[derive(Eq)]
-pub struct PassportElementErrorFrontSide {
-    #[serde(rename = "type")]
-    pub type_field: PassportElementErrorFrontSideType,
-    pub file_hash: String,
-    pub message: String,
-}
-
-#[apply(apistruct!)]
-#[derive(Eq)]
-pub struct PassportElementErrorReverseSide {
-    #[serde(rename = "type")]
-    pub type_field: PassportElementErrorReverseSideType,
-    pub file_hash: String,
-    pub message: String,
-}
-
-#[apply(apistruct!)]
-#[derive(Eq)]
-pub struct PassportElementErrorSelfie {
-    #[serde(rename = "type")]
-    pub type_field: PassportElementErrorSelfieType,
-    pub file_hash: String,
-    pub message: String,
-}
-
-#[apply(apistruct!)]
-#[derive(Eq)]
-pub struct PassportElementErrorFile {
-    #[serde(rename = "type")]
-    pub type_field: PassportElementErrorFileType,
-    pub file_hash: String,
-    pub message: String,
-}
-
-#[apply(apistruct!)]
-#[derive(Eq)]
-pub struct PassportElementErrorFiles {
-    #[serde(rename = "type")]
-    pub type_field: PassportElementErrorFileType,
-    pub file_hashes: Vec<String>,
-    pub message: String,
-}
-
-#[apply(apistruct!)]
-#[derive(Eq)]
-pub struct PassportElementErrorTranslationFile {
-    #[serde(rename = "type")]
-    pub type_field: PassportElementErrorTranslationFileType,
-    pub file_hash: String,
-    pub message: String,
-}
-
-#[apply(apistruct!)]
-#[derive(Eq)]
-pub struct PassportElementErrorTranslationFiles {
-    #[serde(rename = "type")]
-    pub type_field: PassportElementErrorTranslationFileType,
-    pub file_hashes: Vec<String>,
-    pub message: String,
-}
-
-#[apply(apistruct!)]
-#[derive(Eq)]
-pub struct PassportElementErrorUnspecified {
-    #[serde(rename = "type")]
-    pub type_field: EncryptedPassportElementType,
-    pub element_hash: String,
-    pub message: String,
-}
-
-#[apply(apistruct!)]
-#[derive(Eq)]
-pub struct Game {
-    pub title: String,
-    pub description: String,
-    pub photo: Vec<PhotoSize>,
-    pub text: Option<String>,
-    pub text_entities: Option<Vec<MessageEntity>>,
-    pub animation: Option<Animation>,
-}
-
-#[apply(apistruct!)]
-#[derive(Eq)]
-pub struct GameHighScore {
-    pub position: u32,
-    pub user: User,
-    pub score: i32,
 }
 
 #[apply(apistruct!)]
@@ -2136,12 +1353,6 @@ pub struct ChatAdministratorRights {
 #[derive(Eq)]
 pub struct WebAppInfo {
     pub url: String,
-}
-
-#[apply(apistruct!)]
-#[derive(Eq)]
-pub struct SentWebAppMessage {
-    pub inline_message_id: String,
 }
 
 #[apply(apistruct!)]
@@ -2245,171 +1456,9 @@ pub struct InaccessibleMessage {
     pub date: u64,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(tag = "type", rename_all = "snake_case")]
-pub enum RevenueWithdrawalState {
-    Pending(RevenueWithdrawalStatePending),
-    Succeeded(RevenueWithdrawalStateSucceeded),
-    Failed(RevenueWithdrawalStateFailed),
-}
-
-#[apply(apistruct!)]
-#[derive(Eq)]
-pub struct RevenueWithdrawalStatePending {}
-
-#[apply(apistruct!)]
-#[derive(Eq)]
-pub struct RevenueWithdrawalStateSucceeded {
-    pub date: u64,
-    pub url: String,
-}
-
-#[apply(apistruct!)]
-#[derive(Eq)]
-pub struct RevenueWithdrawalStateFailed {}
-
-#[apply(apistruct!)]
-#[derive(Eq)]
-pub struct AffiliateInfo {
-    pub affiliate_user: Option<User>,
-    pub affiliate_chat: Option<Chat>,
-    pub commission_per_mille: u32,
-    pub amount: u32,
-    pub nanostar_amount: Option<u32>,
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
-#[serde(tag = "type", rename_all = "snake_case")]
-#[non_exhaustive]
-pub enum TransactionPartner {
-    User(Box<TransactionPartnerUser>),
-    Chat(Box<TransactionPartnerChat>),
-    AffiliateProgram(TransactionPartnerAffiliateProgram),
-    Fragment(TransactionPartnerFragment),
-    TelegramAds(TransactionPartnerTelegramAds),
-    TelegramApi(TransactionPartnerTelegramApi),
-    Other(TransactionPartnerOther),
-}
-
-#[apply(apistruct!)]
-pub struct TransactionPartnerUser {
-    pub user: User,
-    pub affiliate: Option<AffiliateInfo>,
-    pub invoice_payload: Option<String>,
-    pub subscription_period: Option<u32>,
-    pub paid_media: Option<Vec<PaidMedia>>,
-    pub paid_media_payload: Option<String>,
-    pub gift: Option<Gift>,
-}
-
-#[apply(apistruct!)]
-pub struct TransactionPartnerChat {
-    pub chat: Chat,
-    pub gift: Option<Gift>,
-}
-
-#[apply(apistruct!)]
-#[derive(Eq)]
-pub struct TransactionPartnerAffiliateProgram {
-    pub sponsor_user: User,
-    pub commission_per_mille: u32,
-}
-
-#[apply(apistruct!)]
-#[derive(Eq)]
-pub struct TransactionPartnerFragment {
-    pub withdrawal_state: Option<RevenueWithdrawalState>,
-}
-
-#[apply(apistruct!)]
-#[derive(Eq)]
-pub struct TransactionPartnerTelegramAds {}
-
-#[apply(apistruct!)]
-#[derive(Eq)]
-pub struct TransactionPartnerTelegramApi {
-    pub request_count: u64,
-}
-
-#[apply(apistruct!)]
-#[derive(Eq)]
-pub struct TransactionPartnerOther {}
-
-#[apply(apistruct!)]
-pub struct StarTransaction {
-    pub id: String,
-    pub amount: u32,
-    pub nanostar_amount: u32,
-    pub date: u64,
-    pub source: Option<TransactionPartner>,
-    pub receiver: Option<TransactionPartner>,
-}
-
-#[apply(apistruct!)]
-pub struct StarTransactions {
-    pub transactions: Vec<StarTransaction>,
-}
-
 #[cfg(test)]
 mod serde_tests {
     use super::*;
-
-    #[test]
-    pub fn update_content_is_flattened() {
-        let update_content = r#"{
-            "update_id": 2341,
-            "message": {
-                "message_id": 2746,
-                "from": {
-                    "id": 1276618370,
-                    "is_bot": true,
-                    "first_name": "test_el_bot",
-                    "username": "el_mon_test_bot"
-                },
-                "date": 1618207352,
-                "chat": {
-                    "id": 275808073,
-                    "type": "private",
-                    "username": "Ayrat555",
-                    "first_name": "Ayrat",
-                    "last_name": "Badykov"
-                },
-                "text": "Hello!"
-            }
-        }"#;
-
-        let update: Update = serde_json::from_str(update_content).unwrap();
-
-        let message = Message::builder()
-            .message_id(2746)
-            .from(
-                User::builder()
-                    .id(1276618370)
-                    .is_bot(true)
-                    .first_name("test_el_bot")
-                    .username("el_mon_test_bot")
-                    .build(),
-            )
-            .date(1618207352)
-            .chat(
-                Chat::builder()
-                    .id(275808073)
-                    .type_field(ChatType::Private)
-                    .username("Ayrat555")
-                    .first_name("Ayrat")
-                    .last_name("Badykov")
-                    .build(),
-            )
-            .text("Hello!")
-            .build();
-
-        let expected = Update {
-            update_id: 2341,
-            content: UpdateContent::Message(message),
-        };
-
-        assert_eq!(update, expected);
-    }
 
     #[test]
     pub fn kicked_user_status_is_parsed() {

--- a/src/passport.rs
+++ b/src/passport.rs
@@ -1,0 +1,220 @@
+//! API Objects to be used with [Telegram Passport](https://core.telegram.org/bots/api#telegram-passport).
+
+use serde::{Deserialize, Serialize};
+
+use crate::macros::{apistruct, apply};
+
+#[apply(apistruct!)]
+#[derive(Eq)]
+pub struct PassportData {
+    pub data: Vec<EncryptedPassportElement>,
+    pub credentials: EncryptedCredentials,
+}
+
+#[apply(apistruct!)]
+#[derive(Eq)]
+pub struct PassportFile {
+    pub file_id: String,
+    pub file_unique_id: String,
+    pub file_size: u64,
+    pub file_date: u64,
+}
+
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum EncryptedPassportElementType {
+    PersonalDetails,
+    Passport,
+    DriverLicense,
+    IdentityCard,
+    InternalPassport,
+    Address,
+    UtilityBill,
+    BankStatement,
+    RentalAgreement,
+    PassportRegistration,
+    TemporaryRegistration,
+    PhoneNumber,
+    Email,
+}
+
+#[apply(apistruct!)]
+#[derive(Eq)]
+pub struct EncryptedPassportElement {
+    #[serde(rename = "type")]
+    pub type_field: EncryptedPassportElementType,
+    pub data: Option<String>,
+    pub phone_number: Option<String>,
+    pub email: Option<String>,
+    pub files: Option<Vec<PassportFile>>,
+    pub front_side: Option<PassportFile>,
+    pub reverse_side: Option<PassportFile>,
+    pub selfie: Option<PassportFile>,
+    pub translation: Option<Vec<PassportFile>>,
+    pub hash: String,
+}
+
+#[apply(apistruct!)]
+#[derive(Eq)]
+pub struct EncryptedCredentials {
+    pub data: String,
+    pub hash: String,
+    pub secret: String,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "source", rename_all = "snake_case")]
+pub enum PassportElementError {
+    #[serde(rename = "data")]
+    DataField(PassportElementErrorDataField),
+    FrontSide(PassportElementErrorFrontSide),
+    ReverseSide(PassportElementErrorReverseSide),
+    Selfie(PassportElementErrorSelfie),
+    File(PassportElementErrorFile),
+    Files(PassportElementErrorFiles),
+    TranslationFile(PassportElementErrorTranslationFile),
+    TranslationFiles(PassportElementErrorTranslationFiles),
+    Unspecified(PassportElementErrorUnspecified),
+}
+
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum PassportElementErrorDataFieldType {
+    PersonalDetails,
+    Passport,
+    DriverLicense,
+    IdentityCard,
+    InternalPassport,
+    Address,
+}
+
+#[apply(apistruct!)]
+#[derive(Eq)]
+pub struct PassportElementErrorDataField {
+    #[serde(rename = "type")]
+    pub type_field: PassportElementErrorDataFieldType,
+    pub field_name: String,
+    pub data_hash: String,
+    pub message: String,
+}
+
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum PassportElementErrorFrontSideType {
+    Passport,
+    DriverLicense,
+    IdentityCard,
+    InternalPassport,
+}
+
+#[apply(apistruct!)]
+#[derive(Eq)]
+pub struct PassportElementErrorFrontSide {
+    #[serde(rename = "type")]
+    pub type_field: PassportElementErrorFrontSideType,
+    pub file_hash: String,
+    pub message: String,
+}
+
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum PassportElementErrorReverseSideType {
+    DriverLicense,
+    IdentityCard,
+}
+
+#[apply(apistruct!)]
+#[derive(Eq)]
+pub struct PassportElementErrorReverseSide {
+    #[serde(rename = "type")]
+    pub type_field: PassportElementErrorReverseSideType,
+    pub file_hash: String,
+    pub message: String,
+}
+
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum PassportElementErrorSelfieType {
+    Passport,
+    DriverLicense,
+    IdentityCard,
+    InternalPassport,
+}
+
+#[apply(apistruct!)]
+#[derive(Eq)]
+pub struct PassportElementErrorSelfie {
+    #[serde(rename = "type")]
+    pub type_field: PassportElementErrorSelfieType,
+    pub file_hash: String,
+    pub message: String,
+}
+
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum PassportElementErrorFileType {
+    UtilityBill,
+    BankStatement,
+    RentalAgreement,
+    PassportRegistration,
+    TemporaryRegistration,
+}
+
+#[apply(apistruct!)]
+#[derive(Eq)]
+pub struct PassportElementErrorFile {
+    #[serde(rename = "type")]
+    pub type_field: PassportElementErrorFileType,
+    pub file_hash: String,
+    pub message: String,
+}
+
+#[apply(apistruct!)]
+#[derive(Eq)]
+pub struct PassportElementErrorFiles {
+    #[serde(rename = "type")]
+    pub type_field: PassportElementErrorFileType,
+    pub file_hashes: Vec<String>,
+    pub message: String,
+}
+
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum PassportElementErrorTranslationFileType {
+    Passport,
+    DriverLicense,
+    IdentityCard,
+    InternalPassport,
+    UtilityBill,
+    BankStatement,
+    RentalAgreement,
+    PassportRegistration,
+    TemporaryRegistration,
+}
+
+#[apply(apistruct!)]
+#[derive(Eq)]
+pub struct PassportElementErrorTranslationFile {
+    #[serde(rename = "type")]
+    pub type_field: PassportElementErrorTranslationFileType,
+    pub file_hash: String,
+    pub message: String,
+}
+
+#[apply(apistruct!)]
+#[derive(Eq)]
+pub struct PassportElementErrorTranslationFiles {
+    #[serde(rename = "type")]
+    pub type_field: PassportElementErrorTranslationFileType,
+    pub file_hashes: Vec<String>,
+    pub message: String,
+}
+
+#[apply(apistruct!)]
+#[derive(Eq)]
+pub struct PassportElementErrorUnspecified {
+    #[serde(rename = "type")]
+    pub type_field: EncryptedPassportElementType,
+    pub element_hash: String,
+    pub message: String,
+}

--- a/src/payments.rs
+++ b/src/payments.rs
@@ -1,0 +1,210 @@
+//! API Objects to be used with [Payments](https://core.telegram.org/bots/api#payments).
+
+use serde::{Deserialize, Serialize};
+
+use crate::macros::{apistruct, apply};
+use crate::objects::{Chat, PaidMedia, User};
+use crate::stickers::Gift;
+
+#[apply(apistruct!)]
+#[derive(Eq)]
+pub struct LabeledPrice {
+    pub label: String,
+    pub amount: u32,
+}
+
+#[apply(apistruct!)]
+#[derive(Eq)]
+pub struct Invoice {
+    pub title: String,
+    pub description: String,
+    pub start_parameter: String,
+    pub currency: String,
+    pub total_amount: u32,
+}
+
+#[apply(apistruct!)]
+#[derive(Eq)]
+pub struct ShippingAddress {
+    pub country_code: String,
+    pub state: String,
+    pub city: String,
+    pub street_line1: String,
+    pub street_line2: String,
+    pub post_code: String,
+}
+
+#[apply(apistruct!)]
+#[derive(Eq)]
+pub struct OrderInfo {
+    pub name: Option<String>,
+    pub phone_number: Option<String>,
+    pub email: Option<String>,
+    pub shipping_address: Option<ShippingAddress>,
+}
+
+#[apply(apistruct!)]
+#[derive(Eq)]
+pub struct ShippingOption {
+    pub id: String,
+    pub title: String,
+    pub prices: Vec<LabeledPrice>,
+}
+
+#[apply(apistruct!)]
+#[derive(Eq)]
+pub struct SuccessfulPayment {
+    pub currency: String,
+    pub total_amount: u32,
+    pub invoice_payload: String,
+    pub subscription_expiration_date: Option<u64>,
+    pub is_recurring: Option<bool>,
+    pub is_first_recurring: Option<bool>,
+    pub shipping_option_id: Option<String>,
+    pub order_info: Option<OrderInfo>,
+    pub telegram_payment_charge_id: String,
+    pub provider_payment_charge_id: String,
+}
+
+#[apply(apistruct!)]
+#[derive(Eq)]
+pub struct RefundedPayment {
+    pub currency: String,
+    pub total_amount: u32,
+    pub invoice_payload: String,
+    pub telegram_payment_charge_id: String,
+    pub provider_payment_charge_id: Option<String>,
+}
+
+#[apply(apistruct!)]
+#[derive(Eq)]
+pub struct ShippingQuery {
+    pub id: String,
+    pub from: User,
+    pub invoice_payload: String,
+    pub shipping_address: ShippingAddress,
+}
+
+#[apply(apistruct!)]
+#[derive(Eq)]
+pub struct PreCheckoutQuery {
+    pub id: String,
+    pub from: User,
+    pub currency: String,
+    pub total_amount: u32,
+    pub invoice_payload: String,
+    pub shipping_option_id: Option<String>,
+    pub order_info: Option<OrderInfo>,
+}
+
+#[apply(apistruct!)]
+#[derive(Eq)]
+pub struct PaidMediaPurchased {
+    pub from: User,
+    pub paid_media_payload: String,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum RevenueWithdrawalState {
+    Pending(RevenueWithdrawalStatePending),
+    Succeeded(RevenueWithdrawalStateSucceeded),
+    Failed(RevenueWithdrawalStateFailed),
+}
+
+#[apply(apistruct!)]
+#[derive(Eq)]
+pub struct RevenueWithdrawalStatePending {}
+
+#[apply(apistruct!)]
+#[derive(Eq)]
+pub struct RevenueWithdrawalStateSucceeded {
+    pub date: u64,
+    pub url: String,
+}
+
+#[apply(apistruct!)]
+#[derive(Eq)]
+pub struct RevenueWithdrawalStateFailed {}
+
+#[apply(apistruct!)]
+#[derive(Eq)]
+pub struct AffiliateInfo {
+    pub affiliate_user: Option<User>,
+    pub affiliate_chat: Option<Chat>,
+    pub commission_per_mille: u32,
+    pub amount: u32,
+    pub nanostar_amount: Option<u32>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "type", rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum TransactionPartner {
+    User(Box<TransactionPartnerUser>),
+    Chat(Box<TransactionPartnerChat>),
+    AffiliateProgram(TransactionPartnerAffiliateProgram),
+    Fragment(TransactionPartnerFragment),
+    TelegramAds(TransactionPartnerTelegramAds),
+    TelegramApi(TransactionPartnerTelegramApi),
+    Other(TransactionPartnerOther),
+}
+
+#[apply(apistruct!)]
+pub struct TransactionPartnerUser {
+    pub user: User,
+    pub affiliate: Option<AffiliateInfo>,
+    pub invoice_payload: Option<String>,
+    pub subscription_period: Option<u32>,
+    pub paid_media: Option<Vec<PaidMedia>>,
+    pub paid_media_payload: Option<String>,
+    pub gift: Option<Gift>,
+}
+
+#[apply(apistruct!)]
+pub struct TransactionPartnerChat {
+    pub chat: Chat,
+    pub gift: Option<Gift>,
+}
+
+#[apply(apistruct!)]
+#[derive(Eq)]
+pub struct TransactionPartnerAffiliateProgram {
+    pub sponsor_user: User,
+    pub commission_per_mille: u32,
+}
+
+#[apply(apistruct!)]
+#[derive(Eq)]
+pub struct TransactionPartnerFragment {
+    pub withdrawal_state: Option<RevenueWithdrawalState>,
+}
+
+#[apply(apistruct!)]
+#[derive(Eq)]
+pub struct TransactionPartnerTelegramAds {}
+
+#[apply(apistruct!)]
+#[derive(Eq)]
+pub struct TransactionPartnerTelegramApi {
+    pub request_count: u64,
+}
+
+#[apply(apistruct!)]
+#[derive(Eq)]
+pub struct TransactionPartnerOther {}
+
+#[apply(apistruct!)]
+pub struct StarTransaction {
+    pub id: String,
+    pub amount: u32,
+    pub nanostar_amount: u32,
+    pub date: u64,
+    pub source: Option<TransactionPartner>,
+    pub receiver: Option<TransactionPartner>,
+}
+
+#[apply(apistruct!)]
+pub struct StarTransactions {
+    pub transactions: Vec<StarTransaction>,
+}

--- a/src/stickers.rs
+++ b/src/stickers.rs
@@ -1,0 +1,87 @@
+//! API Objects to be used with [Stickers](https://core.telegram.org/bots/api#stickers).
+
+use serde::{Deserialize, Serialize};
+
+use crate::input_file::FileUpload;
+use crate::macros::{apistruct, apply};
+use crate::objects::{File, PhotoSize};
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum StickerType {
+    Regular,
+    Mask,
+    CustomEmoji,
+}
+
+#[apply(apistruct!)]
+pub struct Sticker {
+    pub file_id: String,
+    pub file_unique_id: String,
+    #[serde(rename = "type")]
+    pub sticker_type: StickerType,
+    pub width: u32,
+    pub height: u32,
+    pub is_animated: bool,
+    pub is_video: bool,
+    pub thumbnail: Option<PhotoSize>,
+    pub emoji: Option<String>,
+    pub set_name: Option<String>,
+    pub premium_animation: Option<File>,
+    pub mask_position: Option<MaskPosition>,
+    pub custom_emoji_id: Option<String>,
+    pub needs_repainting: Option<bool>,
+    pub file_size: Option<u64>,
+}
+
+#[apply(apistruct!)]
+pub struct StickerSet {
+    pub name: String,
+    pub title: String,
+    pub sticker_type: StickerType,
+    #[doc(hidden)]
+    #[deprecated(since = "0.19.2", note = "Please use `sticker_type` instead")]
+    pub contains_masks: bool,
+    pub stickers: Vec<Sticker>,
+    pub thumbnail: Option<PhotoSize>,
+}
+
+#[apply(apistruct!)]
+pub struct MaskPosition {
+    pub point: String,
+    pub x_shift: f64,
+    pub y_shift: f64,
+    pub scale: f64,
+}
+
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum StickerFormat {
+    Static,
+    Animated,
+    Video,
+}
+
+#[apply(apistruct!)]
+pub struct InputSticker {
+    pub sticker: FileUpload,
+    pub format: StickerFormat,
+    pub emoji_list: Vec<String>,
+    pub mask_position: Option<MaskPosition>,
+    pub keywords: Option<Vec<String>>,
+}
+
+#[apply(apistruct!)]
+pub struct Gift {
+    pub id: String,
+    pub stricker: Sticker,
+    pub star_count: u32,
+    pub upgrade_star_count: Option<u32>,
+    pub total_count: Option<u32>,
+    pub remaining_count: Option<u32>,
+}
+
+#[apply(apistruct!)]
+pub struct Gifts {
+    pub gifts: Vec<Gift>,
+}

--- a/src/trait_async.rs
+++ b/src/trait_async.rs
@@ -1,15 +1,18 @@
 use std::path::PathBuf;
 
-use crate::api_params::{InputMedia, Media};
+use crate::games::GameHighScore;
+use crate::inline_mode::{PreparedInlineMessage, SentWebAppMessage};
 use crate::input_file::HasInputFile;
+use crate::input_media::{InputMedia, MediaGroupInputMedia};
 use crate::objects::{
     BotCommand, BotDescription, BotName, BotShortDescription, BusinessConnection,
     ChatAdministratorRights, ChatFullInfo, ChatInviteLink, ChatMember, File, ForumTopic,
-    GameHighScore, Gifts, MenuButton, Message, MessageId, Poll, PreparedInlineMessage,
-    SentWebAppMessage, StarTransactions, Sticker, StickerSet, Update, User, UserChatBoosts,
-    UserProfilePhotos, WebhookInfo,
+    MenuButton, Message, MessageId, Poll, User, UserChatBoosts, UserProfilePhotos,
 };
+use crate::payments::StarTransactions;
 use crate::response::{MessageOrBool, MethodResponse};
+use crate::stickers::{Gifts, Sticker, StickerSet};
+use crate::updates::{Update, WebhookInfo};
 
 macro_rules! request {
     ($name:ident, $return:ty) => {
@@ -107,17 +110,17 @@ where
         let mut params = params.clone();
         for media in &mut params.media {
             match media {
-                Media::Audio(audio) => {
+                MediaGroupInputMedia::Audio(audio) => {
                     replace_attach!(audio.media);
                     replace_attach!(audio.thumbnail);
                 }
-                Media::Document(document) => {
+                MediaGroupInputMedia::Document(document) => {
                     replace_attach!(document.media);
                 }
-                Media::Photo(photo) => {
+                MediaGroupInputMedia::Photo(photo) => {
                     replace_attach!(photo.media);
                 }
-                Media::Video(video) => {
+                MediaGroupInputMedia::Video(video) => {
                     replace_attach!(video.media);
                     replace_attach!(video.cover);
                     replace_attach!(video.thumbnail);
@@ -351,6 +354,7 @@ where
     request!(setChatMenuButton, bool);
     request!(getChatMenuButton, MenuButton);
     request!(unpinAllGeneralForumTopicMessages, bool);
+    request!(setPassportDataErrors, bool);
 
     async fn request_with_possible_form_data<Params, Output>(
         &self,

--- a/src/trait_sync.rs
+++ b/src/trait_sync.rs
@@ -1,15 +1,18 @@
 use std::path::PathBuf;
 
-use crate::api_params::{InputMedia, Media};
+use crate::games::GameHighScore;
+use crate::inline_mode::{PreparedInlineMessage, SentWebAppMessage};
 use crate::input_file::HasInputFile;
+use crate::input_media::{InputMedia, MediaGroupInputMedia};
 use crate::objects::{
     BotCommand, BotDescription, BotName, BotShortDescription, BusinessConnection,
     ChatAdministratorRights, ChatFullInfo, ChatInviteLink, ChatMember, File, ForumTopic,
-    GameHighScore, Gifts, MenuButton, Message, MessageId, Poll, PreparedInlineMessage,
-    SentWebAppMessage, StarTransactions, Sticker, StickerSet, Update, User, UserChatBoosts,
-    UserProfilePhotos, WebhookInfo,
+    MenuButton, Message, MessageId, Poll, User, UserChatBoosts, UserProfilePhotos,
 };
+use crate::payments::StarTransactions;
 use crate::response::{MessageOrBool, MethodResponse};
+use crate::stickers::{Gifts, Sticker, StickerSet};
+use crate::updates::{Update, WebhookInfo};
 
 macro_rules! request {
     ($name:ident, $return:ty) => {
@@ -98,17 +101,17 @@ pub trait TelegramApi {
         let mut params = params.clone();
         for media in &mut params.media {
             match media {
-                Media::Audio(audio) => {
+                MediaGroupInputMedia::Audio(audio) => {
                     replace_attach!(audio.media);
                     replace_attach!(audio.thumbnail);
                 }
-                Media::Document(document) => {
+                MediaGroupInputMedia::Document(document) => {
                     replace_attach!(document.media);
                 }
-                Media::Photo(photo) => {
+                MediaGroupInputMedia::Photo(photo) => {
                     replace_attach!(photo.media);
                 }
-                Media::Video(video) => {
+                MediaGroupInputMedia::Video(video) => {
                     replace_attach!(video.media);
                     replace_attach!(video.cover);
                     replace_attach!(video.thumbnail);
@@ -336,6 +339,7 @@ pub trait TelegramApi {
     request!(setChatMenuButton, bool);
     request!(getChatMenuButton, MenuButton);
     request!(unpinAllGeneralForumTopicMessages, bool);
+    request!(setPassportDataErrors, bool);
 
     fn request_with_possible_form_data<Params, Output>(
         &self,

--- a/src/updates.rs
+++ b/src/updates.rs
@@ -1,0 +1,129 @@
+//! API Objects used to [get updates](https://core.telegram.org/bots/api#getting-updates).
+
+use serde::{Deserialize, Serialize};
+
+use crate::inline_mode::{ChosenInlineResult, InlineQuery};
+use crate::macros::{apistruct, apply};
+use crate::objects::{
+    AllowedUpdate, BusinessConnection, BusinessMessagesDeleted, CallbackQuery, ChatBoostRemoved,
+    ChatBoostUpdated, ChatJoinRequest, ChatMemberUpdated, Message, MessageReactionCountUpdated,
+    MessageReactionUpdated, Poll, PollAnswer,
+};
+use crate::payments::{PaidMediaPurchased, PreCheckoutQuery, ShippingQuery};
+
+/// Represents an incoming update from telegram.
+/// [Official documentation.](https://core.telegram.org/bots/api#update)
+#[apply(apistruct!)]
+pub struct Update {
+    pub update_id: u32,
+
+    /// Maps to exactly one of the many optional fields
+    /// from [the official documentation](https://core.telegram.org/bots/api#update).
+    #[serde(flatten)]
+    pub content: UpdateContent,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum UpdateContent {
+    Message(Message),
+    EditedMessage(Message),
+    ChannelPost(Message),
+    EditedChannelPost(Message),
+    BusinessConnection(BusinessConnection),
+    BusinessMessage(Message),
+    EditedBusinessMessage(Message),
+    DeletedBusinessMessages(BusinessMessagesDeleted),
+    MessageReaction(MessageReactionUpdated),
+    MessageReactionCount(MessageReactionCountUpdated),
+    InlineQuery(InlineQuery),
+    ChosenInlineResult(ChosenInlineResult),
+    CallbackQuery(CallbackQuery),
+    ShippingQuery(ShippingQuery),
+    PreCheckoutQuery(PreCheckoutQuery),
+    Poll(Poll),
+    PollAnswer(PollAnswer),
+    MyChatMember(ChatMemberUpdated),
+    ChatMember(ChatMemberUpdated),
+    ChatJoinRequest(ChatJoinRequest),
+    ChatBoost(ChatBoostUpdated),
+    RemovedChatBoost(ChatBoostRemoved),
+    PurchasedPaidMedia(PaidMediaPurchased),
+}
+
+#[apply(apistruct!)]
+#[derive(Eq)]
+pub struct WebhookInfo {
+    pub url: String,
+    pub has_custom_certificate: bool,
+    pub pending_update_count: u32,
+    pub ip_address: Option<String>,
+    pub last_error_date: Option<u64>,
+    pub last_error_message: Option<String>,
+    pub last_synchronization_error_date: Option<u64>,
+    pub max_connections: Option<u16>,
+    pub allowed_updates: Option<Vec<AllowedUpdate>>,
+}
+
+#[cfg(test)]
+mod serde_tests {
+    use super::*;
+    use crate::objects::{Chat, ChatType, User};
+
+    #[test]
+    pub fn update_content_is_flattened() {
+        let update_content = r#"{
+            "update_id": 2341,
+            "message": {
+                "message_id": 2746,
+                "from": {
+                    "id": 1276618370,
+                    "is_bot": true,
+                    "first_name": "test_el_bot",
+                    "username": "el_mon_test_bot"
+                },
+                "date": 1618207352,
+                "chat": {
+                    "id": 275808073,
+                    "type": "private",
+                    "username": "Ayrat555",
+                    "first_name": "Ayrat",
+                    "last_name": "Badykov"
+                },
+                "text": "Hello!"
+            }
+        }"#;
+
+        let update: Update = serde_json::from_str(update_content).unwrap();
+
+        let message = Message::builder()
+            .message_id(2746)
+            .from(
+                User::builder()
+                    .id(1276618370)
+                    .is_bot(true)
+                    .first_name("test_el_bot")
+                    .username("el_mon_test_bot")
+                    .build(),
+            )
+            .date(1618207352)
+            .chat(
+                Chat::builder()
+                    .id(275808073)
+                    .type_field(ChatType::Private)
+                    .username("Ayrat555")
+                    .first_name("Ayrat")
+                    .last_name("Badykov")
+                    .build(),
+            )
+            .text("Hello!")
+            .build();
+
+        let expected = Update {
+            update_id: 2341,
+            content: UpdateContent::Message(message),
+        };
+
+        assert_eq!(update, expected);
+    }
+}


### PR DESCRIPTION
Also, add From implementations for some enums.

For categories in the Bot API documentation I did not provide top level re-exports. They are separated on the website so they can also be imported from their own module by users.

files except trait_*, api_params and objects should be sorted like they are on the Bot API Documentation Website.

BREAKING CHANGE: imports change

BREAKING CHANGE: Media renamed to MediaGroupInputMedia