### PR TITLE
feat: add LinkPreviewOptions::DISABLED

### DIFF
--- a/src/objects.rs
+++ b/src/objects.rs
@@ -592,6 +592,16 @@ pub struct LinkPreviewOptions {
     pub show_above_text: Option<bool>,
 }
 
+impl LinkPreviewOptions {
+    pub const DISABLED: Self = Self {
+        is_disabled: Some(true),
+        url: None,
+        prefer_small_media: None,
+        prefer_large_media: None,
+        show_above_text: None,
+    };
+}
+
 #[apply(apistruct!)]
 #[derive(Eq)]
 pub struct PhotoSize {


### PR DESCRIPTION
It's simpler to write than `LinkPreviewOptions::builder().is_disabled(true).build()` all the time.