### PR TITLE
refactor!: move ResponseParams to response module

### DIFF
--- a/src/client_ureq.rs
+++ b/src/client_ureq.rs
@@ -230,7 +230,7 @@ mod tests {
     #[test]
     fn set_webhook_success() {
         let response_string =
-            "{\"ok\":true,\"result\":true,\"description\":\"Webhook is already deleted\"}";
+            "{\"ok\":true,\"description\":\"Webhook is already deleted\",\"result\":true}";
         let params = SetWebhookParams::builder().url("").build();
         let response = case!(setWebhook, 200, response_string, params).unwrap();
         assert_json_str(&response, response_string);
@@ -239,7 +239,7 @@ mod tests {
     #[test]
     fn delete_webhook_success() {
         let response_string =
-            "{\"ok\":true,\"result\":true,\"description\":\"Webhook is already deleted\"}";
+            "{\"ok\":true,\"description\":\"Webhook is already deleted\",\"result\":true}";
         let params = DeleteWebhookParams::builder().build();
         let response = case!(deleteWebhook, 200, response_string, params).unwrap();
         assert_json_str(&response, response_string);

--- a/src/objects.rs
+++ b/src/objects.rs
@@ -1236,13 +1236,6 @@ pub struct BotCommand {
 }
 
 #[apply(apistruct!)]
-#[derive(Copy, Eq)]
-pub struct ResponseParameters {
-    pub migrate_to_chat_id: Option<i64>,
-    pub retry_after: Option<u16>,
-}
-
-#[apply(apistruct!)]
 #[derive(Eq)]
 pub struct Story {
     pub chat: Chat,

--- a/src/response.rs
+++ b/src/response.rs
@@ -6,15 +6,22 @@
 
 use serde::{Deserialize, Serialize};
 
-use crate::objects::{Message, ResponseParameters};
+use crate::objects::Message;
 
+/// Response on successful request.
+///
+/// `ok` is always `true`.
+/// Some methods may return a human-readable `description` of the result.
+/// The result of the query can be found in the 'result' field.
+///
+/// See <https://core.telegram.org/bots/api#making-requests>
 #[serde_with::skip_serializing_none]
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct MethodResponse<T> {
     /// Always true
     pub ok: bool,
-    pub result: T,
     pub description: Option<String>,
+    pub result: T,
 }
 
 /// Error on an unsuccessful request.
@@ -40,4 +47,11 @@ pub struct ErrorResponse {
 pub enum MessageOrBool {
     Message(Message),
     Bool(bool),
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde_with::skip_serializing_none]
+pub struct ResponseParameters {
+    pub migrate_to_chat_id: Option<i64>,
+    pub retry_after: Option<u16>,
 }


### PR DESCRIPTION
BREAKING CHANGE: ResponseParams moves to different module

BREAKING CHANGE: ResponseParams builder is gone. Its something that should only be read. Therefore, a bit less compile time.