### PR TITLE
fix ChatBackground deserialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,8 @@ let send_message_params = SendMessageParams::builder()
 
 ### Making requests
 
-```rust,no_run,ignore
+```rust,no_run
+# #[cfg(feature = "client-ureq")] fn main() {
 use frankenstein::TelegramApi;
 use frankenstein::client_ureq::Bot;
 use frankenstein::methods::{GetUpdatesParams, SendMessageParams};
@@ -107,6 +108,8 @@ let update_params = GetUpdatesParams::builder()
     .allowed_updates(vec![AllowedUpdate::Message])
     .build();
 let result = bot.get_updates(&update_params);
+# }
+# #[cfg(not(feature = "client-ureq"))] fn main() {}
 ```
 
 Every function returns a `Result` with a successful response or failed response.

--- a/README.md
+++ b/README.md
@@ -86,8 +86,7 @@ let send_message_params = SendMessageParams::builder()
 
 ### Making requests
 
-```rust,no_run
-#![cfg(feature = "client-ureq")]
+```rust,no_run,ignore
 use frankenstein::TelegramApi;
 use frankenstein::client_ureq::Bot;
 use frankenstein::methods::{GetUpdatesParams, SendMessageParams};

--- a/src/types.rs
+++ b/src/types.rs
@@ -171,9 +171,16 @@ pub enum MenuButton {
     Default,
 }
 
+#[apply(apistruct!)]
+#[derive(Eq)]
+pub struct ChatBackground {
+    #[serde(rename = "type")]
+    pub type_field: BackgroundType,
+}
+
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(tag = "type", rename_all = "snake_case")]
-pub enum ChatBackground {
+pub enum BackgroundType {
     Fill(BackgroundTypeFill),
     Wallpaper(BackgroundTypeWallpaper),
     Pattern(BackgroundTypePattern),
@@ -2002,6 +2009,13 @@ mod serde_tests {
                 "skip_entity_detection": true
             })
         );
+    }
+
+    #[test]
+    pub fn chat_background_set_is_parsed() {
+        let json = r#"{"type":{"type":"wallpaper","document":{"file_id":"EAACAgIAAxUAAWpEOWtsM9rqRO6kUKtDPg29mLuzAAIupQACRlYhSk400Uru27X0PAQ","file_unique_id":"AgADLqUAAkZWIUo","file_size":105235,"mime_type":"image/jpeg"},"dark_theme_dimming":4,"is_moving":true}}"#;
+        let bg: ChatBackground = serde_json::from_str(json).unwrap();
+        assert!(matches!(bg.type_field, BackgroundType::Wallpaper(_)));
     }
 
     #[test]


### PR DESCRIPTION
ChatBackground is a struct wrapping BackgroundType, not the enum itself.
The flat model caused serde to fail with "invalid type: map, expected
variant identifier" on any message containing chat_background_set.

Also fix a doctest broken by #\![cfg] stripping the implicit fn main().