### PR TITLE
refactor!: box large enum variants

### DIFF
--- a/examples/async_reply_to_message_updates.rs
+++ b/examples/async_reply_to_message_updates.rs
@@ -23,7 +23,7 @@ async fn main() {
                         let bot_clone = bot.clone();
 
                         tokio::spawn(async move {
-                            process_message(^message, bot_clone).await;
+                            process_message(*message, bot_clone).await;
                         });
                     }
                     update_params.offset = Some(i64::from(update.update_id) + 1);

--- a/examples/async_reply_to_message_updates.rs
+++ b/examples/async_reply_to_message_updates.rs
@@ -23,7 +23,7 @@ async fn main() {
                         let bot_clone = bot.clone();
 
                         tokio::spawn(async move {
-                            process_message(message, bot_clone).await;
+                            process_message(^message, bot_clone).await;
                         });
                     }
                     update_params.offset = Some(i64::from(update.update_id) + 1);

--- a/src/response.rs
+++ b/src/response.rs
@@ -45,7 +45,7 @@ pub struct ErrorResponse {
 #[derive(Debug, Serialize, Deserialize, PartialEq)]
 #[serde(untagged)]
 pub enum MessageOrBool {
-    Message(Message),
+    Message(Box<Message>),
     Bool(bool),
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -1445,7 +1445,7 @@ pub struct BusinessMessagesDeleted {
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 #[serde(untagged)]
 pub enum MaybeInaccessibleMessage {
-    Message(Message),
+    Message(Box<Message>),
     InaccessibleMessage(InaccessibleMessage),
 }
 

--- a/src/updates.rs
+++ b/src/updates.rs
@@ -26,7 +26,7 @@ pub struct Update {
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub enum UpdateContent {
-    Message(Message),
+    Message(Box<Message>),
     EditedMessage(Message),
     ChannelPost(Message),
     EditedChannelPost(Message),
@@ -38,7 +38,7 @@ pub enum UpdateContent {
     MessageReactionCount(MessageReactionCountUpdated),
     InlineQuery(InlineQuery),
     ChosenInlineResult(ChosenInlineResult),
-    CallbackQuery(CallbackQuery),
+    CallbackQuery(Box<CallbackQuery>),
     ShippingQuery(ShippingQuery),
     PreCheckoutQuery(PreCheckoutQuery),
     Poll(Poll),

--- a/src/updates.rs
+++ b/src/updates.rs
@@ -121,7 +121,7 @@ mod serde_tests {
 
         let expected = Update {
             update_id: 2341,
-            content: UpdateContent::Message(message),
+            content: UpdateContent::Message(Box::new(message)),
         };
 
         assert_eq!(update, expected);

--- a/src/updates.rs
+++ b/src/updates.rs
@@ -27,12 +27,12 @@ pub struct Update {
 #[serde(rename_all = "snake_case")]
 pub enum UpdateContent {
     Message(Box<Message>),
-    EditedMessage(Message),
-    ChannelPost(Message),
-    EditedChannelPost(Message),
+    EditedMessage(Box<Message>),
+    ChannelPost(Box<Message>),
+    EditedChannelPost(Box<Message>),
     BusinessConnection(BusinessConnection),
-    BusinessMessage(Message),
-    EditedBusinessMessage(Message),
+    BusinessMessage(Box<Message>),
+    EditedBusinessMessage(Box<Message>),
     DeletedBusinessMessages(BusinessMessagesDeleted),
     MessageReaction(MessageReactionUpdated),
     MessageReactionCount(MessageReactionCountUpdated),


### PR DESCRIPTION
BREAKING CHANGE: messages might need to be unboxed before usage