### PR TITLE
Partial 10.2 support

### DIFF
--- a/src/methods.rs
+++ b/src/methods.rs
@@ -54,6 +54,8 @@ pub struct SendMessageParams {
     pub chat_id: ChatId,
     pub message_thread_id: Option<i32>,
     pub direct_messages_topic_id: Option<i64>,
+    pub receiver_user_id: Option<u64>,
+    pub callback_query_id: Option<String>,
     pub text: String,
     pub parse_mode: Option<ParseMode>,
     pub entities: Option<Vec<MessageEntity>>,
@@ -162,6 +164,8 @@ pub struct SendPhotoParams {
     pub chat_id: ChatId,
     pub message_thread_id: Option<i32>,
     pub direct_messages_topic_id: Option<i64>,
+    pub receiver_user_id: Option<u64>,
+    pub callback_query_id: Option<String>,
     pub photo: FileUpload,
     pub caption: Option<String>,
     pub parse_mode: Option<ParseMode>,
@@ -184,6 +188,8 @@ pub struct SendAudioParams {
     pub chat_id: ChatId,
     pub message_thread_id: Option<i32>,
     pub direct_messages_topic_id: Option<i64>,
+    pub receiver_user_id: Option<u64>,
+    pub callback_query_id: Option<String>,
     pub audio: FileUpload,
     pub caption: Option<String>,
     pub parse_mode: Option<ParseMode>,
@@ -208,6 +214,8 @@ pub struct SendDocumentParams {
     pub chat_id: ChatId,
     pub message_thread_id: Option<i32>,
     pub direct_messages_topic_id: Option<i64>,
+    pub receiver_user_id: Option<u64>,
+    pub callback_query_id: Option<String>,
     pub document: FileUpload,
     pub thumbnail: Option<FileUpload>,
     pub caption: Option<String>,
@@ -230,6 +238,8 @@ pub struct SendVideoParams {
     pub chat_id: ChatId,
     pub message_thread_id: Option<i32>,
     pub direct_messages_topic_id: Option<i64>,
+    pub receiver_user_id: Option<u64>,
+    pub callback_query_id: Option<String>,
     pub video: FileUpload,
     pub duration: Option<u32>,
     pub width: Option<u32>,
@@ -259,6 +269,8 @@ pub struct SendAnimationParams {
     pub chat_id: ChatId,
     pub message_thread_id: Option<i32>,
     pub direct_messages_topic_id: Option<i64>,
+    pub receiver_user_id: Option<u64>,
+    pub callback_query_id: Option<String>,
     pub animation: FileUpload,
     pub duration: Option<u32>,
     pub width: Option<u32>,
@@ -285,6 +297,8 @@ pub struct SendVoiceParams {
     pub chat_id: ChatId,
     pub message_thread_id: Option<i32>,
     pub direct_messages_topic_id: Option<i64>,
+    pub receiver_user_id: Option<u64>,
+    pub callback_query_id: Option<String>,
     pub voice: FileUpload,
     pub caption: Option<String>,
     pub parse_mode: Option<ParseMode>,
@@ -306,6 +320,8 @@ pub struct SendVideoNoteParams {
     pub chat_id: ChatId,
     pub message_thread_id: Option<i32>,
     pub direct_messages_topic_id: Option<i64>,
+    pub receiver_user_id: Option<u64>,
+    pub callback_query_id: Option<String>,
     pub video_note: FileUpload,
     pub duration: Option<u32>,
     pub length: Option<u32>,
@@ -385,6 +401,8 @@ pub struct SendLocationParams {
     pub chat_id: ChatId,
     pub message_thread_id: Option<i32>,
     pub direct_messages_topic_id: Option<i64>,
+    pub receiver_user_id: Option<u64>,
+    pub callback_query_id: Option<String>,
     pub latitude: f64,
     pub longitude: f64,
     pub horizontal_accuracy: Option<f64>,
@@ -441,6 +459,8 @@ pub struct SendVenueParams {
     pub chat_id: ChatId,
     pub message_thread_id: Option<i32>,
     pub direct_messages_topic_id: Option<i64>,
+    pub receiver_user_id: Option<u64>,
+    pub callback_query_id: Option<String>,
     pub latitude: f64,
     pub longitude: f64,
     pub title: String,
@@ -465,6 +485,8 @@ pub struct SendContactParams {
     pub chat_id: ChatId,
     pub message_thread_id: Option<i32>,
     pub direct_messages_topic_id: Option<i64>,
+    pub receiver_user_id: Option<u64>,
+    pub callback_query_id: Option<String>,
     pub phone_number: String,
     pub first_name: String,
     pub last_name: Option<String>,
@@ -1126,6 +1148,58 @@ pub struct EditMessageReplyMarkupParams {
 
 #[apply(apistruct!)]
 #[derive(Eq)]
+pub struct EditEphemeralMessageTextParams {
+    pub chat_id: ChatId,
+    pub receiver_user_id: u64,
+    pub ephemeral_message_id: i32,
+    pub text: String,
+    pub parse_mode: Option<ParseMode>,
+    pub entities: Option<Vec<MessageEntity>>,
+    pub link_preview_options: Option<LinkPreviewOptions>,
+    pub reply_markup: Option<InlineKeyboardMarkup>,
+}
+
+#[apply(apistruct!)]
+#[derive(Eq)]
+pub struct EditEphemeralMessageMediaParams {
+    pub chat_id: ChatId,
+    pub receiver_user_id: u64,
+    pub ephemeral_message_id: i32,
+    pub media: InputMedia,
+    pub reply_markup: Option<InlineKeyboardMarkup>,
+}
+
+#[apply(apistruct!)]
+#[derive(Eq)]
+pub struct EditEphemeralMessageCaptionParams {
+    pub chat_id: ChatId,
+    pub receiver_user_id: u64,
+    pub ephemeral_message_id: i32,
+    pub caption: Option<String>,
+    pub parse_mode: Option<ParseMode>,
+    pub caption_entities: Option<Vec<MessageEntity>>,
+    pub reply_markup: Option<InlineKeyboardMarkup>,
+}
+
+#[apply(apistruct!)]
+#[derive(Eq)]
+pub struct EditEphemeralMessageReplyMarkupParams {
+    pub chat_id: ChatId,
+    pub receiver_user_id: u64,
+    pub ephemeral_message_id: i32,
+    pub reply_markup: Option<InlineKeyboardMarkup>,
+}
+
+#[apply(apistruct!)]
+#[derive(Eq)]
+pub struct DeleteEphemeralMessageParams {
+    pub chat_id: ChatId,
+    pub receiver_user_id: u64,
+    pub ephemeral_message_id: i32,
+}
+
+#[apply(apistruct!)]
+#[derive(Eq)]
 pub struct StopPollParams {
     pub business_connection_id: Option<String>,
     pub chat_id: ChatId,
@@ -1187,6 +1261,8 @@ pub struct SendStickerParams {
     pub chat_id: ChatId,
     pub message_thread_id: Option<i32>,
     pub direct_messages_topic_id: Option<i64>,
+    pub receiver_user_id: Option<u64>,
+    pub callback_query_id: Option<String>,
     pub sticker: FileUpload,
     pub emoji: Option<String>,
     pub disable_notification: Option<bool>,

--- a/src/payments.rs
+++ b/src/payments.rs
@@ -227,3 +227,11 @@ pub struct StarAmount {
     pub amount: i32,
     pub nanostar_amount: Option<i32>,
 }
+
+#[apply(apistruct!)]
+#[derive(Eq)]
+pub struct BotSubscriptionUpdated {
+    pub user: User,
+    pub invoice_payload: String,
+    pub state: String,
+}

--- a/src/trait_async.rs
+++ b/src/trait_async.rs
@@ -429,6 +429,11 @@ where
     }
 
     request!(editMessageReplyMarkup, MessageOrBool);
+    request!(editEphemeralMessageText, bool);
+    request!(editEphemeralMessageMedia, bool);
+    request!(editEphemeralMessageCaption, bool);
+    request!(editEphemeralMessageReplyMarkup, bool);
+    request!(deleteEphemeralMessage, bool);
     request!(stopPoll, Poll);
     request!(approveSuggestedPost, bool);
     request!(declineSuggestedPost, bool);

--- a/src/trait_sync.rs
+++ b/src/trait_sync.rs
@@ -414,6 +414,11 @@ pub trait TelegramApi {
     }
 
     request!(editMessageReplyMarkup, MessageOrBool);
+    request!(editEphemeralMessageText, bool);
+    request!(editEphemeralMessageMedia, bool);
+    request!(editEphemeralMessageCaption, bool);
+    request!(editEphemeralMessageReplyMarkup, bool);
+    request!(deleteEphemeralMessage, bool);
     request!(stopPoll, Poll);
     request!(approveSuggestedPost, bool);
     request!(declineSuggestedPost, bool);

--- a/src/types.rs
+++ b/src/types.rs
@@ -341,6 +341,7 @@ pub enum AllowedUpdate {
     ChatBoost,
     RemovedChatBoost,
     ManagedBot,
+    Subscription,
 }
 
 #[apply(apistruct!)]

--- a/src/types.rs
+++ b/src/types.rs
@@ -98,8 +98,9 @@ pub struct BotCommandScopeChatMember {
 #[apply(apistruct!)]
 #[derive(Eq)]
 pub struct ReplyParameters {
-    pub message_id: i32,
+    pub message_id: Option<i32>,
     pub chat_id: Option<ChatId>,
+    pub ephemeral_message_id: Option<i32>,
     pub allow_sending_without_reply: Option<bool>,
     pub quote: Option<String>,
     pub quote_parse_mode: Option<ParseMode>,
@@ -466,6 +467,8 @@ pub struct Message {
     pub sender_boost_count: Option<u32>,
     pub sender_business_bot: Option<Box<User>>,
     pub sender_tag: Option<String>,
+    pub receiver_user: Option<Box<User>>,
+    pub ephemeral_message_id: Option<i32>,
     pub date: u64,
     pub guest_query_id: Option<String>,
     pub business_connection_id: Option<String>,
@@ -1600,6 +1603,7 @@ pub struct ForumTopic {
 pub struct BotCommand {
     pub command: String,
     pub description: String,
+    pub is_ephemeral: Option<bool>,
 }
 
 #[apply(apistruct!)]
@@ -1965,6 +1969,35 @@ mod serde_tests {
         let added: CommunityChatAdded = serde_json::from_str(content).unwrap();
         assert_eq!(added.community.id, 123456789);
         assert_eq!(added.community.name, "My Community");
+    }
+
+    #[test]
+    pub fn ephemeral_message_fields_are_parsed() {
+        let content = r#"{
+            "message_id": 1,
+            "date": 1618207352,
+            "chat": {
+                "id": 275808073,
+                "type": "private"
+            },
+            "ephemeral_message_id": 42,
+            "receiver_user": {
+                "id": 7,
+                "is_bot": false,
+                "first_name": "Recv"
+            }
+        }"#;
+
+        let message: Message = serde_json::from_str(content).unwrap();
+        assert_eq!(message.ephemeral_message_id, Some(42));
+        assert_eq!(message.receiver_user.unwrap().id, 7);
+    }
+
+    #[test]
+    pub fn reply_parameters_omits_message_id_when_ephemeral() {
+        let params = ReplyParameters::builder().ephemeral_message_id(9).build();
+        let value = serde_json::to_value(&params).unwrap();
+        assert_eq!(value, serde_json::json!({ "ephemeral_message_id": 9 }));
     }
 
     #[test]

--- a/src/types.rs
+++ b/src/types.rs
@@ -435,7 +435,25 @@ pub struct ChatFullInfo {
     pub unique_gift_colors: Option<UniqueGiftColors>,
     pub paid_message_star_count: Option<u32>,
     pub guard_bot: Option<User>,
+    pub community: Option<Community>,
 }
+
+#[apply(apistruct!)]
+#[derive(Eq)]
+pub struct Community {
+    pub id: i64,
+    pub name: String,
+}
+
+#[apply(apistruct!)]
+#[derive(Eq)]
+pub struct CommunityChatAdded {
+    pub community: Community,
+}
+
+#[apply(apistruct!)]
+#[derive(Eq)]
+pub struct CommunityChatRemoved {}
 
 #[apply(apistruct!)]
 pub struct Message {
@@ -527,6 +545,8 @@ pub struct Message {
     pub chat_background_set: Option<Box<ChatBackground>>,
     pub checklist_tasks_done: Option<Box<ChecklistTasksDone>>,
     pub checklist_tasks_added: Option<Box<ChecklistTasksAdded>>,
+    pub community_chat_added: Option<Box<CommunityChatAdded>>,
+    pub community_chat_removed: Option<Box<CommunityChatRemoved>>,
     pub direct_message_price_changed: Option<Box<DirectMessagePriceChanged>>,
     pub forum_topic_created: Option<Box<ForumTopicCreated>>,
     pub forum_topic_edited: Option<Box<ForumTopicEdited>>,
@@ -1930,6 +1950,20 @@ mod serde_tests {
 
         let member: ChatMember = serde_json::from_str(member_content).unwrap();
         assert!(matches!(member, ChatMember::Kicked(_)));
+    }
+
+    #[test]
+    pub fn community_chat_added_is_parsed() {
+        let content = r#"{
+            "community": {
+                "id": 123456789,
+                "name": "My Community"
+            }
+        }"#;
+
+        let added: CommunityChatAdded = serde_json::from_str(content).unwrap();
+        assert_eq!(added.community.id, 123456789);
+        assert_eq!(added.community.name, "My Community");
     }
 
     #[test]

--- a/src/updates.rs
+++ b/src/updates.rs
@@ -4,7 +4,9 @@ use serde::{Deserialize, Serialize};
 
 use crate::inline_mode::{ChosenInlineResult, InlineQuery};
 use crate::macros::{apistruct, apply};
-use crate::payments::{PaidMediaPurchased, PreCheckoutQuery, ShippingQuery};
+use crate::payments::{
+    BotSubscriptionUpdated, PaidMediaPurchased, PreCheckoutQuery, ShippingQuery,
+};
 use crate::types::{
     AllowedUpdate, BusinessConnection, BusinessMessagesDeleted, CallbackQuery, ChatBoostRemoved,
     ChatBoostUpdated, ChatJoinRequest, ChatMemberUpdated, ManagedBotUpdated, Message,
@@ -51,6 +53,7 @@ pub enum UpdateContent {
     RemovedChatBoost(ChatBoostRemoved),
     PurchasedPaidMedia(PaidMediaPurchased),
     ManagedBot(ManagedBotUpdated),
+    Subscription(BotSubscriptionUpdated),
 }
 
 #[apply(apistruct!)]
@@ -127,5 +130,24 @@ mod serde_tests {
         };
 
         assert_eq!(update, expected);
+    }
+
+    #[test]
+    pub fn subscription_update_is_parsed() {
+        let content = r#"{
+            "update_id": 100,
+            "subscription": {
+                "user": {
+                    "id": 1,
+                    "is_bot": false,
+                    "first_name": "First"
+                },
+                "invoice_payload": "payload",
+                "state": "canceled"
+            }
+        }"#;
+
+        let update: Update = serde_json::from_str(content).unwrap();
+        assert!(matches!(update.content, UpdateContent::Subscription(_)));
     }
 }


### PR DESCRIPTION
This PR adds support for 3 out of 4 features from [Bot API 10.2](https://core.telegram.org/bots/api#july-14-2026). The only missing piece is `Rich Messages`, skipped for now as it seems pretty not-so-straightforward. Output types exist, but we need to add input types as well, which _mostly_ match the output ones.