### PR TITLE
build(lints): lint things that break API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,6 @@ unsafe_code = "forbid"
 [lints.clippy]
 pedantic = { level = "warn", priority = -1 }
 nursery = { level = "warn", priority = -1 }
-struct_excessive_bools = "allow" # due to Telegram API
 
 # TODO: remove and fix (or allow explicitly on the specific problem)
 missing_errors_doc = "allow"

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,1 @@
+avoid-breaking-exported-api = false

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,8 +1,10 @@
 # https://github.com/rust-lang/rustfmt/blob/master/Configurations.md
-format_code_in_doc_comments=true
-format_macro_matchers=true
-group_imports="StdExternalCrate"
-imports_granularity="Module"
-normalize_doc_attributes=true
-reorder_impl_items=true
-use_field_init_shorthand=true
+format_code_in_doc_comments = true
+format_macro_bodies = true
+format_macro_matchers = true
+group_imports = "StdExternalCrate"
+imports_granularity = "Module"
+normalize_comments = true
+normalize_doc_attributes = true
+reorder_impl_items = true
+use_field_init_shorthand = true

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -5,6 +5,11 @@ macro_rules_attribute::attribute_alias! {
     #[apply(apistruct!)] =
         #[::serde_with::skip_serializing_none]
         #[derive(Clone, Debug, PartialEq, ::bon::Builder, ::serde::Serialize, ::serde::Deserialize)]
+        #[allow(
+            clippy::struct_excessive_bools,
+            clippy::struct_field_names,
+            // reason = "same as Telegram Bot API"
+        )]
         #[builder(
             on(Box<_>, into),
             on(ChatId, into),

--- a/src/objects.rs
+++ b/src/objects.rs
@@ -1,7 +1,5 @@
 //! [Available Types](https://core.telegram.org/bots/api#available-types) of the Bot API.
 
-#![allow(deprecated)]
-
 use serde::{Deserialize, Serialize};
 
 use crate::games::{CallbackGame, Game};


### PR DESCRIPTION
This is useful while developing to notice these lints even before they are released.
Even when breaking they improve the code quality.