### PR TITLE
perf(client): less clones on creating multipart form

### DIFF
--- a/src/client_reqwest.rs
+++ b/src/client_reqwest.rs
@@ -105,19 +105,17 @@ impl AsyncTelegramApi for Bot {
             use serde_json::Value;
 
             let json_string = crate::json::encode(&params)?;
-            let json_struct: Value = serde_json::from_str(&json_string).unwrap();
-
+            let json_struct: serde_json::Map<String, Value> =
+                serde_json::from_str(&json_string).unwrap();
             let file_keys: Vec<&str> = files.iter().map(|(key, _)| *key).collect();
 
             let mut form = multipart::Form::new();
-            for (key, val) in json_struct.as_object().unwrap() {
+            for (key, val) in json_struct {
                 if !file_keys.contains(&key.as_str()) {
-                    let val = match val {
-                        Value::String(val) => val.to_string(),
-                        other => other.to_string(),
+                    form = match val {
+                        Value::String(val) => form.text(key, val),
+                        other => form.text(key, other.to_string()),
                     };
-
-                    form = form.text(key.clone(), val);
                 }
             }
 

--- a/src/client_ureq.rs
+++ b/src/client_ureq.rs
@@ -92,18 +92,17 @@ impl TelegramApi for Bot {
         Output: serde::de::DeserializeOwned,
     {
         let json_string = crate::json::encode(&params)?;
-        let json_struct: Value = serde_json::from_str(&json_string).unwrap();
+        let json_struct: serde_json::Map<String, Value> =
+            serde_json::from_str(&json_string).unwrap();
         let file_keys: Vec<&str> = files.iter().map(|(key, _)| *key).collect();
 
         let mut form = Multipart::new();
-        for (key, val) in json_struct.as_object().unwrap() {
+        for (key, val) in json_struct {
             if !file_keys.contains(&key.as_str()) {
-                let val = match val {
-                    Value::String(val) => val.to_string(),
-                    other => other.to_string(),
+                match val {
+                    Value::String(val) => form.add_text(key, val),
+                    other => form.add_text(key, other.to_string()),
                 };
-
-                form.add_text(key, val);
             }
         }
 


### PR DESCRIPTION
Seeing the improved clippy::implicit_clone suggestions on nightly I found this case where serde_json::from_str basically creates owned values only to clone them direcly to create the multipart form.

As serde did not parsed into a map and rather a Value in between this required clones but merging this results in owned values.