### PR TITLE
ci(rust): dont check features on beta

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -49,7 +49,6 @@ jobs:
       matrix:
         toolchain:
           - stable
-          - beta
           - "1.75"
         os:
           - ubuntu-latest


### PR DESCRIPTION
Running on beta mainly uses up a lot of resources without much benefit. Doing this on stable and the MSRV is way more useful in comparison. The main benefit of beta is to check that the beta channel works in order to provide feedback to Rust. Thats already done with test and clippy (and therefore check).