### PR TITLE
fix!: Optional `year`

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -1142,7 +1142,7 @@ pub struct ChatPermissions {
 pub struct Birthdate {
     pub day: u8,
     pub month: u8,
-    pub year: u16,
+    pub year: Option<u16>,
 }
 
 #[apply(apistruct!)]


### PR DESCRIPTION
Fixes #285

Note that this is a breaking change for anyone using `year` field on `Birthdate`.